### PR TITLE
feat(cymatic): audio→Geometry Nodes 3D visualizer (MVP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,9 @@ pnpm-lock.yaml
 
 # Tauri bundle outputs
 packages/fermata/src-tauri/bundle/
+
+# Prior-art clones — study only, not vendored (GPL/MIT mix)
+research/prior-art/
+
+# CC audio test tracks (binary scratch)
+research/audio/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Setka is a monorepo containing six interconnected media processing and automation packages:
+Setka is a monorepo containing seven interconnected media processing and automation packages:
 
 - **setka-common**: Shared utilities for file structure management
 - **obsession**: OBS Canvas Recorder with FFmpeg extraction and metadata collection
 - **beatrix**: Dedicated audio analysis for animation timing and beat detection
 - **cinemon**: Blender VSE project creation with audio-driven animations
+- **cymatic**: Blender Geometry Nodes 3D audio visualizer driven by beatrix analysis
 - **medusa**: Media upload automation to YouTube/Vimeo and social media publishing
 - **fermata**: Tauri-based desktop GUI for managing recordings and batch operations
 
@@ -90,6 +91,7 @@ medusa ←──┼─┐
           │ │
 cinemon ←─┼─┼─── setka-common (file_structure, utils)
           │ │       ↘ beatrix (audio analysis)
+cymatic ←─┼─┤
           │ │
 obsession ←┘ │
           │
@@ -100,10 +102,12 @@ beatrix ←─┘
 
 - **File Structure**: All packages use `setka-common.file_structure.specialized.RecordingStructureManager`
 - **Audio Processing**: Dedicated audio analysis via `beatrix.core.AudioAnalyzer`
+- **3D Visualization**: `cymatic` consumes the beatrix `*_analysis.json` to drive a Blender Geometry Nodes scene
 - **CLI Integration**:
   - `obs-extract` → extract sources from OBS recordings
   - `beatrix` → analyze audio for animation timing
   - `cinemon-blend-setup` → create Blender projects with animations
+  - `cymatic-render` → render a 3D Geometry Nodes audio visualizer from a beatrix analysis
   - `medusa` → upload and publish media
 - **GUI Integration**:
   - `fermata` → Tauri desktop app for batch operations and recording management
@@ -244,6 +248,7 @@ Each package provides specific commands:
 - `beatrix` - Analyze audio for animation timing (beatrix)
 - `cinemon-blend-setup` - Create animated Blender VSE projects (cinemon)
 - `cinemon-generate-config` - Generate YAML configuration files (cinemon)
+- `cymatic-render` - Render a 3D Geometry Nodes audio visualizer from a beatrix analysis (cymatic)
 - Direct module execution for medusa: `python -m medusa.cli`
 
 ## Practical Usage Examples

--- a/docs/brainstorms/2026-05-30-gn-audio-visualizer-requirements.md
+++ b/docs/brainstorms/2026-05-30-gn-audio-visualizer-requirements.md
@@ -1,0 +1,95 @@
+# Wymagania: Wizualizer audio 3D (Geometry Nodes + Blender MCP)
+
+- **Data:** 2026-05-30
+- **Status:** Wymagania — gotowe do planowania (`/ce:plan`)
+- **Autorzy:** Wojciech Koziej + Claude
+- **Powiązane pakiety:** `beatrix` (źródło danych), `cinemon` (referencja architektury), `setka-common` (struktura plików)
+
+## Problem i cel
+
+Dane z `beatrix` (beaty, onsety, energy_peaks, sekcje oraz time-series energii pasm bass/mid/high) są dziś konsumowane wyłącznie przez `cinemon` w trybie **VSE** — animacje 2D na paskach wideo (skala, shake, kolor). Nie istnieje ścieżka generująca **proceduralną wizualizację 3D** sterowaną tą analizą.
+
+**Cel:** Dla wybranej ścieżki dźwiękowej wygenerować abstrakcyjny wizualizer 3D (scena Geometry Nodes), sterowany danymi `beatrix`, renderowany do pliku wideo. Budowa sceny prowadzona iteracyjnie przez Claude'a za pośrednictwem **Blender MCP** (pętla: zbuduj → screenshot viewportu → oceń → popraw).
+
+## Użytkownik i wartość
+
+- **Użytkownik:** twórca nagrań (Wojciech) — chce z istniejącej analizy audio uzyskać wizualnie atrakcyjny materiał 3D bez ręcznego ślęczenia w Blenderze nad driverami.
+- **Wartość:** nowy typ outputu z tego samego pipeline'u (OBS → beatrix → render), reużycie analizy jako jedynego źródła prawdy, autoring sceny przez agenta zamiast ręcznej pracy node-by-node.
+
+## Decyzje (rozstrzygnięte w tym brainstormie)
+
+1. **Rezultat:** abstrakcyjny wizualizer renderowany do **pliku wideo** (mp4). Nie łączymy go (na razie) z footage z OBS.
+2. **Rola MCP — HIPOTEZA DO WALIDACJI, nie decyzja zamknięta.** Zamierzenie: iteracyjny dialog wizualny (Claude buduje scenę przez MCP, ocenia, poprawia). MCP = partner autoringu, nie runtime renderu. **Dwa tryby oceny, bo różnią się tym co mierzą:**
+   - **statyczny screenshot viewportu** → kompozycja/struktura sceny (NIE pokaże synchronizacji — sync to własność ruchu);
+   - **krótki render-klip / playback** → synchronizacja akcentów z beatami (jedyny sposób na weryfikację sync).
+   - **Wymaga spike'a (patrz „Ryzyka i spike'i")** zanim uznamy tryb autoringu za przyjęty. **Fallback:** jeśli pętla nie zbiega w budżecie iteracji — agent generuje setup GN raz, człowiek dostraja ręcznie (lub podejście A).
+3. **Mapowanie audio→obraz:** **hybryda** — time-series pasm (bass/mid/high) steruje ciągłym ruchem/formą tła; beaty i `energy_peaks` dorzucają dyskretne akcenty (impulsy, błyski, wyrzuty cząstek).
+4. **Most danych beatrix→GN: podejście B — „mesh-jako-dane".** Cała analiza kodowana jest jako geometria danych (krzywa/siatka: X = czas, atrybuty wierzchołków = bass/mid/high + flagi beat/peak). Drzewo GN **próbkuje** ten obiekt po aktualnej klatce i czyta wszystkie cechy naraz.
+   - **Realna oś B-vs-A:** B trzyma całą piosenkę jako **jeden zapytywalny obiekt** (brak N kanałów driverów); A jest mechanicznie prostsze i to znany wzorzec. *Uwaga:* „poprawność przy scrubbingu" **nie** różnicuje B od A — keyframe scrubują poprawnie z definicji; to nie jest argument za B.
+   - **Ryzyko:** time-sampling atrybutów po czasie w GN jest niesprawdzony (otwarte pytanie 3, spike). Gdyby B okazało się trudne, A pozostaje gotowym wzorcem awaryjnym.
+   - **Odrzucone:** podejście C (natywny „Bake Sound to F-Curve") — dubluje analizę, tworzy drugie źródło prawdy, ryzyko rozjazdu timingu.
+5. **Normalizacja pasm — w zakresie nowego modułu (nie beatrix).** `bass/mid/high_energy` to surowe magnitudy STFT (`np.mean(np.abs(stft))`): nieznormalizowane, różne skale per pasmo, zmienne per utwór. Nowy moduł liczy **deterministyczny** transform 0..1 raz na całą analizę. **Cel na MVP = czytelność W OBRĘBIE utworu** (per-track percentyl/max) — NIE porównywalność między utworami; te dwa cele są sprzeczne (per-track normalizacja kasuje właśnie różnice głośności między utworami). Porównywalność między utworami (skala absolutna/log kalibrowana raz) = późniejsze rozszerzenie, poza MVP. beatrix pozostaje nietknięty (single source).
+
+## Zakres (in scope)
+
+- Odczyt istniejącego `*_analysis.json` z `beatrix`. **MVP konsumuje:** `duration`, `sample_rate`, `tempo.bpm`, `animation_events.{beats,onsets,energy_peaks}`, `frequency_bands.{times,bass_energy,mid_energy,high_energy}`. **`animation_events.sections` POMINIĘTE na MVP** (to listy dictów `{start,end,label}`, nie skalary — kodowanie odłożone; hybryda i kryterium 1 ich nie wymagają).
+- **Normalizacja pasm** do zakresu wizualnego (Decyzja 5) — warunek widoczności ciągłej energii. *Spike-gated:* wchodzi do MVP pod warunkiem pozytywnego wyniku Spike 1.
+- Konwersja analizy na obiekt-danych w scenie 3D (most B). *Spike-gated:* pod warunkiem Spike 2; przy kill → fallback do podejścia A (keyframe+drivery).
+- Co najmniej jeden działający preset wizualny (hybryda ciągłe+impulsy) jako pierwszy „pionowy plasterek". **Parametry presetu na MVP = prosty dataclass/dict** przekazywany do skryptu Blendera (NIE system YAML z `cinemon` — przedwczesny dla jednego presetu). Preset wystawia kilka wpływowych parametrów (paleta, prymityw geometrii, intensywność akcentów), by tanio próbkować warianty.
+- **Spike MCP** (prerequisite, patrz „Ryzyka"): potwierdzić wybrany serwer MCP umie uruchomić Pythona w żywym Blenderze i pobrać screenshot viewportu. Bez tego pętla autoringu jest nieweryfikowalna.
+- Autoring sceny przez Blender MCP z pętlą (zależny od wyniku spike'a).
+- Render do pliku wideo zgodny ze strukturą katalogów (`blender/render/`).
+- Zgodność z czasem: synchronizacja klatka↔sekunda wg `fps` i `beatrix` (czas w sekundach).
+- Wybór ścieżki audio przez reużycie `beatrix.core.audio_validator.AudioValidator` (publiczna klasa, `cinemon` już importuje z `beatrix` — bez nowego kodu analizy).
+
+## Poza zakresem (non-goals)
+
+- Łączenie warstwy 3D z footage z OBS (osobny, późniejszy pomysł).
+- Własna analiza audio w tym module — **wszystkie** dane pochodzą z `beatrix`.
+- Render produkcyjny przez MCP (render leci osobno, headless).
+- Biblioteka wielu gotowych presetów na start (MVP = jeden dobry preset; kolejne to rozszerzenie).
+- Real-time playback dla widza końcowego (samodzielny odtwarzacz). Podgląd w edytorze przez screenshoty MCP **jest** w zakresie.
+
+## Kryteria sukcesu
+
+**MVP (gate „gotowe"):**
+1. Z istniejącego `*_analysis.json` powstaje scena 3D, w której widać reakcję na: (a) ciągłą **znormalizowaną** energię pasm i (b) dyskretne beaty/peaki.
+2. Sync **obiektywnie**: akcenty wizualne padają w granicach **±N klatek** (N do ustalenia, np. ≤2) od timestampów beatów/peaków z beatrix — mierzalne z danych, nie tylko „na oko + ucho".
+3. Próbkowanie po czasie działa poprawnie: dla dowolnej klatki stan wizualizacji odpowiada danym beatrix w tym czasie (test poprawności implementacji samplingu — nie dowód wyższości B nad A). *Mierzone na ≥2 utworach o RÓŻNYM `sample_rate`* (siatka STFT zależna od sr — patrz Otwarte 3).
+4. **Stop-rule:** twórca akceptuje co najmniej jeden wyrenderowany klip jako warty użycia, **w budżecie ≤K iteracji pętli/dostrojeń** (K do ustalenia, np. 5); brak akceptacji po K → fail gate i fallback (generuj-raz + ręczne). Warunek zakończenia, nie „rób ładniej" w nieskończoność.
+
+**Faza 2 (poza gate MVP, zależne od spike'a):**
+5. Pętla MCP autoringu zbiega bez ręcznej ingerencji w node'y w budżecie iteracji — przeniesione tu, bo zależy od nierozstrzygniętej infrastruktury MCP (otwarte pytanie 2).
+
+> Uwaga: „beatrix = jedyne źródło analizy" to ograniczenie architektoniczne (Decyzja 4), nie kryterium-wynik — usunięte z listy kryteriów, by lista mierzyła rezultaty, nie inwarianty.
+
+## Otwarte pytania (do planowania)
+
+1. **Gdzie żyje kod?** Nowy pakiet vs. rozszerzenie `cinemon` — **decyzja do jawnego ważenia, nie domyślnego nowego pakietu.** Wspólne z cinemon: kontrakt danych beatrix, subprocess Blendera (`project_manager.py`), wzorzec presetów, `audio_validator`. Tyle wspólnej maszynerii sugeruje **wspólny core lub submode w cinemon** zamiast czystego splitu — zwłaszcza przy 1 deweloperze / 6 pakietach (koszt utrzymania). Paradygmat-specyficzne (autoring GN, pętla MCP, render 3D) vs wspólne — rozpisać w `/ce:plan` i zdecydować kosztem utrzymania, nie nowością.
+2. **Setup Blender MCP** — który konkretny serwer (np. `ahujasid/blender-mcp`?), czy umie Python + screenshot viewportu w docelowym Blenderze, kroki integracji. **Prerequisite-spike, nie część buildu wizualizera.**
+3. **Mechanika próbkowania po czasie w GN** — krzywa vs siatka; matematyka time→index (`time_sec = frame / fps`). **UWAGA: siatka czasu jest zależna od utworu** — beatrix ładuje audio z `sr=None`, więc krok `frequency_bands.times` = `hop_length/sr` jest różny per plik (~23ms przy 22050 Hz, ~10.7ms przy 48 kHz). Most B MUSI czytać `sample_rate` i wyprowadzać index z faktycznego `times[]`, nie z zakładanego stałego kroku — inaczej sync rozjedzie się na utworach o innym sr (przejdzie spike na jednym, pęknie na produkcji). `sections` pominięte na MVP (patrz Zakres).
+4. **Konfiguracja** — kiedy/czy migrować z dataclass MVP do wzorca YAML `cinemon` (próg: pojawienie się drugiego presetu).
+5. **Reproducible artifact — rozstrzygnięte:** źródłem prawdy jest **skrypt-builder GN (Python) + dataclass parametrów presetu**, commitowany do repo. `.blend` wytworzony interaktywnie przez pętlę MCP = produkt uboczny eksploracji, NIE źródło renderu. Determinizm: `builder + preset-params + analysis.json` → ten sam render. (Otwarte: dokładny kształt serializacji parametrów — implementacja.)
+
+## Ryzyka i spike'i (przed lockiem zakresu)
+
+Trzy techniczne ryzyka rdzenia są realnie niesprawdzone — każde dostaje spike z warunkiem kill/continue **przed** pełnym buildem:
+
+1. **Normalizacja pasm** — czy deterministyczny per-track transform 0..1 daje wizualnie czytelny ruch W OBRĘBIE utworu (porównywalność między utworami świadomie poza MVP). (Decyzja 5)
+2. **GN time-sampling** — czy drzewo GN potrafi czytać atrybut po czasie (Sample Index/Nearest/Curve) z poprawnym `time→index`, wydajnie przy tysiącach wierzchołków. Kill → fallback do podejścia A. (Otwarte 3)
+3. **Pętla MCP** — rozbita na dwa rozłączne warunki (drugi nie jest binarny):
+   - **3a (binarny, decydowalny w godziny):** czy wybrany serwer MCP umie Python+screenshot w żywym Blenderze. Kill → fallback: generacja raz + ręczne dostrojenie.
+   - **3b (hipoteza Fazy 2, NIE warunek kill spike'a):** czy ocena z screenshotu realnie zbiega scenę w ≤K iteracji wg konkretnej rubryki kompozycji. Bez progu nie jest warunkiem kill — przeniesione do Fazy 2 (kryterium 5).
+   (Decyzja 2, Otwarte 2)
+
+**Zbiorcza reguła go/no-go:** fallbacki są per-ryzyko, ale jeśli **jednocześnie** Spike 2 → fallback-A (ręczne drivery) ORAZ Spike 3a/3b → fallback-ręczny, to projekt redukuje się do ręcznego ślęczenia w Blenderze nad driverami — czyli dokładnie tego, co miał wyeliminować (patrz „Użytkownik i wartość"). W tym scenariuszu **bet jest martwy — przerwać, nie kontynuować**.
+
+**Opportunity cost:** to drugi konsument beatrix→wideo obok cinemon, który ma własne luki (jitter/continuous — issue #26, brakujące presety). Bet uznany za **eksploracyjny** — świadomy wybór nowości nad domknięciem cinemon.
+
+## Referencje (repo-relative)
+
+- Schemat danych: `packages/beatrix/src/beatrix/core/audio_analyzer.py`
+- CLI / zapis JSON: `packages/beatrix/src/beatrix/cli/analyze_audio.py`
+- Wzorzec wykonania Blendera: `packages/cinemon/src/cinemon/project_manager.py`
+- Wzorzec konsumpcji analizy + YAML: `packages/cinemon/blender_addon/vse/animation_compositor.py`
+- Struktura katalogów: `setka-common.file_structure.specialized.RecordingStructureManager`

--- a/docs/plans/2026-05-30-001-feat-gn-audio-visualizer-plan.md
+++ b/docs/plans/2026-05-30-001-feat-gn-audio-visualizer-plan.md
@@ -41,7 +41,7 @@ Nowy pakiet workspace (`cymatic`, nazwa robocza) generuje **abstrakcyjny wizuali
 
 **Potwierdzone w tej sesji (Spike 0/1/2/3a):** kroki 1-5 zadziałały end-to-end na żywej maszynie — Claude napędził Blender 5.1.2 przez socket MCP, zbudował reaktywną scenę z realnej analizy, sync potwierdzony.
 
-**⚠ Uwaga render (krok 6):** ten build Blendera 5.1.2 jest **bez wewnętrznego enkodera FFMPEG** i brak systemowego `ffmpeg`. Render do mp4 wymaga instalacji `ffmpeg` (i tak wymagany w CLAUDE.md) → render klatek PNG + mux. Podgląd/akceptacja (krok 5) działa bez tego (Play w Blenderze z sound strip).
+**Render (krok 6) — DZIAŁA end-to-end (2026-05-31):** ten build Blendera 5.1.2 jest bez wewnętrznego enkodera FFMPEG, więc render idzie ścieżką **klatki PNG → mux `ffmpeg`** (zainstalowany `ffmpeg` 8.1.1). Potwierdzone przez `cymatic.render()`: tor beat 120BPM → headless Blender (scena + 360 klatek) → mux → `beat_120bpm_12s_analysis.mp4` (H.264 960×540 + AAC, 12.0s, 2.9MB). Podgląd/akceptacja (krok 5) działa też bez renderu (Play w Blenderze z sound strip).
 
 ## Problem Frame
 
@@ -511,7 +511,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 - Edge case: brak `blender/render/` → `ensure_blender_dir()` tworzy.
 - Integration: pełny przebieg na fixture recording (mock subprocess) generuje oczekiwaną ścieżkę output zgodną ze strukturą katalogów.
 
-**Verification:** Runner odpala Blender headless i produkuje mp4 w `blender/render/` (na realnym Blenderze — manualnie).
+**Verification:** Runner odpala Blender headless i produkuje mp4 w `blender/render/`. **STATUS: DONE (2026-05-31)** — `cymatic.render()` zweryfikowany end-to-end na realnym Blenderze 5.1.2: headless render 360 klatek PNG → mux `ffmpeg` (frames+audio) → `beat_120bpm_12s_analysis.mp4` (H.264 960×540 + AAC, 12.0s). Mux-seam zamknięty (config `frames_dir/audio_file/frame_*`; `_mux_frames` H.264/yuv420p/AAC `-shortest`).
 
 ---
 

--- a/docs/plans/2026-05-30-001-feat-gn-audio-visualizer-plan.md
+++ b/docs/plans/2026-05-30-001-feat-gn-audio-visualizer-plan.md
@@ -1,0 +1,616 @@
+---
+title: "feat: Wizualizer audio 3D (Geometry Nodes + Blender MCP)"
+type: feat
+status: active
+date: 2026-05-30
+origin: docs/brainstorms/2026-05-30-gn-audio-visualizer-requirements.md
+---
+
+# feat: Wizualizer audio 3D (Geometry Nodes + Blender MCP)
+
+## Overview
+
+Nowy pakiet workspace (`cymatic`, nazwa robocza) generuje **abstrakcyjny wizualizer 3D** sterowany analizą `beatrix`, renderowany do mp4. Cała piosenka jest kodowana jako jeden obiekt-danych w scenie (mesh: X = czas, atrybuty wierzchołków = znormalizowane `bass/mid/high` + prekomputowane obwiednie beatów/peaków). Drzewo Geometry Nodes **próbkuje** ten obiekt po bieżącym czasie sceny i czyta wszystkie cechy naraz (most „mesh-jako-dane", podejście B). Look sceny budowany iteracyjnie z pomocą **Blender MCP** (statyczny screenshot = kompozycja), ale **synchronizacja jest weryfikowana z danych, nie z obrazu** — to ograniczenie MCP odkryte w researchu (brak ruchu/klipu w screenshocie).
+
+Źródłem prawdy renderu jest **skrypt-builder GN (Python) + dataclass parametrów presetu**, commitowane do repo; `.blend` z pętli MCP = produkt uboczny. `beatrix` pozostaje nietknięty (single source).
+
+**Dostawa fazowa:** Faza A de-ryzykuje trzema spike'ami z bramkami kill/continue **przed** pełnym buildem. Faza B to MVP build. Faza C (poza gate MVP) to autonomiczna pętla MCP.
+
+## Docelowy workflow (UX — potwierdzony empirycznie 2026-05-31)
+
+```
+1. AUDIO        twórca wskazuje utwór (dowolny format librosa: wav/flac/mp3...)
+      │
+2. ANALIZA      beatrix analyze --beat-division 1  →  *_analysis.json
+      │         (single source of truth; beat_division=1 dla gęstych beatów)
+      │
+3. PRZYGOTOWANIE  cymatic host-side: normalizacja per-track p99 + prekomputacja
+      │           obwiedni beat/peak + dt z times[]  →  dane gotowe do GN
+      │
+4. PROPOZYCJA   Claude (przez Blender Lab MCP / socket) buduje scenę GN w żywym
+      │           Blenderze: data-object + sampler (most B) + preset wizualny.
+      │           Screenshot/short-render → Claude ocenia kompozycję, poprawia
+      │           (pętla autoringu, ≤K iteracji). Sync = z danych, nie z obrazu.
+      │
+5. AKCEPTACJA   twórca ogląda (Play w viewport / klip) → akceptuje look (R4).
+      │           Zaakceptowany look „freeze" → builder.py + PresetParams (commit).
+      │
+6. RENDER       headless, osobno (nie MCP): builder + params + analysis → mp4
+                w blender/render/. (Render wideo: patrz uwaga niżej.)
+```
+
+**Potwierdzone w tej sesji (Spike 0/1/2/3a):** kroki 1-5 zadziałały end-to-end na żywej maszynie — Claude napędził Blender 5.1.2 przez socket MCP, zbudował reaktywną scenę z realnej analizy, sync potwierdzony.
+
+**⚠ Uwaga render (krok 6):** ten build Blendera 5.1.2 jest **bez wewnętrznego enkodera FFMPEG** i brak systemowego `ffmpeg`. Render do mp4 wymaga instalacji `ffmpeg` (i tak wymagany w CLAUDE.md) → render klatek PNG + mux. Podgląd/akceptacja (krok 5) działa bez tego (Play w Blenderze z sound strip).
+
+## Problem Frame
+
+Dane `beatrix` (beaty, onsety, energy_peaks, time-series energii pasm) są dziś konsumowane wyłącznie przez `cinemon` w trybie VSE — animacje 2D na paskach. Brak ścieżki generującej proceduralną wizualizację **3D** z tej samej analizy. Cel: nowy typ outputu z istniejącego pipeline'u (OBS → beatrix → render), autoring sceny przez agenta zamiast ręcznej pracy node-by-node nad driverami. (see origin: `docs/brainstorms/2026-05-30-gn-audio-visualizer-requirements.md`)
+
+## Requirements Trace
+
+- **R1** — Z istniejącego `*_analysis.json` powstaje scena 3D reagująca na: (a) ciągłą **znormalizowaną** energię pasm i (b) dyskretne beaty/peaki (origin: kryterium MVP 1).
+- **R2** — Sync **obiektywny (timing danych)**: akcenty wizualne padają w granicach **±N klatek** (N np. ≤2) od timestampów beatrix — mierzalne z danych (arytmetyka `Seconds/dt`). **Decyzja:** percepcyjne „akcent widać na beacie" NIE jest dowodzone tu (obwiednia prekomputowana → harness dowodzi indeksu, nie pikseli) — pokrywa je **akceptacja twórcy (R4)**. Kryterium MVP 2 = dowód timingu danych, świadomie nie wizualnego (origin: kryterium MVP 2; review: adversarial-tautologia).
+- **R3** — Próbkowanie po czasie poprawne dla dowolnej klatki, **mierzone na ≥2 utworach o RÓŻNYM `sample_rate`** (origin: kryterium MVP 3).
+- **R4** — **Stop-rule (binarny, MVP):** twórca akceptuje **≥1 wyrenderowany klip** jako warty użycia; brak akceptacji → fail gate + fallback generuj-raz. **Bez licznika ≤K w MVP** — budżet iteracji należy wyłącznie do R5 (decyzja: K tylko dla autonomicznej pętli) (origin: kryterium MVP 4).
+- **R5** *(Faza 2, poza gate MVP)* — Pętla MCP autoringu zbiega bez ręcznej ingerencji w node'y w **budżecie ≤K iteracji** (K np. 5) (origin: kryterium Fazy 2 — 5).
+- **INV1** *(inwariant architektoniczny)* — `beatrix` jest jedynym źródłem analizy; nowy moduł nie liczy własnej analizy audio (origin: Decyzja 4).
+- **INV2** *(inwariant)* — Determinizm: `builder + preset-params + analysis.json` → ten sam render; `.blend` nieistotny dla reprodukcji (origin: Otwarte 5).
+
+## Scope Boundaries
+
+- **Brak** łączenia warstwy 3D z footage OBS (osobny, późniejszy pomysł).
+- **Brak** własnej analizy audio — wszystkie dane z `beatrix` (INV1).
+- **Brak** renderu produkcyjnego przez MCP — render leci osobno, headless.
+- **Brak** biblioteki wielu presetów na start — MVP = jeden dobry preset hybrydowy.
+- **Brak** real-time playera dla widza. Podgląd przez screenshoty MCP **jest** w zakresie.
+- **`animation_events.sections` POMINIĘTE na MVP** — to listy dictów `{start,end,label}`, nie skalary; hybryda i R1 ich nie wymagają.
+- **System YAML `cinemon` NIE jest reużywany** — config MVP = prosty dataclass (origin: Decyzja zakresu; jeden preset).
+
+### Deferred to Separate Tasks
+
+- Normalizacja porównywalna **między utworami** (skala absolutna/log): późniejsze rozszerzenie poza MVP (per-track i cross-track są sprzeczne — origin: Decyzja 5).
+- Migracja config dataclass → wzorzec YAML `cinemon`: dopiero gdy pojawi się drugi preset (origin: Otwarte 4).
+- Kodowanie `sections` jako danych dla przejść scen: po MVP.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Subprocess Blendera:** `packages/cinemon/src/cinemon/project_manager.py` — `BlenderProjectManager` buduje `[blender, "--background", "--python", <script>, "--", "--config", <path>]`, `subprocess.run(..., capture_output=True, text=True, check=True)`, `RuntimeError` na `CalledProcessError`. **UWAGA: domyślna gałąź `snap run blender` jest Linux-only** — na macOS wymaga jawnego `blender_executable`.
+- **Parsowanie `--config` w Blenderze:** `packages/cinemon/blender_addon/vse_script.py` skanuje `sys.argv` po `--config`.
+- **Struktura katalogów:** `packages/common/src/setka_common/file_structure/specialized/recording.py` — `ensure_blender_dir()` tworzy `blender/` + `blender/render/`; `get_analysis_file_path()` → `analysis/{stem}_analysis.json`. Wszystkie `@staticmethod`. **Nie hardkodować nazw katalogów.**
+- **Wybór audio:** `packages/beatrix/src/beatrix/core/audio_validator.py` — `AudioValidator.detect_main_audio(extracted_dir, specified_audio=None)`, bezstanowy, komunikaty błędów po polsku.
+- **Kontrakt danych beatrix:** `packages/beatrix/src/beatrix/core/audio_analyzer.py` — `analyze_for_animation()` zwraca `duration`, `sample_rate` (z `librosa.load(sr=None)` → natywny sr), `tempo.{bpm,beat_times,beat_count}`, `animation_events.{beats,onsets,energy_peaks,sections}`, `frequency_bands.{times,bass_energy,mid_energy,high_energy}`. Pasma = `np.mean(np.abs(stft), axis=0)` — **surowe nieznormalizowane magnitudy**. `times = frames_to_time(arange(...), sr=sr)` z `hop_length=512` → **krok siatki `hop_length/sr` zależny od utworu**.
+- **Testy bez Blendera:** `packages/cinemon/tests/conftest.py` — `autouse` fixture `mock_bpy` wstrzykuje `Mock` do `sys.modules["bpy"]`; `mock_subprocess` patchuje `subprocess.run`. Moduły in-Blender używają `try: import bpy / except ImportError: bpy = None`.
+
+### Institutional Learnings
+
+- **Brak `docs/solutions/`** — to pierwszy artefakt wiedzy w tym obszarze. Rozważyć `/ce:compound` po spike'ach (GN time-sampling, normalizacja, pętla MCP).
+- **`docs/DATA_FLOW_SPECIFICATION.md` ma NIEAKTUALNY schemat JSON** (pokazuje zagnieżdżone `spectral_analysis.frequency_bands.bass.energy`). **Ufać kodowi `audio_analyzer.py` i brainstormowi**, nie temu spec — reużyć z niego tylko konwencję katalogów `blender/render/`.
+
+### External References
+
+- **Blender MCP** (`ahujasid/blender-mcp`, v1.5.6, 2026-03): eksponuje `execute_blender_code` (dowolny `bpy`) i `get_viewport_screenshot` (zwraca obraz jako MCP `Image`, ~800px). **Brak dedykowanego narzędzia GN** (PR #92 niezmergowany). **Brak ruchu/klipu/playbacku** — screenshot to statyczna klatka → **sync nieweryfikowalny z obrazu**. Alternatywy: oficjalny Blender Lab MCP (early, first-party), lub **własny cienki socket-bridge / headless `bpy`** (może mniej pracy niż cudzy addon, sandbox pod kontrolą). `execute_blender_code` = niesandboxowany kod LLM → throwaway plik.
+- **GN time-sampling** (Blender 4.3+/4.5): `Scene Time → Seconds`; `Sample Index` (×2 + `Mix` dla interpolacji liniowej, `Clamp=on`); `index = Seconds / dt`. `Sample Index` nie interpoluje sam. `Store/Named Attribute` + `me.attributes.new(type='FLOAT', domain='POINT')` + `foreach_set('value', np_float32)` do budowy danych z numpy. Builder: `node_group.interface.new_socket(...)` — **API 4.0+ (stare `ng.inputs/outputs` USUNIĘTE, kod 3.x rzuci AttributeError)**. Koszt samplingu kilku indeksów/klatkę pomijalny. Obwiednie beatów: **prekomputować w numpy** jako atrybut (`exp(-dt_event/tau)` lub `clamp(1 - dt/decay)`), unika drogiego proximity per-frame.
+
+### Prior-art (sklonowane do `research/prior-art/` — study-only, gitignored, NIE wendorowane)
+
+Cztery projekty zbadane w kodzie. **Twardy wniosek: żaden NIE de-ryzykuje Spike 2 (most B, `Seconds/dt → Sample Index`)** — rdzeń trzeba zrobić od zera (żywy Blender + Manual).
+
+- **`negdo/Sound_Nodes` (GPL-3.0, Blender 3.4):** robi **most A** (keyframe-bake + driver), nie B — zero `Sample Index`/`Scene Time`/mesh-attribute. **Blueprint FALLBACKU-A**, nie walidacja B. Waliduje koncept `beat_env`: ich „Beats Triangle" = bliskość-do-najbliższego-beatu = nasze `clamp(1-dt/decay)` (w Lite tylko opisany w README, nie zaimplementowany → **LEARN, nie LIFT**). API socketów 3.x (`.outputs.new`) **usunięte w 4.0** — nie kopiować. Daje wzorzec keyframe-asercji dla Unit 10 pod fallback-A (czyt. `fcurves`). GPL → tylko `blender_script/`, reimplementacja z README.
+- **`kessoning/Audio-Offline-Analysis` (MIT, 2023, martwy):** ~3 linie transferu — max-scaling `arr/np.max(arr)` (jeden skalar, NIE per-band STFT, **bez guardu zera**) + `round(beat_sec*fps)`. Potwierdza arytmetykę Unit 5; potwierdza max-scaling jako **start** Spike 1, nie zamyka (brak percentyla, brak oceny klipu; `librosa.load` resampluje do 22050 → maskuje problem sr, który MY obsługujemy jawnie). Nie rozwiązuje per-band normalizacji ani `dt`-z-`times[]`.
+- **`tom-malaeasy/Audio2Blender` (GPL-3.0, Blender 2.80, beta):** potwierdza **kanał mesh-as-data** (`mesh.attributes.new('FLOAT','POINT')` + `foreach_set`) = koncept Unit 6. **README kłamie** o „sends to Geometry Nodes" — zero budowania node-group, Unit 7 nietknięty. Realtime (`sounddevice`, timery) = **AVOID** (łamie INV1). `bl_info` 2.80 → nie wzorzec API.
+- **`miolini/blender-auto-render` (BRAK licencji = all rights reserved):** **SKIP** — nie wolno kopiować. Orkiestracja = uboższy podzbiór `BlenderProjectManager` (bez stderr-capture, bez `--` separatora). Direct-mp4-mux = anty-wzorzec vs frames→FFmpeg-mux. EEVEE legacy API usunięte w 4.2+. Render-block bez audio. → Reużyj cinemon `project_setup.py` (H264+AAC) + CGWire frames-then-mux.
+
+### Verified Absence
+
+Repo-wide grep: zero `geometry.?node`, `node_group`, `MCP`, `bmesh`, `bpy.data.meshes`. Cały kod Blendera w repo to **VSE 2D only**. Moduł 3D GN jest **greenfield**.
+
+## Key Technical Decisions
+
+- **Nowy pakiet workspace `cymatic`** (decyzja użytkownika, Otwarte 1): member `packages/cymatic/`, zależny od `setka-common` + `beatrix`. Powód: config `cinemon` mocno sprzężony z VSE (`strip_animations` po nazwie pliku, `layout`, `AnimationSpec`) — nic z tego nie pasuje do sceny GN; czysty rozdział paradygmatów. Reużycie: `RecordingStructureManager`, `AudioValidator`, wzorzec subprocess + `--config`, wzorzec `try/except ImportError: bpy=None` + conftest Mock. Nazwa robocza, do zmiany przy scaffoldzie.
+- **Most B (mesh-jako-dane)** z fallbackiem A: dane jako mesh (N wierzchołków, X=czas, float-atrybuty); drzewo GN próbkuje przez `Sample Index`. Gdyby Spike 2 zabił B → fallback do podejścia A (keyframe+drivery). (origin: Decyzja 4)
+  - **Blast radius fallbacku-A** (review: adversarial — to NIE „adaptacja parametru", to ~40% przepisania buildu): pod A **znikają** Unit 6 (data-object), Unit 7 (GN sampler) i cała sekcja interpolacji w High-Level Technical Design; Unit 10 zmienia strategię z „odczyt kanału GN" na „odczyt czasów keyframe F-curve". **Keyframe-based asercja Unit 10 pod A NIE jest jeszcze zaprojektowana** — to dług dziedziczony przy kill. Konsekwencja dla bramki: zbiorcza reguła go/no-go traktuje pojedynczy fallback-A jako tani, a jest kosztowny — przy kill Spike 2 świadomie zważyć, czy kontynuować, nie kontynuować domyślnie.
+- **`dt` czytany z `times[]` per-track, NIE hardkodowany.** `dt = times[1] - times[0]` (równoważne `hop_length/sample_rate`). Most B czyta `sample_rate` i wyprowadza index z faktycznej siatki — inaczej sync przejdzie spike na jednym sr i pęknie na produkcji o innym sr. (origin: Otwarte 3) — **najwyższe ryzyko detalu**.
+- **Normalizacja per-track w nowym module** (numpy, deterministyczna, raz na analizę): percentyl/max do 0..1. Cel MVP = czytelność W OBRĘBIE utworu. `beatrix` nietknięty. (origin: Decyzja 5)
+- **Obwiednie beatów/peaków prekomputowane w numpy** (podejście C z researchu): osobne float-atrybuty `beat_env`/`peak_env`, samplowane tym samym `Sample Index` co pasma. Cała semantyka zdarzeń poza grafem.
+- **Sync weryfikowany z DANYCH, nie z obrazu** (wymuszone ograniczeniem MCP): harness czyta czasy keyframe / próbkuje stan na klatkach beatów i liczy odchyłkę w klatkach. MCP screenshot służy tylko kompozycji/lookowi (statyka). (origin: Decyzja 2, doprecyzowane researchem)
+- **Config MVP = dataclass**, serializowany do pliku przekazywanego przez `--config` (nie YAML cinemon). (origin: Decyzja zakresu, Otwarte 4)
+- **Artefakt reprodukowalny = builder.py + dataclass params** (commit); `.blend` produkt uboczny. (origin: Otwarte 5, INV2)
+- **Render headless osobno** (nie przez MCP), do `blender/render/` przez `ensure_blender_dir()`.
+- **`fps` pochodzi z `VisualizerConfig`, NIE z analizy** (review: feasibility/scope/adversarial). `beatrix` **nie emituje `fps`** (zwraca tylko `duration`, `sample_rate`, `tempo`, `animation_events`, `frequency_bands`). `build_scene.py` ustawia `scene.render.fps` z tej samej wartości config, której używa harness sync (`round(beat_sec*fps)`) — inaczej time-based GN sampling (`Seconds/dt`, fps-niezależny) i frame-based asercja mogą się rozjechać. Default np. 30.
+- **„Look freeze" — krok kodyfikacji** (review: adversarial INV2): look wyeksplorowany przez MCP MUSI być przepisany do `hybrid_v1.py` + `PresetParams` **i zweryfikowany**, że re-run buildera na tym samym `analysis.json` odtwarza zaakceptowaną klatkę (pixel/perceptual diff na klatce akceptacji). Pętla MCP może manipulować **tylko parametrami wyrażalnymi w `PresetParams`** — inaczej INV2 nie zachodzi. **R4 (akceptacja) bramkuje output BUILDERA, nie interaktywny `.blend`.**
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Gdzie żyje kod?** → Nowy pakiet workspace `cymatic` (decyzja użytkownika).
+- **Mechanika GN time→index?** → `Scene Time → Seconds`, `index = Seconds/dt` (dt z `times[]`), `Sample Index`×2 + `Mix`, `Clamp=on`. (research framework-docs)
+- **Reprezentacja zdarzeń?** → prekomputowane obwiednie decay w numpy jako atrybuty (podejście C).
+- **Jak weryfikować sync skoro MCP nie pokazuje ruchu?** → asercja na danych (czasy keyframe / sampling na klatkach beatów), nie wizualnie.
+- **Reproducible artifact?** → builder.py + dataclass params (origin: Otwarte 5).
+
+### Deferred to Implementation
+
+- **Wybór serwera MCP — ROZSTRZYGNIĘTE (Spike 3a):** oficjalny **Blender Lab MCP** (GPL-3.0), zainstalowany i zweryfikowany na Blenderze 5.1.2. Napęd: natywne narzędzia MCP w Claude Code (po reloadzie) LUB wprost przez socket `localhost:9876` (cienki klient). Nie ahujasid, nie własny bridge.
+- **Ścieżka `blender_executable` na macOS** — POTWIERDZONE: `/Applications/Blender.app/Contents/MacOS/Blender`, **Blender 5.1.2** (nowszy niż target 4.3/4.5; API `interface` 4.0+ działa — Spike 2 PASS). `snap run blender` Linux-only. Default config dla tej maszyny = ścieżka macOS.
+- **Dokładna wartość N** (tolerancja sync w klatkach, np. ≤2) — kalibracja przy harnessie sync (Unit 10), zależna od `dt` vs `1/fps`. N jest **stałą wewnętrzną harnessu (Unit 10)**, nie polem config (review: scope — przedwczesna powierzchnia konfiguracji); promować do config tylko gdy dane pokażą wariancję per-track.
+- **Dokładna wartość K** (budżet iteracji stop-rule, np. 5) — ustalić przy **autonomicznej pętli MCP (Unit 11 / Faza C)**, po potwierdzeniu że Spike 3a przeszedł (review: coherence — K to parametr R5/Fazy C, nie Fazy B).
+- **Zachowanie loadera przy `len(times) < 2`** (`dt = times[1]-times[0]` rzuci IndexError) — guard + jasny błąd dla zdegenerowanej/krótkiej analizy (review: feasibility — to najbardziej load-bearing wartość).
+- **Dokładny kształt serializacji dataclass** (JSON vs prosty YAML bez maszynerii cinemon) — implementacja (Unit 4).
+- **Metoda normalizacji** — **ROZSTRZYGNIĘTE Spike 1 (na realnym CC0 jazz, 48k):** kotwica **`p99`** (percentyl 99) — clamp_hi 1%, CV ~0.7 (bass/high) / ~0.4 (mid), mean ~0.32, odporna na pojedyncze transjenty (max-scaling zaniża zakres do mean ~0.25; p95 clampuje 5%). Per-band, deterministyczna, z guardem zera. Potwierdzić na ≥1 dodatkowym utworze innego gatunku.
+- **Codec/container mp4** — dopasować do ustawień FFMPEG z `packages/cinemon/blender_addon/vse/project_setup.py` (Unit 9).
+- **Mechanizm odczytu stanu kanału GN per-klatka w harnessie (Unit 10)** — czy `build_scene.py` eksportuje plik danych per-frame, czy harness biegnie wewnątrz Blendera (kolejny subprocess)? (review: scope — niejawne). Determinuje, czy Unit 10 to czysty test Pythona, czy wymaga subprocess.
+- **Rozwiązanie `extracted_dir` dla `AudioValidator`** z `base_directory` (lub bezpośrednie `--analysis-file`/`--main-audio`) — Unit 5.
+- **Czy nazwa `cymatic` trwa do MVP** czy rename przy scaffoldzie (rename mid-build = churn ścieżek importu) — decyzja przy Unit 4.
+
+## Output Structure
+
+    packages/cymatic/
+    ├── pyproject.toml                         # member workspace, deps: setka-common, beatrix
+    ├── src/cymatic/
+    │   ├── __init__.py
+    │   ├── config.py                          # dataclass: VisualizerConfig + PresetParams
+    │   ├── analysis_loader.py                 # wczytanie JSON, AudioValidator, dt z times[]
+    │   ├── normalization.py                   # per-track 0..1 + prekomputacja obwiedni
+    │   ├── runner.py                          # host-side: subprocess blender + --config + render
+    │   └── cli.py                             # entry point (np. cymatic-render)
+    ├── blender_script/                        # wykonywane WEWNĄTRZ Blendera (import bpy)
+    │   ├── build_scene.py                     # entry: --config → data-object + GN + scena + render
+    │   ├── data_object.py                     # numpy → mesh + float-atrybuty (foreach_set)
+    │   ├── gn_sampler.py                       # builder drzewa GN (node_group.interface)
+    │   └── presets/
+    │       └── hybrid_v1.py                    # jeden preset wizualny (look)
+    └── tests/
+        ├── conftest.py                        # mock_bpy + mock_subprocess (wzorzec cinemon)
+        ├── test_normalization.py
+        ├── test_analysis_loader.py
+        ├── test_data_object.py
+        ├── test_gn_sampler.py
+        ├── test_runner.py
+        └── test_sync_verification.py
+
+> Drzewo to deklaracja zakresu, nie sztywne ograniczenie — implementacja może dostosować układ.
+
+## High-Level Technical Design
+
+> *Ilustruje zamierzone podejście, jako wskazówka kierunkowa do recenzji, NIE specyfikacja implementacji. Agent implementujący traktuje to jako kontekst, nie kod do odtworzenia.*
+
+Przepływ danych (host-side → in-Blender):
+
+```
+*_analysis.json (beatrix)
+        │
+        ▼  analysis_loader.py     reużywa AudioValidator; czyta sample_rate, dt = times[1]-times[0]
+   { duration, dt, bands(raw), beats[], energy_peaks[] }   # fps z VisualizerConfig, NIE z analizy
+        │
+        ▼  normalization.py        per-track 0..1 (percentyl/max), deterministyczne
+   { bass_n[], mid_n[], high_n[], beat_env[], peak_env[] }   # obwiednie prekomputowane (numpy)
+        │
+        ▼  config.py               dataclass VisualizerConfig + PresetParams → serializacja
+   config_file  ──►  runner.py  ──►  blender --background --python build_scene.py -- --config <file>
+                                                  │
+                          ┌───────────────────────┼───────────────────────────┐
+                          ▼                        ▼                           ▼
+                   data_object.py            gn_sampler.py                presets/hybrid_v1.py
+              numpy → mesh N wierzch.    node_group GN:                scena: pasma→ciągła forma,
+              X=czas, attrs:             Scene Time→Seconds            impulsy→akcenty (skala/błysk)
+              bass_n,mid_n,high_n,       index = Seconds/dt
+              beat_env,peak_env          Sample Index ×2 + Mix (Clamp)
+                                          → bass/mid/high/beat/peak (interp.)
+                          └───────────────────────┬───────────────────────────┘
+                                                   ▼  render headless → blender/render/<name>.mp4
+```
+
+Interpolacja w GN (most B, rdzeń sync):
+
+```
+Scene Time.Seconds ──► [÷ dt] ──► index_f
+   i0 = floor(index_f);  i1 = i0+1;  frac = index_f - i0
+   v0 = SampleIndex(attr, i0, Clamp=on)
+   v1 = SampleIndex(attr, i1, Clamp=on)
+   value = Mix(v0, v1, frac)          # liniowa interpolacja między próbkami
+```
+
+## Implementation Units
+
+> **Fazowanie:** Faza 0 (pożądalność) → Faza A (spike'y techniczne, bramki kill) → Faza B (build MVP) → Faza C (poza gate). Faza 0 i A MUSZĄ poprzedzić Fazę B. **Zbiorcza reguła go/no-go:** jeśli Spike 2 → fallback-A ORAZ Spike 3a → fallback-ręczny jednocześnie, projekt redukuje się do ręcznego ślęczenia nad driverami (to, co miał wyeliminować) → **bet martwy, przerwać** (origin: reguła zbiorcza).
+
+### Faza 0 — Pożądalność (przed inżynierią)
+
+- [ ] **Unit 0: Spike — pożądalność outputu 3D (throwaway)**
+
+**Goal:** Tanio potwierdzić, że abstrakcyjny wizualizer 3D to output, który twórca faktycznie chce — **zanim** ruszy jakikolwiek scaffold/spike techniczny.
+
+**Requirements:** Warunek wstępny R4 (pożądalność przed inżynierią).
+
+**Dependencies:** Brak.
+
+**Approach:**
+- Ręcznie w Blenderze (godziny): prosty throwaway `.blend` — kilka obiektów GN/keyframe sterowanych zgrubnie energią z jednego realnego `*_analysis.json`, render krótkiego klipu mp4. **Bez `cymatic`, bez scaffoldu, bez mostu B** — cel to obraz do oceny, nie architektura.
+- Twórca ogląda klip i ocenia: czy ten typ wizualizacji jest warty budowania pełnego pipeline'u.
+
+**Execution note:** Maksymalnie tani, jednorazowy. Nic z tego kodu nie trafia do produkcji.
+
+**Test scenarios:**
+- Test expectation: none — throwaway probe, brak zmiany behawioralnej do testowania. Output = decyzja twórcy.
+
+**Verification (bramka kill):** Twórca uznaje typ outputu za wart budowania. **Kill → cały bet pada za grosze, przed inżynierią** (najtańszy możliwy punkt porzucenia; review: product — najdroższa porażka odkryta najpóźniej, ten spike ją przesuwa na początek).
+
+**STATUS: PASS (2026-05-31).** Zbudowano działający artefakt wprost w żywym Blenderze 5.1.2 (napęd przez socket): 3 koncentryczne kręgi słupków (bass/mid/high) z przewijaną historią energii + świecący rdzeń pulsujący na `beat_env`, na realnych danych. **Sync potwierdzony** (wizualnie+słuchowo) na syntetycznym rytmie 120 BPM. Twórca: „jest synchronizacja, możemy działać". Skrypty: `research/build_visualizer_v1.py`, `research/build_visualizer_v2.py`.
+> **Finding (do buildu):** domyślny `beat_division=8` w beatrix decymuje beaty ~8× → na 120s jazzu tylko 32 beaty (rzadkie pulsy). Wizualizer powinien wołać beatrix z **`beat_division=1`** (lub mapować `onsets`/`energy_peaks` na impulsy) dla gęstego, czytelnego rytmu.
+
+### Faza A — De-ryzykowanie (spike'y z bramkami)
+
+- [ ] **Unit 1: Spike — normalizacja pasm (per-track 0..1)**
+
+**Goal:** Potwierdzić, że deterministyczny per-track transform surowych magnitud STFT daje wizualnie czytelny ruch W OBRĘBIE utworu.
+
+**Requirements:** R1 (część ciągła), INV1.
+
+**Dependencies:** Brak (czysty numpy + istniejące `*_analysis.json`).
+
+**Files:**
+- Create (prototyp, może wylądować w `normalization.py`): `packages/cymatic/src/cymatic/normalization.py`
+- Test: `packages/cymatic/tests/test_normalization.py`
+
+**Approach:**
+- Wczytać `frequency_bands.{bass,mid,high}_energy` z realnego `*_analysis.json`.
+- Porównać warianty: max-scaling, percentyl (np. 95/99), log+percentyl. Wybrać deterministyczny.
+- Ocena czytelności: rozkład wartości po normalizacji (czy ruch widoczny, czy nie klipuje do 0/1 przez większość czasu).
+
+**Execution note:** Spike eksploracyjny — wynik to decyzja metody + dane, nie produkcyjny moduł. Walidacja w `ce:work`.
+
+**Test scenarios:**
+- Happy path: znormalizowane pasmo mieści się w [0,1], `min≈0`, `max≈1` dla wybranej metody.
+- Edge case: pasmo o stałej (niemal zerowej) energii — brak dzielenia przez zero, wynik zdefiniowany (np. wszystkie 0).
+- Determinizm: dwukrotna normalizacja tych samych danych → identyczny wynik (bit-for-bit).
+
+**Verification (bramka kill — MIERZALNA, nie estetyczna):** Na ≥1 realnym utworze, dla wybranej metody, **udział klatek sklipowanych do 0/1 < X%** ORAZ **współczynnik zmienności (CV) energii > Y** (X, Y ustalone z góry, np. X=20%, Y dobrane na podglądzie). **STATUS: PASS (2026-05-31)** na CC0 jazz 48k — kotwica `p99`: clamp_hi 1%, CV 0.4–0.7, mean 0.32. Wszystkie warianty (max/p99/p95) zaliczyły; p99 wybrany. **Kill** jeśli żadna deterministyczna metoda nie spełnia progu (review: adversarial — „czytelny" to osąd estetyczny, nie bramka; bez progu spike jest nie-do-obalenia). Jeśli progu nie da się sensownie ustalić → spike degraduje do **doradczego** (twardy output = „istnieje wybrana metoda deterministyczna"), nie kill-gate (origin: Spike 1).
+
+---
+
+- [ ] **Unit 2: Spike — GN time-sampling (most B) na ≥2 sr**
+
+**Goal:** Potwierdzić, że drzewo GN czyta atrybut po czasie z poprawnym `time→index`, na ≥2 utworach o RÓŻNYM `sample_rate`.
+
+**Requirements:** R2, R3 (rdzeń), INV2.
+
+**Dependencies:** Brak — spike może użyć syntetycznej tablicy `np.linspace(0,1,N)` zamiast znormalizowanych danych beatrix (review: scope — Unit 1 nie blokuje; realne dane wchodzą dopiero w Unit 6). Może biec równolegle do Unit 1.
+
+**Files:**
+- Create (prototyp → `data_object.py` + `gn_sampler.py`): `packages/cymatic/blender_script/data_object.py`, `packages/cymatic/blender_script/gn_sampler.py`
+- Test: `packages/cymatic/tests/test_gn_sampler.py` (struktura node tree przez mock bpy)
+
+**Approach:**
+- Zbudować minimalny data-object: mesh N wierzch., X=czas, atrybut `bass_n` (`me.attributes.new(type='FLOAT', domain='POINT')` + `foreach_set`).
+- Zbudować minimalne drzewo GN: `Scene Time→Seconds`, `÷ dt`, `Sample Index`×2 + `Mix`, `Clamp=on`.
+- **`dt` z `times[1]-times[0]`** (NIE stała). Przetestować na utworze 22050 Hz i 48 kHz.
+- Asercja na danych: dla wybranych klatek wartość z GN == znormalizowana wartość beatrix w tym czasie (z tolerancją interpolacji).
+
+**Execution note:** Najpierw asercja poprawności `time→index` na dwóch sr — to jest cały sens spike'a.
+
+**Test scenarios:**
+- Happy path (mock bpy): builder tworzy `node_group` z socketami przez `interface.new_socket`, węzły `GeometryNodeInputSceneTime`, `GeometryNodeSampleIndex` istnieją, `clamp=True`.
+- Integration (żywy Blender, ręcznie w spike'u): dla 22050 Hz wartość@frame odpowiada `bass_n[round(sec/dt)]` ±interp.
+- Integration: ten sam test dla 48 kHz — index liczony z `dt` tego pliku, nie z poprzedniego.
+- Edge case: czas przed pierwszą / po ostatniej próbce → `Clamp` zwraca wartość skrajną, nie 0/czarną klatkę.
+
+**Verification (bramka kill):** Stan wizualizacji@dowolna klatka odpowiada danym beatrix na **obu** sr. **Kill → fallback do podejścia A** (keyframe+drivery), reszta planu adaptuje się do A (origin: Spike 2).
+
+**STATUS: PASS (2026-05-31)** na żywym **Blenderze 5.1.2**, realny CC0 jazz, **OBA sr**. Graf: `Scene Time→Seconds → ÷dt → Sample Index×2 + Mix(frac), Clamp=on`, `index` z `dt` każdego utworu. Read-back przez depsgraph (probe vertex Z): **max abs_err = 5.96e-08** (precyzja float) na 48k (dt=0.010667) i 44k (dt=0.011610). Most B potwierdzony empirycznie; API `node_group.interface.new_socket` (4.0+) działa na 5.x. Skrypt: `research/spike2_gn_sampling.py`. **Fallback-A zdjęty ze stołu dla rdzenia.**
+
+---
+
+- [ ] **Unit 3: Spike — MCP/bridge (binarny 3a)**
+
+**Goal:** Potwierdzić binarnie, że wybrana ścieżka MCP/bridge umie uruchomić Python (`bpy`) w żywym Blenderze i zwrócić screenshot viewportu, którego agent „widzi".
+
+**Requirements:** Warunek wstępny R5 (Unit 11 zależy od pass Spike 3a). Kill → fallback-ręczny zastępujący autonomiczną pętlę; MVP (R4) nadal osiągalny bez tego spike'a.
+
+**Dependencies:** Brak (niezależny od Unit 1/2).
+
+**Files:**
+- Create (notatka/skrypt spike'a): `docs/solutions/` (po spike'u) lub `packages/cymatic/blender_script/` smoke-skrypt.
+
+**Approach:**
+- Ocenić 3 opcje: `ahujasid/blender-mcp` (gotowy, ~800px screenshot, niesandboxowany `execute_blender_code`), oficjalny Blender Lab MCP, **własny cienki socket-bridge / headless `bpy`** (sandbox pod kontrolą, spójny z istniejącym headless w repo).
+- Smoke test: uruchom trywialny `bpy` (utwórz kostkę), pobierz screenshot, potwierdź że obraz wraca do agenta.
+- Na macOS: potwierdź ścieżkę Blendera (nie `snap`), local-network permission dla socketu loopback.
+- **Kryteria bezpieczeństwa (review: security — 10 min source review, nie blokują spike'a):** (1) czy addon robi połączenia wychodzące poza loopback? (2) czy źródło jest przeglądalne i sprawdzone? (3) socket binduje **tylko `127.0.0.1`** (nigdy `0.0.0.0`) i żyje **tylko na czas sesji autoringu** (nie trwały demon); (4) czy przyjmuje połączenia od dowolnego procesu lokalnego, czy tylko od rodzica.
+
+**Execution note:** Binarny, godziny. NIE buduj tu wizualizera — tylko potwierdź zdolność.
+
+**Test scenarios:**
+- Happy path: `execute_blender_code` tworzy obiekt; `get_viewport_screenshot` zwraca obraz widziany przez agenta.
+- Error path: długi skrypt nie zawiesza trwale UI / timeout obsłużony.
+
+**Verification (bramka kill):** Python+screenshot działają w żywym Blenderze na macOS. **Kill → fallback:** agent generuje setup GN raz, człowiek dostraja ręcznie (MVP nadal osiągalny przez builder, bez autonomicznej pętli). **3b (zbieżność pętli) NIE jest tu bramką — to Faza C / R5.** (origin: Spike 3a/3b)
+
+**STATUS: PASS (2026-05-31).** Serwer **ROZSTRZYGNIĘTY: oficjalny Blender Lab MCP** (`blender.org/lab`, GPL-3.0) — już zainstalowany: addon `lab_blender_org/mcp` w Blenderze 5.1.2 (socket non-blocking `localhost:9876`, `weak_sandbox.py`) + rozszerzenie Claude Desktop `blmcp`. Zweryfikowane end-to-end: `execute_blender_code` zwrócił `{version:5.1.2, objects:[Camera,Cube,Light]}`; `bpy.ops.screen.screenshot` → PNG 2532×1834, agent odczytał obraz. Narzędzia: `execute_blender_code`, `get_screenshot_of_window/area_as_image`, `render_viewport_to_path`, `search_manual_docs`, summaries blendfile. **Podpięty do Claude Code** (`claude mcp add blender`, local scope, ✓ Connected — natywne po reloadzie). **Uproszczenie:** można też napędzać wprost przez socket (`connection.py`, ~95 linii, null-byte JSON `type:execute`) — bez warstwy serwera MCP; obniża zależność Unit 11.
+
+> **Przed Fazą B — sprawdź zbiorczą regułę go/no-go:** jeśli Spike 0 (pożądalność) OK, Spike 1 OK, Spike 2 OK i (Spike 3a OK LUB akceptacja fallbacku-ręcznego dla MVP) → wejdź w Fazę B. **Spike 3a kill blokuje tylko Fazę C / Unit 11 — NIE Fazę B**; MVP osiągalny bez autonomicznej pętli (review: coherence). Kill Spike 2 → patrz „Blast radius fallbacku-A" (Key Technical Decisions): świadoma decyzja, nie auto-kontynuacja.
+
+### Faza B — Build MVP
+
+- [ ] **Unit 4: Scaffold pakietu + config dataclass**
+
+**Goal:** Utworzyć pakiet workspace `cymatic` z podziałem host/in-Blender i dataclass config.
+
+**Requirements:** Fundament dla R1–R4, INV2.
+
+**Dependencies:** Decyzja o nazwie pakietu (potwierdzić przy scaffoldzie).
+
+**Files:**
+- Create: `packages/cymatic/pyproject.toml`, `packages/cymatic/src/cymatic/__init__.py`, `packages/cymatic/src/cymatic/config.py`, `packages/cymatic/tests/conftest.py`
+- Modify: `pyproject.toml` (root — dodać member do `[tool.uv.workspace]` i `[tool.uv.sources]`)
+
+**Approach:**
+- Member workspace, deps `setka-common` + `beatrix` przez `{ workspace = true }`. Backend hatchling (jak cinemon).
+- Podział: `src/cymatic/` (host, absolute imports) vs `blender_script/` (in-Blender, `try/except ImportError: bpy=None`).
+- `conftest.py`: skopiować wzorzec `mock_bpy` + `mock_subprocess` z `packages/cinemon/tests/conftest.py`; wstrzyknąć `blender_script/` na `sys.path`.
+- `config.py`: `@dataclass VisualizerConfig` (ścieżki: analysis_file, output_mp4, base_directory; `fps` (default np. 30); `resolution`; `blender_executable`) + `@dataclass PresetParams` (paleta, prymityw geometrii, intensywność akcentów, `decay`/`tau`). **`n_tolerance_frames` NIE jest tu** — to stała wewnętrzna harnessu (Unit 10), nie powierzchnia config (review: scope). Serializacja do pliku **przez `tempfile.NamedTemporaryFile`** (review: security — sprzątany po subprocess, nie zostawia layoutu FS na dysku) i deserializacja w `build_scene.py`.
+- **Packaging:** `blender_script/` poza wheel (`packages = ['src/cymatic']`, jak `blender_addon/` w cinemon); `runner.py` lokalizuje `build_scene.py` przez `Path(__file__).parent.parent.parent / 'blender_script' / 'build_scene.py'` (wzorzec `BlenderProjectManager`). Root `pyproject.toml`: dodać `packages/cymatic/tests` do `testpaths` i `packages/cymatic/src` do `pythonpath` (review: feasibility — inaczej `uv run pytest` nie zbierze pakietu).
+
+**Patterns to follow:** `packages/cinemon/pyproject.toml` (struktura), `packages/cinemon/tests/conftest.py` (mocki), `packages/common/src/setka_common/config/yaml_config.py` (`ProjectConfig` jako referencja pól — fps/resolution/render_output/base_directory).
+
+**Test scenarios:**
+- Happy path: `VisualizerConfig` round-trip serializacja↔deserializacja zachowuje wszystkie pola.
+- Edge case: brak opcjonalnego pola (`resolution=None`) → sensowny default.
+- Happy path: `uv sync` widzi nowy pakiet (smoke importu `import cymatic`).
+
+**Verification:** Pakiet importowalny, testy uruchamiają się z mock bpy, config round-trip przechodzi.
+
+---
+
+- [ ] **Unit 5: Loader analizy + normalizacja + prekomputacja obwiedni**
+
+**Goal:** Host-side moduł: wczytuje `*_analysis.json`, wybiera audio, normalizuje pasma per-track, prekomputuje obwiednie beatów/peaków, wyprowadza `dt` z `times[]`.
+
+**Requirements:** R1, R3 (dt), INV1.
+
+**Dependencies:** Unit 1 (metoda normalizacji), Unit 4 (config).
+
+**Files:**
+- Create: `packages/cymatic/src/cymatic/analysis_loader.py`, `packages/cymatic/src/cymatic/normalization.py` (finalizacja prototypu z Unit 1)
+- Test: `packages/cymatic/tests/test_analysis_loader.py`, `packages/cymatic/tests/test_normalization.py`
+
+**Approach:**
+- `analysis_loader`: ścieżka JSON pochodzi **wprost z `VisualizerConfig.analysis_file`** — NIE z `get_analysis_file_path()` (review: scope — jego sygnatura to `(video_path)` i derywuje stem z pliku wideo, nie z katalogu nagrania; niezgodne z wejściem cymatic). Wybór audio: `AudioValidator.detect_main_audio(extracted_dir, ...)` — **uwaga: bierze `extracted/`, nie katalog nagrania**; rozwiązać `extracted_dir` z `base_directory` przed wywołaniem (lub przyjąć audio z config). **Wyprowadzić `dt = times[1] - times[0]`** (walidować spójność z `hop_length/sample_rate`; **guard na `len(times) < 2`** → jasny błąd). Odczytać `sample_rate`, `duration`. **`fps` z `VisualizerConfig.fps` (beatrix NIE emituje `fps`)**, nie z JSON.
+- `normalization`: deterministyczny transform 0..1 (metoda z Unit 1); prekomputacja `beat_env`/`peak_env` z `animation_events.{beats,energy_peaks}` (np. `clamp(1 - dt_event/decay)` lub `exp(-dt_event/tau)`) na siatce `times[]`. **Uwaga (review: adversarial):** `energy_peaks` w beatrix to **wyłącznie peaki basu** (`_find_bass_peaks`) — `peak_env` jest strukturalnie bass-driven; na utworach bass-light `peak_env` będzie rzadkie/puste, a jedynym pozostałym impulsem jest `beats` (siatka tempa). Preset (Unit 8) nie powinien zakładać gęstych peaków.
+- Output: struktura gotowa do zakodowania jako atrybuty (równej długości tablice numpy).
+
+**Patterns to follow:** `packages/cinemon/blender_addon/vse/animation_compositor.py` (`_extract_events` — mapowanie triggerów na klucze eventów), `AudioValidator` API.
+
+**Test scenarios:**
+- Happy path: dla fixture JSON wszystkie pasma znormalizowane do [0,1], długości == `len(times)`.
+- Edge case (R3): dwa fixture o różnym `sample_rate` (22050, 48000) → `dt` różne, poprawnie wyprowadzone z `times[]`, nie z założonej stałej.
+- Edge case: beat dokładnie na próbce vs między próbkami → obwiednia szczytuje we właściwym indeksie.
+- Error path: brak pliku analizy → `FileNotFoundError`; wiele plików audio bez wskazania → propagacja `MultipleAudioFilesError`.
+- Error path: `len(times) < 2` → jasny błąd (nie IndexError z `times[1]`).
+- Edge case: pusta lista `energy_peaks` → `peak_env` same zera, brak wyjątku.
+- Happy path: `fps` czytane z `VisualizerConfig`, NIE z JSON (brak klucza `fps` w analizie nie powoduje błędu).
+- Integration: pełne przejście loader→normalizacja na realnym `*_analysis.json` daje tablice równej długości gotowe dla data-object.
+
+**Verification:** Dla ≥2 utworów o różnym sr loader produkuje spójne, znormalizowane, równej długości tablice z poprawnym `dt`.
+
+---
+
+- [ ] **Unit 6: Data-object builder (numpy → mesh + atrybuty)** *(in-Blender)*
+
+**Goal:** Zbudować w Blenderze obiekt-danych: mesh N wierzch., X=czas, float-atrybuty `bass_n/mid_n/high_n/beat_env/peak_env`.
+
+**Requirements:** R1, INV2. (R2/R3 weryfikowane w Unit 10, nie tu — Unit 6 buduje tylko strukturę danych.)
+
+**Dependencies:** Unit 2 (potwierdzony wzorzec), Unit 5 (dane).
+
+**Files:**
+- Create: `packages/cymatic/blender_script/data_object.py`
+- Test: `packages/cymatic/tests/test_data_object.py` (mock bpy — asercje struktury)
+
+**Approach:**
+- `me.vertices.add(N)`; `co[0::3] = arange(N)*dt` (X=czas); `me.vertices.foreach_set("co", co)`.
+- Per kanał: `me.attributes.new(name, type='FLOAT', domain='POINT')` + `attr.data.foreach_set("value", np.ascontiguousarray(arr, float32))`.
+- Jeden obiekt, wiele atrybutów (jeden „data object", wiele kanałów).
+
+**Patterns to follow:** wzorzec `foreach_set` z numpy (research framework-docs); `try/except ImportError: bpy=None`.
+
+**Test scenarios:**
+- Happy path (mock bpy): builder woła `attributes.new` dla 5 kanałów, `foreach_set` z buforem długości N.
+- Edge case: N==len(times) zachowane; bufor float32, C-contiguous.
+- Integration (żywy Blender, manualnie/Unit 2): odczyt atrybutu po indeksie == wartość wejściowa.
+
+**Verification:** Data-object ma N wierzchołków i 5 poprawnych float-atrybutów; X-pozycje == `arange(N)*dt`.
+
+---
+
+- [ ] **Unit 7: GN sampler tree builder** *(in-Blender)*
+
+**Goal:** Programowo zbudować drzewo GN próbkujące data-object po czasie i wystawiające interpolowane `bass/mid/high/beat/peak`.
+
+**Requirements:** R2, R3.
+
+**Dependencies:** Unit 6 (data-object).
+
+**Files:**
+- Create: `packages/cymatic/blender_script/gn_sampler.py`
+- Test: `packages/cymatic/tests/test_gn_sampler.py` (mock bpy — struktura)
+
+**Approach:**
+- `bpy.data.node_groups.new(..., 'GeometryNodeTree')`; sockety przez **`ng.interface.new_socket(name, in_out, socket_type)`** (API 4.0+).
+- Węzły: `GeometryNodeInputSceneTime` (Seconds), `GeometryNodeMath` (DIVIDE: Seconds/dt), `GeometryNodeSampleIndex`×2 (`data_type='FLOAT'`, `domain='POINT'`, `clamp=True`), `Mix` (frac). Per kanał wpięty `GeometryNodeInputNamedAttribute`.
+- `dt` przekazane jako wartość węzła (z config), spójne z data-object.
+
+**Patterns to follow:** schemat interpolacji z sekcji High-Level Technical Design; API `node_group.interface` (research).
+
+**Test scenarios:**
+- Happy path (mock bpy): tworzone węzły o właściwych bpy id; sockety przez `interface.new_socket` (NIE `ng.inputs`); `clamp=True`, `data_type='FLOAT'`.
+- Edge case: builder pod 4.x — brak użycia usuniętego `ng.inputs/outputs`. **UWAGA (review: feasibility):** zwykły `Mock` fabrykuje każdy atrybut, więc `mock_ng.inputs` i `mock_ng.interface` są nieodróżnialnie truthy — test mockowy NIE wykryje regresji 3.x→4.x. Asercja realna tylko w żywym Blenderze (Unit 2 spike). W teście mockowym: asercja na ścieżce kodu (np. `spec`-owany mock interfejsu) lub jawny grep, nie poleganie na fabrykowanym atrybucie.
+- Integration (Unit 2): interpolacja liniowa między próbkami daje wartość pośrednią dla czasu między indeksami.
+
+**Verification:** Drzewo GN buduje się bez błędu, próbkuje 5 kanałów jednym indeksem, interpoluje liniowo.
+
+---
+
+- [ ] **Unit 8: Preset wizualny + montaż sceny** *(in-Blender)*
+
+**Goal:** Jeden hybrydowy preset: pasma → ciągła forma/ruch tła, impulsy (beat/peak) → dyskretne akcenty (skala/błysk/wyrzut). Codyfikowany w builderze.
+
+**Requirements:** R1, INV2. (Akceptacja R4 zachodzi na wyrenderowanym klipie z Unit 9, nie tu.)
+
+**Dependencies:** Unit 7 (sampler wystawia kanały).
+
+**Files:**
+- Create: `packages/cymatic/blender_script/presets/hybrid_v1.py`, `packages/cymatic/blender_script/build_scene.py` (orkiestracja: parse `--config` → data_object → gn_sampler → preset → [render w Unit 9])
+- Test: `packages/cymatic/tests/test_data_object.py`/dedykowany (mock bpy — montaż struktury)
+
+**Approach:**
+- Wystawione kanały GN sterują: ciągłe pasma → deformacja/instancje/skala formy; `beat_env`/`peak_env` → impulsy (skok skali, emisja, błysk materiału).
+- `PresetParams` (paleta, prymityw, intensywność) wpięte jako wejścia.
+- Look hybrydowego presetu autorowany **bezpośrednio przez dewelopera** w `hybrid_v1.py`. Screenshoty MCP mogą **opcjonalnie** wspomóc statyczny przegląd kompozycji, ale **NIE są wymagane** do zaliczenia Unit 8 (review: scope/coherence — autonomiczna pętla to Unit 11/Faza C, ten unit nie zależy od pass Spike 3a). Finalny look **zapisany w builderze** (źródło prawdy, „look freeze" — patrz Key Technical Decisions/INV2), nie w `.blend`.
+- `build_scene.py` parsuje `--config` ze `sys.argv` (wzorzec `vse_script.py`).
+
+**Execution note:** MVP NIE zależy od MCP ani od autonomicznej zbieżności pętli (to R5/Faza C). Preset musi dać się zbudować i wyrenderować czysto z samego buildera.
+
+**Test scenarios:**
+- Happy path (mock bpy): `build_scene.main()` parsuje `--config`, woła data_object + gn_sampler + preset w kolejności, zwraca 0.
+- Edge case: brak `--config` → czytelny błąd, kod != 0.
+- Integration (żywy Blender): scena renderuje pojedynczą klatkę bez błędu; akcent widoczny przy `frame_set` na czas beatu.
+
+**Verification:** Z config + data-object powstaje scena 3D, w której (a) ciągła energia i (b) impulsy beat/peak są widocznie sterowane (R1).
+
+---
+
+- [ ] **Unit 9: Host-side runner + render do mp4**
+
+**Goal:** Host-side: zbudować komendę subprocess, uruchomić Blender headless, wyrenderować mp4 do `blender/render/`.
+
+**Requirements:** R4, INV2.
+
+**Dependencies:** Unit 4 (config), Unit 8 (build_scene).
+
+**Files:**
+- Create: `packages/cymatic/src/cymatic/runner.py`, `packages/cymatic/src/cymatic/cli.py`
+- Test: `packages/cymatic/tests/test_runner.py` (mock subprocess)
+
+**Approach:**
+- Wzorzec `BlenderProjectManager`: `[blender_executable, "--background", "--python", build_scene.py, "--", "--config", <file>]`, `subprocess.run(..., capture_output=True, text=True, check=True)`, `RuntimeError` na `CalledProcessError` (stderr).
+- **macOS: `blender_executable` z config (jawna ścieżka), NIE `snap run`.** Zachować gałąź snap dla Linuxa.
+- Output przez `RecordingStructureManager.ensure_blender_dir()` → `blender/render/<name>.mp4`. Render headless (nie MCP). **Render-block: kopiować z `packages/cinemon/blender_addon/vse/project_setup.py`** (kanoniczny: `FFMPEG`/`MPEG4`/`H264`/`HIGH` + audio `AAC`/192/48000) — NIE z `blender-auto-render` (bez audio, MKV/AV1, brak licencji). Rozważyć **frames→FFmpeg-mux** (PNG → `ffmpeg`) zamiast bezpośredniego muxera Blendera (pewniejsze; setka ma FFmpeg 4.4+; review prior-art + CGWire 2026).
+- `build_scene.py` ustawia `scene.render.fps` z `VisualizerConfig.fps` — ta sama wartość, której używa harness sync (Unit 10), by time-based sampler i frame-based asercja nie rozjechały się.
+- CLI entry point (np. `cymatic-render <recording_dir> [--main-audio ...]`).
+
+**Patterns to follow:** `packages/cinemon/src/cinemon/project_manager.py` (subprocess, separator `--`, obsługa błędów), `RecordingStructureManager`.
+
+**Test scenarios:**
+- Happy path (mock subprocess): runner buduje poprawną komendę z `--config` i ścieżką build_scene; sukces → ścieżka mp4.
+- Edge case: `blender_executable="blender"` na Linux → gałąź `snap run`; jawna ścieżka → bezpośrednio.
+- Error path: `CalledProcessError` → `RuntimeError` z treścią stderr.
+- Edge case: brak `blender/render/` → `ensure_blender_dir()` tworzy.
+- Integration: pełny przebieg na fixture recording (mock subprocess) generuje oczekiwaną ścieżkę output zgodną ze strukturą katalogów.
+
+**Verification:** Runner odpala Blender headless i produkuje mp4 w `blender/render/` (na realnym Blenderze — manualnie).
+
+---
+
+- [ ] **Unit 10: Harness weryfikacji sync (z danych)**
+
+**Goal:** Obiektywnie zmierzyć, że akcenty wizualne padają w ±N klatek od beatów/peaków beatrix — z danych, nie z obrazu.
+
+**Requirements:** R2, R3.
+
+**Dependencies:** Unit 7/8 (scena z akcentami), Unit 5 (dane referencyjne).
+
+**Files:**
+- Create: `packages/cymatic/src/cymatic/sync_verification.py` (lub w `tests/`)
+- Test: `packages/cymatic/tests/test_sync_verification.py`
+
+**Approach:**
+- Strategia z danych (wymuszona ograniczeniem MCP): w żywym Blenderze `frame_set(f)` na klatki wokół beatów; odczytać stan kanału impulsu (lub czasy keyframe F-curve, jeśli fallback A) i znaleźć klatkę szczytu akcentu.
+- Odchyłka = |klatka_szczytu - round(beat_sec * fps)|. Asercja ≤ N.
+- **Mierzyć na ≥2 utworach o RÓŻNYM sr** (R3): potwierdzić, że `dt`-based index trzyma sync na obu.
+- Skalibrować N (np. ≤2) — zależne od `dt` vs `1/fps` (kwantyzacja STFT to dolna granica). N = stała wewnętrzna harnessu (nie config).
+- **Asercja spójności fps:** `config.fps == scene.render.fps == fps użyte w `round(beat_sec*fps)`** — chroni przed dryfem time-based vs frame-based (review: feasibility/adversarial).
+- **Zakres tego dowodu (review: adversarial — szczerość kryterium 2):** obwiednia jest prekomputowana w numpy i samplowana po indeksie, więc ten harness weryfikuje przede wszystkim **arytmetykę `Seconds/dt` i rozmieszczenie obwiedni** (częściowo pokrywa Unit 2/Unit 5), oraz kwantyzację `dt` vs `1/fps`. **NIE** dowodzi percepcyjnego „akcent widać na beacie" — easing presetu, motion blur i liniowe rozmycie impulsu między próbkami (`dt` ~11–23 ms) mogą zmiękczyć akcent. Percepcyjna weryfikacja należy do akceptacji twórcy (R4), nie do tego harnessu. Kryterium MVP 2 = dowód timingu danych, nie timingu wizualnego — patrz present-finding poniżej.
+
+**Test scenarios:**
+- Happy path: dla syntetycznych danych (beat na znanym czasie) szczyt impulsu wypada w ±N klatek.
+- Edge case (R3): test na 22050 Hz i 48 kHz — sync trzyma na obu (NIE tylko na tym, na którym przeszedł spike).
+- Edge case: beat blisko końca utworu → brak indeksu poza zakresem (Clamp).
+- Error path: utwór bez beatów → harness raportuje brak, nie crash.
+
+**Verification (gate R2/R3):** Na ≥2 utworach różnego sr wszystkie akcenty w ±N klatek. To **obiektywny** dowód sync (kryterium MVP 2 i 3).
+
+### Faza C — Poza gate MVP (zależne od Spike 3a)
+
+- [ ] **Unit 11: Autonomiczna pętla autoringu MCP (R5)**
+
+**Goal:** Sformalizować pętlę build→screenshot→ocena→popraw tak, by zbiegała look bez ręcznej ingerencji w node'y w budżecie ≤K iteracji.
+
+**Requirements:** R5 (Faza 2).
+
+**Dependencies:** Unit 3 (Spike 3a pass), Unit 8 (preset jako punkt startowy).
+
+**Files:**
+- Create: `packages/cymatic/` (orkiestracja pętli — host-side), rubryka oceny kompozycji.
+
+**Approach:**
+- Pętla: agent buduje/poprawia look przez `execute_blender_code`, pobiera `get_viewport_screenshot` (statyka, ~800px), ocenia wg **konkretnej, falsyfikowalnej rubryki** (kadr, occlusion, liczba instancji, obecność akcentu@frame), poprawia.
+- **Sync NIE oceniany z obrazu** — zostaje w Unit 10 (dane). Pętla = tylko kompozycja/look.
+- Budżet ≤K iteracji; po K bez akceptacji → fallback (generuj-raz + ręczne). Trzymać najnowsze 1-2 screenshoty w kontekście (koszt obrazu).
+
+**Test scenarios:**
+- Happy path: pętla wykonuje ≤K iteracji, każda z konkretną oceną; zwraca zaakceptowany look lub fallback.
+- Edge case: brak zbieżności w K → czysty fallback, nie nieskończona pętla.
+
+**Verification (R5):** Pętla zbiega look w ≤K bez ręcznej edycji node'ów. **To kryterium Fazy 2, poza gate MVP** (origin: kryterium 5).
+
+## System-Wide Impact
+
+- **Interaction graph:** Nowy pakiet jest **dodatkowym konsumentem** `beatrix` obok `cinemon`. Reużywa `setka-common` (`RecordingStructureManager`) i `beatrix` (`AudioValidator`). Brak modyfikacji `beatrix`/`cinemon` (INV1). (`MediaDiscovery` NIE jest reużywane — to maszyneria odkrywania wideo/YAML cinemon, nieistotna dla cymatic; review: scope.)
+- **Error propagation:** Subprocess Blendera → `RuntimeError` ze stderr (wzorzec cinemon). Błędy walidacji audio propagują z `beatrix` (`NoAudioFileError`/`MultipleAudioFilesError`, komunikaty po polsku).
+- **State lifecycle risks:** `.blend` z pętli MCP jest **efemeryczny** — nie commitować jako źródło; źródło = builder + params (INV2). `execute_blender_code` niesandboxowany → throwaway plik.
+- **API surface parity:** Nowy CLI entry point (`cymatic-render`) — dodać do `pyproject.toml` `[project.scripts]`. Brak zmian w istniejących entry points.
+- **Integration coverage:** Krytyczne ścieżki, których mocki nie udowodnią: (1) GN time-sampling na żywym Blenderze (Unit 2 spike + Unit 10); (2) render headless do mp4 (Unit 9, manualnie); (3) sync na 2 różnych sr (Unit 10).
+- **Unchanged invariants:** `beatrix` (single source analizy) i config VSE `cinemon` pozostają nietknięte. Nowy pakiet czyta wyłącznie istniejący `*_analysis.json`.
+- **Maintenance cost:** +1 pakiet (1 dev / 6 pakietów) — świadomy koszt (origin: opportunity cost, bet eksploracyjny obok luk cinemon issue #26). **Ścieżka utylizacji przy kill (review: product):** jeśli bet umrze (zbiorcza reguła go/no-go), `cymatic` usuwany z workspace members + sources, nie zostawiany jako orphan; kod buildera GN może być zarchiwizowany w `docs/solutions/` jeśli spike'y dały wiedzę.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| ~~GN time-sampling niesprawdzony (most B)~~ — **ROZWIĄZANE: Spike 2 PASS (2026-05-31)** na Blenderze 5.1.2, oba sr, err 6e-08 | Most B potwierdzony empirycznie; ryzyko zamknięte. Fallback-A pozostaje udokumentowany (`Sound_Nodes`), ale niepotrzebny dla rdzenia |
+| **Sync rozjeżdża się na innym `sample_rate`** | `dt` z `times[]` per-track (NIE stała); Unit 10 mierzy na ≥2 sr (R3) — łapie regresję, której spike na 1 sr by nie wykrył |
+| **MCP nie pokazuje ruchu** → sync nieweryfikowalny wizualnie | Sync z danych (Unit 10), nie z obrazu; MCP tylko do kompozycji (statyka) |
+| ~~MCP/bridge nie działa w żywym Blenderze~~ — **ROZWIĄZANE: Spike 3a PASS (2026-05-31)** — oficjalny Blender Lab MCP, execute+screenshot zweryfikowane na 5.1.2 | Ryzyko zamknięte; socket loopback :9876, sandbox obecny |
+| **Oba rdzeniowe bety padają** (Spike 2→A ORAZ 3a→ręczne) | **Zbiorcza reguła go/no-go: bet martwy, przerwać** — projekt zredukowałby się do ręcznego ślęczenia nad driverami |
+| **`snap run blender` Linux-only** na macOS | `blender_executable` jawny w config; zachować gałąź snap dla Linux |
+| **API GN 3.x vs 4.x** (`ng.inputs` usunięte) | Builder używa `node_group.interface.new_socket` (4.0+); test asercją; introspekcja node'ów przed budową |
+| **Normalizacja nieczytelna** | Spike 1 z bramką kill przed buildem |
+| **Niesandboxowany `execute_blender_code`** — blast radius szerszy niż 1 `.blend` (review: security): kod LLM ma dostęp do całego FS użytkownika (tokeny OAuth medusa, inne nagrania, `~`) | Proces MCP odpalany z `cwd` = izolowany katalog temp (NIE root nagrania); operować na **kopii** `.blend`, nie w katalogu nagrania; wywołania `execute_blender_code` w Unit 11 raczej szablonowane/recenzowane niż w pełni dowolne |
+| **Socket loopback (port 9876)** — lokalna powierzchnia code-execution (review: security) | Bind tylko `127.0.0.1`; lifetime = sesja autoringu; jeśli `ahujasid/blender-mcp` — potwierdzić loopback-only (kryteria w Spike 3a) |
+| **Koszt tokenów obrazu w pętli MCP** | `max_size` ~800px; trzymać najnowsze 1-2 screenshoty; ≤K iteracji + fallback (Unit 11) |
+
+## Documentation / Operational Notes
+
+- Po spike'ach: rozważyć `/ce:compound` → `docs/solutions/` (GN time-sampling, normalizacja per-track, pętla MCP) — brak istniejącej bazy wiedzy.
+- **Zaktualizować `docs/DATA_FLOW_SPECIFICATION.md`** lub oznaczyć jego schemat JSON jako nieaktualny (pokazuje `spectral_analysis.*`, kod emituje flat `frequency_bands.*`).
+- macOS: udokumentować ścieżkę `blender_executable` i wymaganą wersję Blendera (4.3+/4.5) w README pakietu.
+- Render codec/container: dopasować do `packages/cinemon/blender_addon/vse/project_setup.py` (FFMPEG settings).
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-30-gn-audio-visualizer-requirements.md](docs/brainstorms/2026-05-30-gn-audio-visualizer-requirements.md)
+- Kontrakt danych: `packages/beatrix/src/beatrix/core/audio_analyzer.py`
+- Wybór audio: `packages/beatrix/src/beatrix/core/audio_validator.py`
+- Wzorzec subprocess: `packages/cinemon/src/cinemon/project_manager.py`, `packages/cinemon/blender_addon/vse_script.py`
+- Konsumpcja analizy: `packages/cinemon/blender_addon/vse/animation_compositor.py`
+- Render FFMPEG: `packages/cinemon/blender_addon/vse/project_setup.py`
+- Struktura katalogów: `packages/common/src/setka_common/file_structure/specialized/recording.py`
+- Testy bez Blendera: `packages/cinemon/tests/conftest.py`
+- External: `ahujasid/blender-mcp` (v1.5.6); Blender Manual GN (`Scene Time`, `Sample Index`, `Sample Curve`, `NodeTreeInterface` API 4.0+)
+- Prior-art (study-only, gitignored): `research/prior-art/{Sound_Nodes,Audio-Offline-Analysis,Audio2Blender,blender-auto-render}/`
+- **Dane testowe (gitignored, `research/audio/`):** CC0 jazz „Al McKibbon — Monsieur Phillipe" (archive.org, public domain), 120 s, dwa sr: `jazz_120s_48k.wav` (dt=0.010667) + `jazz_120s_44k.wav` (dt=0.011610) → `research/audio/analysis/*_analysis.json`. Reprodukują R3 (różny sr→różny dt) i skrajne skale pasm (bass 81.8 vs high 2.5). **Spike 1 PASS** na tych danych (kotwica p99).
+```

--- a/docs/plans/2026-05-30-001-feat-gn-audio-visualizer-plan.md
+++ b/docs/plans/2026-05-30-001-feat-gn-audio-visualizer-plan.md
@@ -220,7 +220,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ### Faza 0 — Pożądalność (przed inżynierią)
 
-- [ ] **Unit 0: Spike — pożądalność outputu 3D (throwaway)**
+- [x] **Unit 0: Spike — pożądalność outputu 3D (throwaway)**
 
 **Goal:** Tanio potwierdzić, że abstrakcyjny wizualizer 3D to output, który twórca faktycznie chce — **zanim** ruszy jakikolwiek scaffold/spike techniczny.
 
@@ -244,7 +244,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ### Faza A — De-ryzykowanie (spike'y z bramkami)
 
-- [ ] **Unit 1: Spike — normalizacja pasm (per-track 0..1)**
+- [x] **Unit 1: Spike — normalizacja pasm (per-track 0..1)**
 
 **Goal:** Potwierdzić, że deterministyczny per-track transform surowych magnitud STFT daje wizualnie czytelny ruch W OBRĘBIE utworu.
 
@@ -272,7 +272,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ---
 
-- [ ] **Unit 2: Spike — GN time-sampling (most B) na ≥2 sr**
+- [x] **Unit 2: Spike — GN time-sampling (most B) na ≥2 sr**
 
 **Goal:** Potwierdzić, że drzewo GN czyta atrybut po czasie z poprawnym `time→index`, na ≥2 utworach o RÓŻNYM `sample_rate`.
 
@@ -304,7 +304,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ---
 
-- [ ] **Unit 3: Spike — MCP/bridge (binarny 3a)**
+- [x] **Unit 3: Spike — MCP/bridge (binarny 3a)**
 
 **Goal:** Potwierdzić binarnie, że wybrana ścieżka MCP/bridge umie uruchomić Python (`bpy`) w żywym Blenderze i zwrócić screenshot viewportu, którego agent „widzi".
 
@@ -335,7 +335,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ### Faza B — Build MVP
 
-- [ ] **Unit 4: Scaffold pakietu + config dataclass**
+- [x] **Unit 4: Scaffold pakietu + config dataclass**
 
 **Goal:** Utworzyć pakiet workspace `cymatic` z podziałem host/in-Blender i dataclass config.
 
@@ -365,7 +365,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ---
 
-- [ ] **Unit 5: Loader analizy + normalizacja + prekomputacja obwiedni**
+- [x] **Unit 5: Loader analizy + normalizacja + prekomputacja obwiedni**
 
 **Goal:** Host-side moduł: wczytuje `*_analysis.json`, wybiera audio, normalizuje pasma per-track, prekomputuje obwiednie beatów/peaków, wyprowadza `dt` z `times[]`.
 
@@ -398,7 +398,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ---
 
-- [ ] **Unit 6: Data-object builder (numpy → mesh + atrybuty)** *(in-Blender)*
+- [x] **Unit 6: Data-object builder (numpy → mesh + atrybuty)** *(in-Blender)*
 
 **Goal:** Zbudować w Blenderze obiekt-danych: mesh N wierzch., X=czas, float-atrybuty `bass_n/mid_n/high_n/beat_env/peak_env`.
 
@@ -426,7 +426,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ---
 
-- [ ] **Unit 7: GN sampler tree builder** *(in-Blender)*
+- [x] **Unit 7: GN sampler tree builder** *(in-Blender)*
 
 **Goal:** Programowo zbudować drzewo GN próbkujące data-object po czasie i wystawiające interpolowane `bass/mid/high/beat/peak`.
 
@@ -454,7 +454,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ---
 
-- [ ] **Unit 8: Preset wizualny + montaż sceny** *(in-Blender)*
+- [x] **Unit 8: Preset wizualny + montaż sceny** *(in-Blender)*
 
 **Goal:** Jeden hybrydowy preset: pasma → ciągła forma/ruch tła, impulsy (beat/peak) → dyskretne akcenty (skala/błysk/wyrzut). Codyfikowany w builderze.
 
@@ -483,7 +483,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ---
 
-- [ ] **Unit 9: Host-side runner + render do mp4**
+- [x] **Unit 9: Host-side runner + render do mp4**
 
 **Goal:** Host-side: zbudować komendę subprocess, uruchomić Blender headless, wyrenderować mp4 do `blender/render/`.
 
@@ -515,7 +515,7 @@ Scene Time.Seconds ──► [÷ dt] ──► index_f
 
 ---
 
-- [ ] **Unit 10: Harness weryfikacji sync (z danych)**
+- [x] **Unit 10: Harness weryfikacji sync (z danych)**
 
 **Goal:** Obiektywnie zmierzyć, że akcenty wizualne padają w ±N klatek od beatów/peaków beatrix — z danych, nie z obrazu.
 

--- a/packages/cymatic/README.md
+++ b/packages/cymatic/README.md
@@ -1,0 +1,11 @@
+# cymatic
+
+3D audio visualizer for the Setka pipeline. Generates a procedural Geometry
+Nodes scene driven by `beatrix` audio analysis and renders it to mp4.
+
+- **Host-side** (`src/cymatic/`): config, analysis loading, normalization, the
+  subprocess runner, and the CLI (`cymatic-render`).
+- **In-Blender** (`blender_script/`, not installed in the wheel): executed by
+  Blender via `--background --python build_scene.py -- --config <file>`.
+
+See `docs/plans/2026-05-30-001-feat-gn-audio-visualizer-plan.md`.

--- a/packages/cymatic/blender_script/__init__.py
+++ b/packages/cymatic/blender_script/__init__.py
@@ -1,0 +1,4 @@
+# ABOUTME: In-Blender script package for cymatic (executed inside Blender via bpy)
+# ABOUTME: NOT installed in the wheel — located by the runner at execution time
+
+"""In-Blender scripts for cymatic (run with ``blender --background --python``)."""

--- a/packages/cymatic/blender_script/build_scene.py
+++ b/packages/cymatic/blender_script/build_scene.py
@@ -1,0 +1,134 @@
+# ABOUTME: In-Blender entry point — parses --config, builds the full GN scene.
+# ABOUTME: config -> load_analysis -> data_object -> sampler -> hybrid_v1 preset.
+
+"""Parametric Blender script for the cymatic 3D audio visualizer (Unit 8).
+
+Executed inside Blender:
+    blender --background --python build_scene.py -- --config <config.json>
+
+Orchestration:
+  1. parse ``--config`` from ``sys.argv`` (after the ``--`` separator),
+  2. load the ``VisualizerConfig``,
+  3. load + normalize the beatrix analysis (host-side pure-numpy modules,
+     reached by injecting the package ``src/`` onto ``sys.path`` — Blender's
+     bundled python ships numpy),
+  4. build the data-object mesh (Unit 6),
+  5. build the GN time-sampler node group (Unit 7),
+  6. assemble the hybrid_v1 visual preset / scene (Unit 8).
+
+Headless rendering to ``blender/render/<name>.mp4`` is wired by the host-side
+runner (Unit 9); this script only builds the scene.
+
+``main() -> int`` returns 0 on success. ``bpy`` is guarded so the module can be
+imported (and ``main`` reasoned about) outside Blender for tests.
+"""
+
+import sys
+from pathlib import Path
+
+try:
+    import bpy
+except ImportError:
+    bpy = None
+
+# --- import path wiring -------------------------------------------------------
+# Sibling in-Blender modules (data_object, gn_sampler, presets/) live next to
+# this file. The host-side pure-numpy modules (config, analysis_loader,
+# normalization) live under the package ``src/`` and are NOT on Blender's path,
+# so inject both. Blender's bundled python provides numpy.
+_script_dir = Path(__file__).parent
+_src_dir = _script_dir.parent / "src"
+for _p in (str(_script_dir), str(_src_dir)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# In-Blender builders (siblings).
+from data_object import build_data_object  # noqa: E402
+from gn_sampler import DEFAULT_CHANNELS, build_sampler_group  # noqa: E402
+from presets import build_preset_scene  # noqa: E402
+
+# Host-side pure-numpy modules (package src/, numpy-only — no bpy).
+from cymatic.analysis_loader import load_analysis  # noqa: E402
+from cymatic.config import VisualizerConfig  # noqa: E402
+
+
+def parse_config_path(argv=None):
+    """Find the ``--config <path>`` argument in argv.
+
+    Mirrors cinemon's vse_script.py: scans for the ``--config`` flag and
+    returns the following token.
+
+    Args:
+        argv: argument list (defaults to ``sys.argv``).
+
+    Returns:
+        str: path to the config file.
+
+    Raises:
+        ValueError: if no ``--config`` argument is present.
+    """
+    if argv is None:
+        argv = sys.argv
+
+    for i, arg in enumerate(argv):
+        if arg == "--config" and i + 1 < len(argv):
+            return argv[i + 1]
+
+    raise ValueError("No config file specified. Use --config <path> argument.")
+
+
+def main(argv=None) -> int:
+    """Build the visualizer scene from the config.
+
+    Returns:
+        int: exit code (0 on success, non-zero on error).
+    """
+    try:
+        config_path = parse_config_path(argv)
+    except ValueError as exc:
+        print(f"cymatic build_scene: {exc}")
+        return 1
+
+    config = VisualizerConfig.from_json(Path(config_path).read_text())
+
+    # 1. host-side load + normalize (pure numpy, no bpy).
+    analysis = load_analysis(config)
+
+    # 2. data-object: numpy channels -> mesh + FLOAT/POINT attributes (Unit 6).
+    channels = {
+        "bass_n": analysis.bass,
+        "mid_n": analysis.mid,
+        "high_n": analysis.high,
+        "beat_env": analysis.beat_env,
+        "peak_env": analysis.peak_env,
+    }
+    data_obj = build_data_object("audio_data", analysis.dt, channels)
+
+    # 3. GN sampler node group reading the data-object by scene time (Unit 7).
+    sampler_group = build_sampler_group(
+        "cymatic_sampler", analysis.dt, data_obj, channels=DEFAULT_CHANNELS
+    )
+
+    # 4. hybrid_v1 preset: rings + core + camera + sun + world + render (Unit 8).
+    build_preset_scene(
+        analysis,
+        data_obj,
+        sampler_group,
+        config.preset,
+        fps=config.fps,
+        resolution=config.resolution,
+    )
+
+    print(f"cymatic build_scene: scene built from {config_path}")
+    return 0
+
+
+def is_running_in_blender() -> bool:
+    """True when executed inside Blender (bpy importable)."""
+    return bpy is not None
+
+
+if __name__ == "__main__":
+    exit_code = main()
+    if not is_running_in_blender():
+        sys.exit(exit_code)

--- a/packages/cymatic/blender_script/build_scene.py
+++ b/packages/cymatic/blender_script/build_scene.py
@@ -38,7 +38,15 @@ except ImportError:
 # so inject both. Blender's bundled python provides numpy.
 _script_dir = Path(__file__).parent
 _src_dir = _script_dir.parent / "src"
-for _p in (str(_script_dir), str(_src_dir)):
+# Sibling workspace packages cymatic depends on (beatrix, setka-common) are not
+# on Blender's bundled-python path either; inject their src/ dirs too so the
+# host-side modules import cleanly inside headless Blender.
+_packages_dir = _script_dir.parent.parent
+_sibling_srcs = [
+    str(_packages_dir / "beatrix" / "src"),
+    str(_packages_dir / "common" / "src"),
+]
+for _p in (str(_script_dir), str(_src_dir), *_sibling_srcs):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
@@ -118,6 +126,24 @@ def main(argv=None) -> int:
         fps=config.fps,
         resolution=config.resolution,
     )
+
+    # 5. optional headless render of the PNG frame sequence (Unit 9 mux seam).
+    # When the runner sets config.frames_dir, render the animation to PNG frames
+    # there; the host-side runner then muxes them + audio to mp4 via ffmpeg
+    # (this Blender build has no internal FFMPEG encoder).
+    if bpy is not None and config.frames_dir:
+        scene = bpy.context.scene
+        scene.frame_start = config.frame_start
+        scene.frame_end = config.frame_end or int(analysis.duration * config.fps)
+        scene.render.image_settings.file_format = "PNG"
+        frames_dir = Path(config.frames_dir)
+        frames_dir.mkdir(parents=True, exist_ok=True)
+        scene.render.filepath = str(frames_dir / "frame_")
+        print(
+            f"cymatic build_scene: rendering frames "
+            f"{scene.frame_start}-{scene.frame_end} -> {frames_dir}"
+        )
+        bpy.ops.render.render(animation=True)
 
     print(f"cymatic build_scene: scene built from {config_path}")
     return 0

--- a/packages/cymatic/blender_script/data_object.py
+++ b/packages/cymatic/blender_script/data_object.py
@@ -1,0 +1,109 @@
+# ABOUTME: In-Blender builder — numpy channels -> mesh with N verts + float attrs
+# ABOUTME: X = time = arange(N)*dt; one FLOAT/POINT attribute per channel (foreach_set)
+
+"""Data-object builder for the cymatic 3D audio visualizer (Unit 6).
+
+Encodes the whole song as a single "data object": a mesh with ``N`` vertices
+whose X coordinate is time (``arange(N) * dt``) and one FLOAT vertex attribute
+(POINT domain) per channel (``bass_n``, ``mid_n``, ``high_n``, ``beat_env``,
+``peak_env``). A Geometry Nodes tree (Unit 7) samples this object by scene time
+via ``Sample Index`` — the "mesh-as-data" bridge (approach B).
+
+The numpy -> mesh pattern here is lifted verbatim from the proven spike code
+(``research/spike2_gn_sampling.py`` and ``research/build_visualizer_v1.py``,
+Stage A), confirmed working on Blender 5.1.2:
+
+    mesh.vertices.add(N)
+    co[0::3] = arange(N) * dt
+    mesh.vertices.foreach_set("co", co)
+    attr = mesh.attributes.new(name=..., type='FLOAT', domain='POINT')
+    attr.data.foreach_set("value", np.ascontiguousarray(arr, np.float32))
+
+This module is executed inside Blender, so ``bpy`` is guarded for import-time
+availability in tests.
+"""
+
+import sys
+
+import numpy as np
+
+try:
+    import bpy
+except ImportError:  # running outside Blender (e.g. unit tests)
+    bpy = None
+
+
+def _bpy():
+    """Resolve the live ``bpy`` module.
+
+    Inside Blender this is the module imported at load time. In tests the
+    autouse ``mock_bpy`` fixture injects a Mock into ``sys.modules["bpy"]``
+    after this module is imported, so fall back to that injected module.
+
+    Raises:
+        RuntimeError: if no ``bpy`` is available (not in Blender, no mock).
+    """
+    mod = bpy if bpy is not None else sys.modules.get("bpy")
+    if mod is None:
+        raise RuntimeError(
+            "build_data_object requires Blender's bpy module (run inside Blender)."
+        )
+    return mod
+
+
+def build_data_object(name, dt, channels):
+    """Build a Blender data-object mesh from equal-length numpy channels.
+
+    Creates a mesh with ``N`` vertices (``N`` = the common length of every
+    channel array), sets each vertex X coordinate to ``arange(N) * dt`` (time),
+    and adds one FLOAT/POINT vertex attribute per channel. All attribute
+    buffers are coerced to C-contiguous ``float32`` of length ``N`` before
+    ``foreach_set``.
+
+    Args:
+        name: name for the mesh and object.
+        dt: time step between samples (seconds); X = arange(N) * dt.
+        channels: mapping of attribute name -> 1-D numpy array. Every array
+            must have the same length (== N). Must be non-empty.
+
+    Returns:
+        The created Blender object (``bpy.types.Object``), linked into the
+        scene collection.
+
+    Raises:
+        ValueError: if ``channels`` is empty or arrays differ in length.
+    """
+    if not channels:
+        raise ValueError("channels must be a non-empty mapping of name -> array.")
+
+    lengths = {key: len(arr) for key, arr in channels.items()}
+    unique_lengths = set(lengths.values())
+    if len(unique_lengths) != 1:
+        raise ValueError(
+            f"All channel arrays must have equal length; got {lengths}."
+        )
+
+    n = unique_lengths.pop()
+    if n == 0:
+        raise ValueError("channel arrays must have length >= 1.")
+
+    bpy_mod = _bpy()
+
+    # --- mesh: N verts, X = arange(N) * dt (time) ---
+    mesh = bpy_mod.data.meshes.new(name)
+    mesh.vertices.add(n)
+    co = np.zeros(n * 3, dtype=np.float32)
+    co[0::3] = np.arange(n, dtype=np.float32) * dt
+    mesh.vertices.foreach_set("co", co)
+
+    # --- one FLOAT/POINT attribute per channel ---
+    for attr_name, arr in channels.items():
+        buf = np.ascontiguousarray(arr, dtype=np.float32)
+        attr = mesh.attributes.new(name=attr_name, type="FLOAT", domain="POINT")
+        attr.data.foreach_set("value", buf)
+
+    mesh.update()
+
+    obj = bpy_mod.data.objects.new(name, mesh)
+    bpy_mod.context.scene.collection.objects.link(obj)
+    return obj

--- a/packages/cymatic/blender_script/gn_sampler.py
+++ b/packages/cymatic/blender_script/gn_sampler.py
@@ -1,0 +1,180 @@
+# ABOUTME: In-Blender Geometry Nodes sampler builder (bridge-B, proven in Spike 2)
+# ABOUTME: Reads stored band attributes by scene time and outputs interpolated values
+
+"""Programmatic Geometry Nodes time-sampler for the cymatic visualizer.
+
+This is the in-Blender side of the "mesh-as-data" bridge (approach B), proven
+live on Blender 5.1.2 in Spike 2 (research/spike2_gn_sampling.py, max abs err
+~6e-08). A data-object mesh stores one FLOAT/POINT attribute per channel, laid
+out with X = arange(N) * dt. This module builds a GeometryNodeTree that, at any
+scene time, computes::
+
+    index_f = SceneTime.Seconds / dt
+    i0 = floor(index_f);  i1 = i0 + 1;  frac = index_f - i0
+    v0 = SampleIndex(attr, i0, clamp=True)
+    v1 = SampleIndex(attr, i1, clamp=True)
+    value = Mix(v0, v1, frac)          # linear interpolation between samples
+
+``dt`` is passed in as a parameter (derived host-side from ``times[1]-times[0]``,
+NOT hardcoded) so the same builder works across tracks of different sample rate.
+
+Node group construction uses the Blender 4.0+ interface API
+(``node_group.interface.new_socket(...)``), never the removed
+``node_group.inputs`` / ``node_group.outputs`` collections.
+"""
+
+try:
+    import bpy
+except ImportError:  # running outside Blender (tests, host-side import)
+    bpy = None
+
+
+# Default channels exposed by the sampler, matching the data-object attributes
+# (per-track normalized bands + precomputed beat/peak envelopes).
+DEFAULT_CHANNELS = ("bass_n", "mid_n", "high_n", "beat_env", "peak_env")
+
+
+def band_sample_field(node_group, scene_time, dt, data_obj, attr_name):
+    """Build one time-sampling + linear-interpolation sub-graph for a channel.
+
+    Wires: SceneTime.Seconds -> DIVIDE by ``dt`` -> (FLOOR=i0, ADD 1=i1,
+    SUBTRACT=frac) -> two ``GeometryNodeSampleIndex`` (FLOAT/POINT, clamp=True)
+    reading ``attr_name`` from ``data_obj`` -> ``ShaderNodeMix`` (FLOAT) blending
+    v0/v1 by ``frac``. This is the exact graph verified in Spike 2.
+
+    Args:
+        node_group: the ``GeometryNodeTree`` to add nodes/links into.
+        scene_time: an existing ``GeometryNodeInputSceneTime`` node (shared so a
+            single Scene Time feeds every channel).
+        dt: sample spacing in seconds (``times[1] - times[0]``); a node default,
+            never hardcoded.
+        data_obj: the data-object holding the per-channel FLOAT attributes.
+        attr_name: name of the FLOAT/POINT attribute to sample.
+
+    Returns:
+        The terminal ``ShaderNodeMix`` node; its FLOAT output socket carries the
+        interpolated channel value.
+    """
+    nodes, links = node_group.nodes, node_group.links
+
+    # index_f = Seconds / dt
+    div = nodes.new("ShaderNodeMath")
+    div.operation = "DIVIDE"
+    links.new(scene_time.outputs["Seconds"], div.inputs[0])
+    div.inputs[1].default_value = dt
+
+    # i0 = floor(index_f)
+    floor = nodes.new("ShaderNodeMath")
+    floor.operation = "FLOOR"
+    links.new(div.outputs[0], floor.inputs[0])
+
+    # frac = index_f - i0
+    frac = nodes.new("ShaderNodeMath")
+    frac.operation = "SUBTRACT"
+    links.new(div.outputs[0], frac.inputs[0])
+    links.new(floor.outputs[0], frac.inputs[1])
+
+    # i1 = i0 + 1
+    i1 = nodes.new("ShaderNodeMath")
+    i1.operation = "ADD"
+    i1.inputs[1].default_value = 1.0
+    links.new(floor.outputs[0], i1.inputs[0])
+
+    # data object -> geometry to sample from
+    obj_info = nodes.new("GeometryNodeObjectInfo")
+    obj_info.inputs["Object"].default_value = data_obj
+    obj_info.transform_space = "ORIGINAL"
+
+    # named FLOAT attribute to read
+    named_attr = nodes.new("GeometryNodeInputNamedAttribute")
+    named_attr.data_type = "FLOAT"
+    named_attr.inputs["Name"].default_value = attr_name
+
+    # two clamped FLOAT/POINT samples: v0 @ i0, v1 @ i1
+    sample0 = nodes.new("GeometryNodeSampleIndex")
+    sample0.data_type = "FLOAT"
+    sample0.domain = "POINT"
+    sample0.clamp = True
+    sample1 = nodes.new("GeometryNodeSampleIndex")
+    sample1.data_type = "FLOAT"
+    sample1.domain = "POINT"
+    sample1.clamp = True
+    for sample, index_node in ((sample0, floor), (sample1, i1)):
+        links.new(obj_info.outputs["Geometry"], sample.inputs["Geometry"])
+        links.new(named_attr.outputs["Attribute"], sample.inputs["Value"])
+        links.new(index_node.outputs[0], sample.inputs["Index"])
+
+    # value = mix(v0, v1, frac)  (linear interpolation)
+    mix = nodes.new("ShaderNodeMix")
+    mix.data_type = "FLOAT"
+    links.new(frac.outputs[0], mix.inputs["Factor"])
+    links.new(sample0.outputs[0], mix.inputs[2])  # A = v0
+    links.new(sample1.outputs[0], mix.inputs[3])  # B = v1
+
+    return mix
+
+
+def build_sampler_group(name, dt, data_obj, channels=DEFAULT_CHANNELS):
+    """Build a reusable GN node group sampling each channel by scene time.
+
+    Creates a ``GeometryNodeTree`` with a passthrough Geometry input/output
+    (sockets via the 4.0+ ``interface.new_socket`` API) plus one FLOAT output
+    socket per channel. A single ``GeometryNodeInputSceneTime`` drives a
+    :func:`band_sample_field` sub-graph for every channel; each interpolated
+    value is routed to its named output socket.
+
+    Args:
+        name: node-group name.
+        dt: sample spacing in seconds (from ``times[1] - times[0]``); passed
+            through to each field, never hardcoded.
+        data_obj: data-object holding the FLOAT/POINT channel attributes.
+        channels: iterable of attribute names to expose (defaults to the five
+            visualizer channels).
+
+    Returns:
+        The created ``bpy.types.GeometryNodeTree`` node group.
+    """
+    channels = tuple(channels)
+    if not channels:
+        raise ValueError("build_sampler_group requires at least one channel.")
+
+    # Resolve bpy lazily so a test-injected mock (sys.modules["bpy"]) is honored
+    # even though the module-level import happened before the mock was set up.
+    _bpy = bpy
+    if _bpy is None:
+        import sys
+
+        _bpy = sys.modules.get("bpy")
+    if _bpy is None:
+        raise RuntimeError("build_sampler_group requires Blender (bpy unavailable).")
+
+    node_group = _bpy.data.node_groups.new(name, "GeometryNodeTree")
+
+    # Sockets via the Blender 4.0+ interface API (NOT node_group.inputs/outputs).
+    node_group.interface.new_socket(
+        "Geometry", in_out="INPUT", socket_type="NodeSocketGeometry"
+    )
+    node_group.interface.new_socket(
+        "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+    )
+    for attr_name in channels:
+        node_group.interface.new_socket(
+            attr_name, in_out="OUTPUT", socket_type="NodeSocketFloat"
+        )
+
+    nodes, links = node_group.nodes, node_group.links
+    group_in = nodes.new("NodeGroupInput")
+    group_out = nodes.new("NodeGroupOutput")
+
+    # Single Scene Time feeds every channel's sampler (fps-independent: seconds).
+    scene_time = nodes.new("GeometryNodeInputSceneTime")
+
+    # Passthrough geometry: input -> output socket 0.
+    links.new(group_in.outputs[0], group_out.inputs[0])
+
+    # One interpolated FLOAT per channel, wired to its named output socket.
+    for offset, attr_name in enumerate(channels, start=1):
+        mix = band_sample_field(node_group, scene_time, dt, data_obj, attr_name)
+        links.new(mix.outputs[0], group_out.inputs[offset])
+
+    return node_group

--- a/packages/cymatic/blender_script/presets/__init__.py
+++ b/packages/cymatic/blender_script/presets/__init__.py
@@ -1,0 +1,13 @@
+# ABOUTME: Visual preset package for cymatic (in-Blender, executed via bpy)
+# ABOUTME: Exposes build_preset_scene from the one MVP hybrid preset (hybrid_v1)
+
+"""Visual presets for the cymatic 3D audio visualizer.
+
+MVP ships exactly one preset (``hybrid_v1``): continuous bands drive form,
+beat/peak envelopes drive impulses. Re-exported here as ``build_preset_scene``
+so the orchestrator (``build_scene.py``) can stay preset-agnostic.
+"""
+
+from .hybrid_v1 import build_preset_scene
+
+__all__ = ["build_preset_scene"]

--- a/packages/cymatic/blender_script/presets/hybrid_v1.py
+++ b/packages/cymatic/blender_script/presets/hybrid_v1.py
@@ -1,0 +1,417 @@
+# ABOUTME: hybrid_v1 visual preset — 3 instanced rings (bass/mid/high) + pulsing core
+# ABOUTME: Ported from research/build_visualizer_v2.py (proven on Blender 5.1.2); punch toned down
+
+"""The MVP hybrid visual preset for the cymatic 3D audio visualizer.
+
+Continuous bands -> form; beats/peaks -> impulses. The look is three concentric
+rings of instanced bars (bass / mid / high) whose per-bar height samples the
+band history with a small per-bar time offset (a scrolling "comet tail" of
+energy), plus a central icosphere that pulses on ``beat_env``. Emissive
+materials over a dark world.
+
+Ported from the proven spike ``research/build_visualizer_v2.py`` (built live on
+Blender 5.1.2, sync confirmed). **Deviations from v2, by instruction:**
+
+  - The ring beat-punch in v2 added ``beat_env * 3`` to bar height, which blew
+    out to pure-white frames on every beat. Here the punch is a tasteful
+    ``beat_env * PUNCH_GAIN`` (default ~1.2) scaled by ``accent_intensity``.
+  - Emission strength is lowered so an on-beat reads as a clear pulse, not a
+    white-out (ring strength ~2.0, core strength ~4.0 vs v2's 4.0 / 8.0).
+
+Knobs are exposed via ``PresetParams`` (palette, primitive, accent_intensity,
+decay, tau). ``decay``/``tau`` are precomputed host-side into ``beat_env`` /
+``peak_env`` (Unit 5), so here they are informational; ``accent_intensity``
+scales the live punch and emission.
+
+This module is executed inside Blender; ``bpy`` is resolved lazily so the
+autouse ``mock_bpy`` test fixture (injected into ``sys.modules`` after import)
+is honored.
+"""
+
+import math
+import sys
+
+try:
+    import bpy
+except ImportError:  # running outside Blender (unit tests, host-side import)
+    bpy = None
+
+
+# Per-bar time offset (seconds) feeding the scrolling-history look: bar index i
+# samples band energy at (SceneTime - i * STRIDE). Matches v2's STRIDE.
+STRIDE = 0.045
+# Number of instanced bars per ring (circle vertex count). Matches v2's M.
+BARS_PER_RING = 128
+# Tasteful beat punch gain (v2 used 3.0 on height -> white-out). Toned down.
+PUNCH_GAIN = 1.2
+
+# Ring layout: (object name, band attribute, radius, color-ramp [low, high]).
+_RINGS = (
+    ("viz_bass", "bass_n", 5.0, [(0.0, 0.2, 1.0, 1.0), (0.2, 0.9, 1.0, 1.0)]),
+    ("viz_mid", "mid_n", 6.4, [(0.0, 1.0, 0.4, 1.0), (1.0, 1.0, 0.2, 1.0)]),
+    ("viz_high", "high_n", 7.8, [(1.0, 0.3, 0.6, 1.0), (1.0, 0.9, 0.9, 1.0)]),
+)
+
+# Toned-down emission strengths (v2: rings 4.0, core 8.0).
+_RING_EMISSION = 2.0
+_CORE_EMISSION = 4.0
+
+
+def _bpy():
+    """Resolve the live ``bpy`` (module import or test-injected mock)."""
+    mod = bpy if bpy is not None else sys.modules.get("bpy")
+    if mod is None:
+        raise RuntimeError(
+            "hybrid_v1 requires Blender's bpy module (run inside Blender)."
+        )
+    return mod
+
+
+def _band_history_height(node_group, scene_time, dt, data_obj, attr_name,
+                         punch_gain):
+    """Per-bar scrolling-history sample for one band, plus a toned beat punch.
+
+    Builds the v2 ``band_field`` sub-graph: each instanced bar (by its point
+    Index) samples the band attribute at ``floor((SceneTime - Index*STRIDE)/dt)``
+    so a wave of past energy scrolls outward around the ring. Adds a global
+    ``beat_env(now) * punch_gain`` term (toned down from v2's *3 white-out).
+
+    Returns the terminal math node whose output [0] is the bar height factor.
+    """
+    nodes, links = node_group.nodes, node_group.links
+
+    idx = nodes.new("GeometryNodeInputIndex")
+    offs = nodes.new("ShaderNodeMath")
+    offs.operation = "MULTIPLY"
+    offs.inputs[1].default_value = STRIDE
+    links.new(idx.outputs["Index"], offs.inputs[0])
+
+    tsec = nodes.new("ShaderNodeMath")
+    tsec.operation = "SUBTRACT"
+    links.new(scene_time.outputs["Seconds"], tsec.inputs[0])
+    links.new(offs.outputs[0], tsec.inputs[1])
+
+    sidx = nodes.new("ShaderNodeMath")
+    sidx.operation = "DIVIDE"
+    sidx.inputs[1].default_value = dt
+    links.new(tsec.outputs[0], sidx.inputs[0])
+
+    flo = nodes.new("ShaderNodeMath")
+    flo.operation = "FLOOR"
+    links.new(sidx.outputs[0], flo.inputs[0])
+
+    obj_info = nodes.new("GeometryNodeObjectInfo")
+    obj_info.inputs["Object"].default_value = data_obj
+    obj_info.transform_space = "ORIGINAL"
+
+    named = nodes.new("GeometryNodeInputNamedAttribute")
+    named.data_type = "FLOAT"
+    named.inputs["Name"].default_value = attr_name
+
+    sample = nodes.new("GeometryNodeSampleIndex")
+    sample.data_type = "FLOAT"
+    sample.domain = "POINT"
+    sample.clamp = True
+    links.new(obj_info.outputs["Geometry"], sample.inputs["Geometry"])
+    links.new(named.outputs["Attribute"], sample.inputs["Value"])
+    links.new(flo.outputs[0], sample.inputs["Index"])
+
+    # --- toned-down global beat punch: + beat_env(now) * punch_gain ---
+    sidx0 = nodes.new("ShaderNodeMath")
+    sidx0.operation = "DIVIDE"
+    sidx0.inputs[1].default_value = dt
+    links.new(scene_time.outputs["Seconds"], sidx0.inputs[0])
+
+    flo0 = nodes.new("ShaderNodeMath")
+    flo0.operation = "FLOOR"
+    links.new(sidx0.outputs[0], flo0.inputs[0])
+
+    beat_named = nodes.new("GeometryNodeInputNamedAttribute")
+    beat_named.data_type = "FLOAT"
+    beat_named.inputs["Name"].default_value = "beat_env"
+
+    beat_sample = nodes.new("GeometryNodeSampleIndex")
+    beat_sample.data_type = "FLOAT"
+    beat_sample.domain = "POINT"
+    beat_sample.clamp = True
+    links.new(obj_info.outputs["Geometry"], beat_sample.inputs["Geometry"])
+    links.new(beat_named.outputs["Attribute"], beat_sample.inputs["Value"])
+    links.new(flo0.outputs[0], beat_sample.inputs["Index"])
+
+    punch = nodes.new("ShaderNodeMath")
+    punch.operation = "MULTIPLY"
+    punch.inputs[1].default_value = punch_gain
+    links.new(beat_sample.outputs[0], punch.inputs[0])
+
+    add = nodes.new("ShaderNodeMath")
+    add.operation = "ADD"
+    links.new(sample.outputs[0], add.inputs[0])
+    links.new(punch.outputs[0], add.inputs[1])
+    return add
+
+
+def _emissive_material(name, color, strength):
+    """A simple emission material (toned-down strength)."""
+    b = _bpy()
+    mat = b.data.materials.new(name)
+    mat.use_nodes = True
+    tree = mat.node_tree
+    tree.nodes.clear()
+    out = tree.nodes.new("ShaderNodeOutputMaterial")
+    em = tree.nodes.new("ShaderNodeEmission")
+    em.inputs["Color"].default_value = color
+    em.inputs["Strength"].default_value = strength
+    tree.links.new(em.outputs["Emission"], out.inputs["Surface"])
+    return mat
+
+
+def _ramp_emissive_material(name, ramp_colors, strength):
+    """Emission material whose color ramps by instance Z (bar height)."""
+    b = _bpy()
+    mat = b.data.materials.new(name)
+    mat.use_nodes = True
+    tree = mat.node_tree
+    tree.nodes.clear()
+    out = tree.nodes.new("ShaderNodeOutputMaterial")
+    em = tree.nodes.new("ShaderNodeEmission")
+    geo = tree.nodes.new("ShaderNodeNewGeometry")
+    sep = tree.nodes.new("ShaderNodeSeparateXYZ")
+    mr = tree.nodes.new("ShaderNodeMapRange")
+    mr.inputs["From Min"].default_value = 0.0
+    mr.inputs["From Max"].default_value = 6.0
+    ramp = tree.nodes.new("ShaderNodeValToRGB")
+    elements = ramp.color_ramp.elements
+    elements[0].position = 0.0
+    elements[0].color = ramp_colors[0]
+    elements[1].position = 1.0
+    elements[1].color = ramp_colors[1]
+    tree.links.new(geo.outputs["Position"], sep.inputs["Vector"])
+    tree.links.new(sep.outputs["Z"], mr.inputs["Value"])
+    tree.links.new(mr.outputs["Result"], ramp.inputs["Fac"])
+    tree.links.new(ramp.outputs["Color"], em.inputs["Color"])
+    em.inputs["Strength"].default_value = strength
+    tree.links.new(em.outputs["Emission"], out.inputs["Surface"])
+    return mat
+
+
+def _build_ring(collection, data_obj, dt, name, attr, radius, ramp_colors,
+                punch_gain):
+    """One ring of instanced bars whose height samples a band's history."""
+    b = _bpy()
+    ng = b.data.node_groups.new(name, "GeometryNodeTree")
+    ng.interface.new_socket("Geometry", in_out="INPUT",
+                            socket_type="NodeSocketGeometry")
+    ng.interface.new_socket("Geometry", in_out="OUTPUT",
+                            socket_type="NodeSocketGeometry")
+    nodes, links = ng.nodes, ng.links
+    gout = nodes.new("NodeGroupOutput")
+
+    circ = nodes.new("GeometryNodeMeshCircle")
+    circ.fill_type = "NONE"
+    circ.inputs["Vertices"].default_value = BARS_PER_RING
+    circ.inputs["Radius"].default_value = radius
+
+    cube = nodes.new("GeometryNodeMeshCube")
+    cube.inputs["Size"].default_value = (0.18, 0.18, 1.0)
+
+    iop = nodes.new("GeometryNodeInstanceOnPoints")
+    links.new(circ.outputs["Mesh"], iop.inputs["Points"])
+    links.new(cube.outputs["Mesh"], iop.inputs["Instance"])
+
+    scene_time = nodes.new("GeometryNodeInputSceneTime")
+    height = _band_history_height(ng, scene_time, dt, data_obj, attr, punch_gain)
+
+    hsc = nodes.new("ShaderNodeMath")
+    hsc.operation = "MULTIPLY_ADD"
+    hsc.inputs[1].default_value = 5.0
+    hsc.inputs[2].default_value = 0.1
+    links.new(height.outputs[0], hsc.inputs[0])
+
+    comb = nodes.new("ShaderNodeCombineXYZ")
+    comb.inputs["X"].default_value = 1.0
+    comb.inputs["Y"].default_value = 1.0
+    links.new(hsc.outputs[0], comb.inputs["Z"])
+
+    scl = nodes.new("GeometryNodeScaleInstances")
+    links.new(iop.outputs["Instances"], scl.inputs["Instances"])
+    links.new(comb.outputs[0], scl.inputs["Scale"])
+
+    setm = nodes.new("GeometryNodeSetMaterial")
+    links.new(scl.outputs[0], setm.inputs["Geometry"])
+    mat = _ramp_emissive_material(name + "_m", ramp_colors, _RING_EMISSION)
+    setm.inputs["Material"].default_value = mat
+    links.new(setm.outputs["Geometry"], gout.inputs[0])
+
+    obj = b.data.objects.new(name, b.data.meshes.new(name))
+    collection.objects.link(obj)
+    obj.modifiers.new("gn", "NODES").node_group = ng
+    return obj
+
+
+def _build_core(collection, data_obj, dt, primitive, accent_intensity):
+    """Central primitive pulsing on beat_env (toned-down punch)."""
+    b = _bpy()
+    ng = b.data.node_groups.new("viz_core_gn", "GeometryNodeTree")
+    ng.interface.new_socket("Geometry", in_out="INPUT",
+                            socket_type="NodeSocketGeometry")
+    ng.interface.new_socket("Geometry", in_out="OUTPUT",
+                            socket_type="NodeSocketGeometry")
+    nodes, links = ng.nodes, ng.links
+    gout = nodes.new("NodeGroupOutput")
+
+    if primitive == "cube":
+        prim = nodes.new("GeometryNodeMeshCube")
+        prim.inputs["Size"].default_value = (1.0, 1.0, 1.0)
+    elif primitive == "uvsphere":
+        prim = nodes.new("GeometryNodeMeshUVSphere")
+        prim.inputs["Radius"].default_value = 1.0
+    else:  # default / "icosphere"
+        prim = nodes.new("GeometryNodeMeshIcoSphere")
+        prim.inputs["Radius"].default_value = 1.0
+        prim.inputs["Subdivisions"].default_value = 3
+    prim_out = prim.outputs["Mesh"]
+
+    scene_time = nodes.new("GeometryNodeInputSceneTime")
+    sidx = nodes.new("ShaderNodeMath")
+    sidx.operation = "DIVIDE"
+    sidx.inputs[1].default_value = dt
+    links.new(scene_time.outputs["Seconds"], sidx.inputs[0])
+    flo = nodes.new("ShaderNodeMath")
+    flo.operation = "FLOOR"
+    links.new(sidx.outputs[0], flo.inputs[0])
+
+    obj_info = nodes.new("GeometryNodeObjectInfo")
+    obj_info.inputs["Object"].default_value = data_obj
+    obj_info.transform_space = "ORIGINAL"
+    named = nodes.new("GeometryNodeInputNamedAttribute")
+    named.data_type = "FLOAT"
+    named.inputs["Name"].default_value = "beat_env"
+    sample = nodes.new("GeometryNodeSampleIndex")
+    sample.data_type = "FLOAT"
+    sample.domain = "POINT"
+    sample.clamp = True
+    links.new(obj_info.outputs["Geometry"], sample.inputs["Geometry"])
+    links.new(named.outputs["Attribute"], sample.inputs["Value"])
+    links.new(flo.outputs[0], sample.inputs["Index"])
+
+    # scale = 0.5 + beat_env * (1.0 + accent_intensity)  (v2 used *3 -> over-pulse)
+    scale = nodes.new("ShaderNodeMath")
+    scale.operation = "MULTIPLY_ADD"
+    scale.inputs[1].default_value = 1.0 + accent_intensity
+    scale.inputs[2].default_value = 0.5
+    links.new(sample.outputs[0], scale.inputs[0])
+
+    cmb = nodes.new("ShaderNodeCombineXYZ")
+    links.new(scale.outputs[0], cmb.inputs["X"])
+    links.new(scale.outputs[0], cmb.inputs["Y"])
+    links.new(scale.outputs[0], cmb.inputs["Z"])
+
+    tr = nodes.new("GeometryNodeTransform")
+    links.new(prim_out, tr.inputs["Geometry"])
+    links.new(cmb.outputs[0], tr.inputs["Scale"])
+
+    setm = nodes.new("GeometryNodeSetMaterial")
+    links.new(tr.outputs[0], setm.inputs["Geometry"])
+    mat = _emissive_material("core_m", (1.0, 0.5, 0.05, 1.0), _CORE_EMISSION)
+    setm.inputs["Material"].default_value = mat
+    links.new(setm.outputs[0], gout.inputs[0])
+
+    obj = b.data.objects.new("viz_core", b.data.meshes.new("viz_core"))
+    collection.objects.link(obj)
+    obj.modifiers.new("gn", "NODES").node_group = ng
+    return obj
+
+
+def _setup_world_and_render(scene, fps, resolution):
+    """Dark world + EEVEE render settings (1280x720 default, fps from config)."""
+    b = _bpy()
+    width, height = (resolution if resolution else (1280, 720))
+    scene.render.resolution_x = width
+    scene.render.resolution_y = height
+    scene.render.fps = fps
+
+    try:
+        scene.render.engine = "BLENDER_EEVEE_NEXT"
+    except (TypeError, ValueError):  # older Blender lacks EEVEE Next id
+        scene.render.engine = "BLENDER_EEVEE"
+
+    world = b.data.worlds.get("cymatic_world") or b.data.worlds.new("cymatic_world")
+    world.use_nodes = True
+    bg = world.node_tree.nodes.get("Background")
+    if bg is not None:
+        bg.inputs[0].default_value = (0.01, 0.01, 0.02, 1.0)
+        bg.inputs[1].default_value = 0.25
+    scene.world = world
+
+
+def _setup_camera_and_sun(collection, scene):
+    """Place the camera and a single sun (lifted from v2)."""
+    b = _bpy()
+    cam_data = b.data.cameras.new("viz_cam")
+    cam = b.data.objects.new("viz_cam", cam_data)
+    collection.objects.link(cam)
+    cam.location = (0, -17, 12)
+    cam.rotation_euler = (math.radians(57), 0, 0)
+    scene.camera = cam
+
+    sun_data = b.data.lights.new("viz_sun", "SUN")
+    sun_data.energy = 1.2
+    sun = b.data.objects.new("viz_sun", sun_data)
+    collection.objects.link(sun)
+    sun.rotation_euler = (math.radians(50), 0, 0.6)
+    return cam, sun
+
+
+def build_preset_scene(analysis, data_obj, sampler_group, preset_params,
+                       fps=30, resolution=None):
+    """Assemble the hybrid_v1 scene: rings + core + camera + sun + world + render.
+
+    Args:
+        analysis: the loaded ``AnalysisData`` (Unit 5) — supplies ``dt`` and
+            ``duration`` for frame range.
+        data_obj: the data-object mesh (Unit 6) holding the channel attributes.
+        sampler_group: the GN sampler node group (Unit 7). Built and passed in
+            by the orchestrator so the preset does not reinvent the sampler;
+            kept available for reuse/composition (the rings build their own
+            per-bar history sub-graph, the core reuses current-time sampling).
+        preset_params: ``PresetParams`` (palette/primitive/accent_intensity/
+            decay/tau). ``accent_intensity`` scales the beat punch + core pulse.
+        fps: render fps (from ``VisualizerConfig``, NOT the analysis).
+        resolution: ``(w, h)`` or ``None`` -> 1280x720.
+
+    Returns:
+        The Blender scene object that was configured.
+    """
+    b = _bpy()
+    scene = b.context.scene
+    dt = float(analysis.dt)
+
+    # accent_intensity (0..1-ish) scales the toned punch around its default.
+    accent = getattr(preset_params, "accent_intensity", 0.5) if preset_params else 0.5
+    primitive = getattr(preset_params, "primitive", "icosphere") if preset_params else "icosphere"
+    punch_gain = PUNCH_GAIN * (0.5 + accent)
+
+    # Fresh collection (idempotent: clear a previous run's objects).
+    existing = b.data.collections.get("cymatic_viz")
+    if existing is not None:
+        for obj in list(existing.objects):
+            b.data.objects.remove(obj, do_unlink=True)
+        b.data.collections.remove(existing)
+    collection = b.data.collections.new("cymatic_viz")
+    scene.collection.children.link(collection)
+
+    # Hide the raw data-object from the render/viewport (it is data, not geometry).
+    data_obj.hide_render = True
+    data_obj.hide_viewport = True
+
+    for name, attr, radius, ramp_colors in _RINGS:
+        _build_ring(collection, data_obj, dt, name, attr, radius, ramp_colors,
+                    punch_gain)
+    _build_core(collection, data_obj, dt, primitive, accent)
+
+    _setup_camera_and_sun(collection, scene)
+    _setup_world_and_render(scene, fps, resolution)
+
+    scene.frame_start = 1
+    scene.frame_end = max(1, int(float(analysis.duration) * fps))
+    return scene

--- a/packages/cymatic/pyproject.toml
+++ b/packages/cymatic/pyproject.toml
@@ -45,6 +45,9 @@ testpaths = ["tests"]
 addopts = [
     "--strict-markers",
     "--strict-config",
+    "--cov=cymatic",
+    "--cov-report=term-missing",
+    "--cov-fail-under=80",
 ]
 markers = [
     "unit: Unit tests",

--- a/packages/cymatic/pyproject.toml
+++ b/packages/cymatic/pyproject.toml
@@ -1,0 +1,87 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cymatic"
+version = "0.1.0"
+description = "3D audio visualizer (Geometry Nodes) driven by beatrix analysis"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [
+    {name = "Your Name", email = "your.email@example.com"},
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "setka-common",
+    "beatrix",
+]
+
+[dependency-groups]
+dev = [
+    "pre-commit>=4.2.0",
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+]
+
+[project.scripts]
+cymatic-render = "cymatic.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cymatic"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+addopts = [
+    "--strict-markers",
+    "--strict-config",
+]
+markers = [
+    "unit: Unit tests",
+    "integration: Integration tests",
+    "slow: Slow tests",
+]
+
+[tool.coverage.run]
+source = ["src"]
+omit = ["*/tests/*", "*/__init__.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W"]
+ignore = ["E501", "E402", "N801", "N802", "F401", "F405", "F821", "N803", "N806", "E722"]
+
+[tool.ruff.lint.per-file-ignores]
+"blender_script/**/*.py" = ["ALL"]
+"tests/**/*.py" = ["N803", "N806", "E722"]
+
+[tool.black]
+line-length = 88
+target-version = ['py310']
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/packages/cymatic/src/cymatic/__init__.py
+++ b/packages/cymatic/src/cymatic/__init__.py
@@ -1,13 +1,17 @@
 # ABOUTME: cymatic package — 3D audio visualizer (Geometry Nodes) host-side API
 # ABOUTME: Generates a procedural 3D scene from beatrix analysis, rendered to mp4
 
-"""cymatic — procedural 3D audio visualizer driven by beatrix analysis."""
+"""cymatic — procedural 3D audio visualizer driven by beatrix analysis.
 
-from cymatic.analysis_loader import AnalysisData, load_analysis
+The public API is exposed lazily via module ``__getattr__`` (PEP 562). Only
+``config`` is eager-imported because it is pure (dataclasses + json). The other
+symbols are resolved on first access so that ``import cymatic`` stays light —
+critically, it must NOT eagerly pull ``runner`` -> ``setka_common`` -> PyYAML,
+since ``build_scene.py`` imports ``cymatic.*`` inside headless Blender whose
+bundled python lacks PyYAML.
+"""
+
 from cymatic.config import PresetParams, VisualizerConfig
-from cymatic.normalization import normalize_band, precompute_envelope
-from cymatic.runner import CymaticRunner, render
-from cymatic.sync_verification import SyncReport, verify_sync
 
 __all__ = [
     "VisualizerConfig",
@@ -23,3 +27,25 @@ __all__ = [
 ]
 
 __version__ = "0.1.0"
+
+# Map lazily-exposed names to their defining submodule.
+_LAZY = {
+    "AnalysisData": "cymatic.analysis_loader",
+    "load_analysis": "cymatic.analysis_loader",
+    "normalize_band": "cymatic.normalization",
+    "precompute_envelope": "cymatic.normalization",
+    "CymaticRunner": "cymatic.runner",
+    "render": "cymatic.runner",
+    "SyncReport": "cymatic.sync_verification",
+    "verify_sync": "cymatic.sync_verification",
+}
+
+
+def __getattr__(name):
+    """PEP 562 lazy attribute resolution for the public API."""
+    module_path = _LAZY.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    return getattr(importlib.import_module(module_path), name)

--- a/packages/cymatic/src/cymatic/__init__.py
+++ b/packages/cymatic/src/cymatic/__init__.py
@@ -1,0 +1,25 @@
+# ABOUTME: cymatic package — 3D audio visualizer (Geometry Nodes) host-side API
+# ABOUTME: Generates a procedural 3D scene from beatrix analysis, rendered to mp4
+
+"""cymatic — procedural 3D audio visualizer driven by beatrix analysis."""
+
+from cymatic.analysis_loader import AnalysisData, load_analysis
+from cymatic.config import PresetParams, VisualizerConfig
+from cymatic.normalization import normalize_band, precompute_envelope
+from cymatic.runner import CymaticRunner, render
+from cymatic.sync_verification import SyncReport, verify_sync
+
+__all__ = [
+    "VisualizerConfig",
+    "PresetParams",
+    "AnalysisData",
+    "load_analysis",
+    "normalize_band",
+    "precompute_envelope",
+    "CymaticRunner",
+    "render",
+    "SyncReport",
+    "verify_sync",
+]
+
+__version__ = "0.1.0"

--- a/packages/cymatic/src/cymatic/analysis_loader.py
+++ b/packages/cymatic/src/cymatic/analysis_loader.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -52,11 +52,18 @@ _BEAT_DECAY = 0.13
 _PEAK_DECAY = 0.25
 
 
-@dataclass
+# eq=False: this dataclass holds np.ndarray fields, and the auto-generated
+# __eq__ would do `arr == arr` -> an array, which raises when truthy-tested.
+@dataclass(eq=False)
 class AnalysisData:
     """Structured, GN-ready result of loading + normalizing an analysis file.
 
     All arrays are ``float32`` and equal length (== ``len(times)``).
+
+    ``raw_beat_times`` / ``raw_peak_times`` are the ORIGINAL event timestamps
+    (seconds) straight from the analysis JSON — kept as the ground truth the
+    sync-verification harness compares against (so a wrong envelope index
+    produces a real, nonzero deviation rather than a tautology).
     """
 
     bass: np.ndarray
@@ -69,6 +76,8 @@ class AnalysisData:
     sample_rate: int
     duration: float
     fps: int
+    raw_beat_times: list[float] = field(default_factory=list)
+    raw_peak_times: list[float] = field(default_factory=list)
     audio_file: Optional[Path] = None
 
 
@@ -115,8 +124,13 @@ def load_analysis(config: VisualizerConfig) -> AnalysisData:
 
     data = json.loads(path.read_text())
 
-    fb = data["frequency_bands"]
-    times = np.asarray(fb["times"], dtype=float)
+    # Required-key access is wrapped so a malformed analysis file fails with a
+    # clear, path-carrying ValueError instead of a bare KeyError.
+    try:
+        fb = data["frequency_bands"]
+        times = np.asarray(fb["times"], dtype=float)
+    except KeyError as exc:
+        raise ValueError(f"Analysis file missing required key {exc}: {path}")
 
     if len(times) < 2:
         raise ValueError(
@@ -125,8 +139,14 @@ def load_analysis(config: VisualizerConfig) -> AnalysisData:
         )
 
     dt = float(times[1] - times[0])
-    sample_rate = int(data["sample_rate"])
-    duration = float(data["duration"])
+    try:
+        sample_rate = int(data["sample_rate"])
+        duration = float(data["duration"])
+        bass_raw = fb["bass_energy"]
+        mid_raw = fb["mid_energy"]
+        high_raw = fb["high_energy"]
+    except KeyError as exc:
+        raise ValueError(f"Analysis file missing required key {exc}: {path}")
 
     # Sanity: dt should match hop_length / sample_rate (advisory log only).
     expected_dt = HOP_LENGTH / sample_rate
@@ -138,15 +158,20 @@ def load_analysis(config: VisualizerConfig) -> AnalysisData:
             sample_rate,
         )
 
-    bass = normalize_band(fb["bass_energy"])
-    mid = normalize_band(fb["mid_energy"])
-    high = normalize_band(fb["high_energy"])
+    bass = normalize_band(bass_raw)
+    mid = normalize_band(mid_raw)
+    high = normalize_band(high_raw)
+
+    # Preset can override the envelope decays (PresetParams validates > 0);
+    # otherwise fall back to the module defaults.
+    beat_decay = config.preset.decay if config.preset is not None else _BEAT_DECAY
+    peak_decay = config.preset.tau if config.preset is not None else _PEAK_DECAY
 
     ae = data.get("animation_events", {})
-    beat_env = precompute_envelope(ae.get("beats", []), times, decay=_BEAT_DECAY)
-    peak_env = precompute_envelope(
-        ae.get("energy_peaks", []), times, decay=_PEAK_DECAY
-    )
+    raw_beat_times = [float(t) for t in ae.get("beats", [])]
+    raw_peak_times = [float(t) for t in ae.get("energy_peaks", [])]
+    beat_env = precompute_envelope(raw_beat_times, times, decay=beat_decay)
+    peak_env = precompute_envelope(raw_peak_times, times, decay=peak_decay)
 
     audio_file = _resolve_audio(config)
 
@@ -161,5 +186,7 @@ def load_analysis(config: VisualizerConfig) -> AnalysisData:
         sample_rate=sample_rate,
         duration=duration,
         fps=config.fps,
+        raw_beat_times=raw_beat_times,
+        raw_peak_times=raw_peak_times,
         audio_file=audio_file,
     )

--- a/packages/cymatic/src/cymatic/analysis_loader.py
+++ b/packages/cymatic/src/cymatic/analysis_loader.py
@@ -81,6 +81,30 @@ class AnalysisData:
     audio_file: Optional[Path] = None
 
 
+def _finite_times(raw, label: str, path: Path) -> list[float]:
+    """Coerce event times to float and drop non-finite (NaN/inf) values.
+
+    A corrupt analysis with a NaN/inf timestamp would otherwise crash downstream
+    at ``int(round(t/dt))``. Dropped values are logged once with a count.
+    """
+    out: list[float] = []
+    dropped = 0
+    for t in raw:
+        f = float(t)
+        if np.isfinite(f):
+            out.append(f)
+        else:
+            dropped += 1
+    if dropped:
+        logger.warning(
+            "analysis_loader: dropped %d non-finite %s time(s): %s",
+            dropped,
+            label,
+            path,
+        )
+    return out
+
+
 def _resolve_audio(config: VisualizerConfig) -> Optional[Path]:
     """Best-effort audio selection via AudioValidator from ``extracted/``.
 
@@ -168,8 +192,12 @@ def load_analysis(config: VisualizerConfig) -> AnalysisData:
     peak_decay = config.preset.tau if config.preset is not None else _PEAK_DECAY
 
     ae = data.get("animation_events", {})
-    raw_beat_times = [float(t) for t in ae.get("beats", [])]
-    raw_peak_times = [float(t) for t in ae.get("energy_peaks", [])]
+    # Drop non-finite event times (NaN/inf from a corrupt analysis) before they
+    # reach precompute_envelope / verify_sync, where int(round(nan/dt)) would
+    # raise "cannot convert float NaN to integer". Mirrors the NaN coercion in
+    # normalize_band: a single bad sample must not crash the whole load.
+    raw_beat_times = _finite_times(ae.get("beats", []), "beats", path)
+    raw_peak_times = _finite_times(ae.get("energy_peaks", []), "energy_peaks", path)
     beat_env = precompute_envelope(raw_beat_times, times, decay=beat_decay)
     peak_env = precompute_envelope(raw_peak_times, times, decay=peak_decay)
 

--- a/packages/cymatic/src/cymatic/analysis_loader.py
+++ b/packages/cymatic/src/cymatic/analysis_loader.py
@@ -1,0 +1,159 @@
+# ABOUTME: Host-side loader for beatrix *_analysis.json -> normalized arrays + dt
+# ABOUTME: Derives dt from times[] per-track (R3), fps from config (beatrix has none).
+
+"""Load a beatrix ``*_analysis.json`` and produce GN-ready data.
+
+The analysis path comes **directly from** ``VisualizerConfig.analysis_file`` —
+NOT from ``RecordingStructureManager.get_analysis_file_path()`` (that takes a
+video path and derives a stem, which is the wrong input shape for cymatic).
+
+``dt`` is derived from the analysis grid (``dt = times[1] - times[0]``), which
+equals ``hop_length / sample_rate`` and is therefore per-track — never
+hardcoded (R3). A guard raises a clear ``ValueError`` when ``len(times) < 2``
+so a degenerate analysis fails loudly instead of raising a raw ``IndexError``.
+
+``fps`` is read from ``VisualizerConfig.fps`` because beatrix does not emit an
+fps field (it returns only ``duration``, ``sample_rate``, ``tempo``,
+``animation_events``, ``frequency_bands``).
+
+Audio selection reuses ``beatrix.core.audio_validator.AudioValidator`` when an
+``extracted/`` directory can be resolved from ``base_directory``; otherwise the
+loader works from the analysis file alone (the audio path is advisory metadata
+here — the analysis JSON is the data source).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from beatrix.core.audio_validator import AudioValidator
+
+from .config import VisualizerConfig
+from .normalization import normalize_band, precompute_envelope
+
+logger = logging.getLogger(__name__)
+
+# beatrix uses librosa hop_length=512; dt == hop_length / sample_rate.
+HOP_LENGTH = 512
+
+# Default envelope decay windows (seconds). Beats are denser/snappier than
+# energy peaks. PresetParams.decay/tau can override per preset later.
+_BEAT_DECAY = 0.13
+_PEAK_DECAY = 0.25
+
+
+@dataclass
+class AnalysisData:
+    """Structured, GN-ready result of loading + normalizing an analysis file.
+
+    All arrays are ``float32`` and equal length (== ``len(times)``).
+    """
+
+    bass: np.ndarray
+    mid: np.ndarray
+    high: np.ndarray
+    beat_env: np.ndarray
+    peak_env: np.ndarray
+    times: np.ndarray
+    dt: float
+    sample_rate: int
+    duration: float
+    fps: int
+    audio_file: Optional[Path] = None
+
+
+def _resolve_audio(config: VisualizerConfig) -> Optional[Path]:
+    """Best-effort audio selection via AudioValidator from ``extracted/``.
+
+    Returns the detected audio path when an ``extracted/`` dir is resolvable,
+    otherwise ``None`` (analysis-only path). Never fatal for loading — the
+    analysis JSON, not the audio, is the data source here.
+    """
+    if not config.base_directory:
+        return None
+    extracted_dir = Path(config.base_directory) / "extracted"
+    if not extracted_dir.exists():
+        return None
+    try:
+        return AudioValidator().detect_main_audio(extracted_dir)
+    except Exception as exc:  # noqa: BLE001 — advisory only, don't fail the load
+        logger.debug("Audio detection skipped: %s", exc)
+        return None
+
+
+def load_analysis(config: VisualizerConfig) -> AnalysisData:
+    """Load and normalize a beatrix analysis into GN-ready arrays.
+
+    Args:
+        config: Visualizer config; ``analysis_file`` is the JSON path,
+            ``fps`` supplies the render fps (beatrix has no fps),
+            ``base_directory`` is used for optional audio resolution.
+
+    Returns:
+        ``AnalysisData`` with normalized bass/mid/high, precomputed
+        beat_env/peak_env, the time grid, dt, sample_rate, duration, fps.
+
+    Raises:
+        FileNotFoundError: When ``analysis_file`` does not exist.
+        ValueError: When ``len(times) < 2`` (dt cannot be derived).
+    """
+    path = Path(config.analysis_file)
+    if not path.exists():
+        raise FileNotFoundError(f"Analysis file not found: {path}")
+
+    data = json.loads(path.read_text())
+
+    fb = data["frequency_bands"]
+    times = np.asarray(fb["times"], dtype=float)
+
+    if len(times) < 2:
+        raise ValueError(
+            f"Analysis 'times' has {len(times)} sample(s); need >= 2 to derive "
+            f"dt = times[1] - times[0]. File: {path}"
+        )
+
+    dt = float(times[1] - times[0])
+    sample_rate = int(data["sample_rate"])
+    duration = float(data["duration"])
+
+    # Sanity: dt should match hop_length / sample_rate (advisory log only).
+    expected_dt = HOP_LENGTH / sample_rate
+    if not np.isclose(dt, expected_dt, atol=1e-4):
+        logger.warning(
+            "dt=%.6f from times[] differs from hop/sr=%.6f (sr=%d)",
+            dt,
+            expected_dt,
+            sample_rate,
+        )
+
+    bass = normalize_band(fb["bass_energy"])
+    mid = normalize_band(fb["mid_energy"])
+    high = normalize_band(fb["high_energy"])
+
+    ae = data.get("animation_events", {})
+    beat_env = precompute_envelope(ae.get("beats", []), times, decay=_BEAT_DECAY)
+    peak_env = precompute_envelope(
+        ae.get("energy_peaks", []), times, decay=_PEAK_DECAY
+    )
+
+    audio_file = _resolve_audio(config)
+
+    return AnalysisData(
+        bass=bass,
+        mid=mid,
+        high=high,
+        beat_env=beat_env,
+        peak_env=peak_env,
+        times=times,
+        dt=dt,
+        sample_rate=sample_rate,
+        duration=duration,
+        fps=config.fps,
+        audio_file=audio_file,
+    )

--- a/packages/cymatic/src/cymatic/analysis_loader.py
+++ b/packages/cymatic/src/cymatic/analysis_loader.py
@@ -32,10 +32,14 @@ from typing import Optional
 
 import numpy as np
 
-from beatrix.core.audio_validator import AudioValidator
-
 from .config import VisualizerConfig
 from .normalization import normalize_band, precompute_envelope
+
+# NOTE: beatrix.core.audio_validator is imported LAZILY inside _resolve_audio.
+# Audio detection is advisory; the analysis JSON is the data source. A top-level
+# import would pull beatrix -> setka_common -> PyYAML, which the bundled python
+# in headless Blender lacks (build_scene runs there). Lazy import keeps the
+# in-Blender path clean while host-side behavior is unchanged.
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +85,8 @@ def _resolve_audio(config: VisualizerConfig) -> Optional[Path]:
     if not extracted_dir.exists():
         return None
     try:
+        from beatrix.core.audio_validator import AudioValidator  # lazy: see module note
+
         return AudioValidator().detect_main_audio(extracted_dir)
     except Exception as exc:  # noqa: BLE001 — advisory only, don't fail the load
         logger.debug("Audio detection skipped: %s", exc)

--- a/packages/cymatic/src/cymatic/cli.py
+++ b/packages/cymatic/src/cymatic/cli.py
@@ -5,7 +5,7 @@
 
 Usage:
     cymatic-render <recording_dir> [--main-audio NAME] [--analysis-file PATH]
-                   [--fps N] [--blender-executable PATH]
+                   [--audio-file PATH] [--fps N] [--blender-executable PATH]
 
 Resolves the beatrix ``*_analysis.json`` (explicit ``--analysis-file`` or, when
 omitted, via ``AudioValidator.detect_main_audio`` on ``<recording_dir>/extracted``
@@ -22,18 +22,34 @@ import argparse
 import sys
 from pathlib import Path
 
+from beatrix.exceptions import MultipleAudioFilesError, NoAudioFileError
 from setka_common.file_structure.specialized import RecordingStructureManager
 
 from cymatic.config import DEFAULT_BLENDER_EXECUTABLE, VisualizerConfig
 from cymatic.runner import render
 
 
+def _detect_audio(recording_dir: Path, main_audio: str | None) -> Path:
+    """Detect the main audio file in ``<recording_dir>/extracted``.
+
+    AudioValidator takes the extracted/ dir, NOT the recording root.
+
+    Raises:
+        NoAudioFileError / MultipleAudioFilesError: from beatrix validation.
+    """
+    from beatrix.core.audio_validator import AudioValidator
+
+    extracted_dir = recording_dir / RecordingStructureManager.EXTRACTED_DIRNAME
+    validator = AudioValidator()
+    return validator.detect_main_audio(extracted_dir, specified_audio=main_audio)
+
+
 def _resolve_analysis_file(
     recording_dir: Path,
     analysis_file: str | None,
     main_audio: str | None,
-) -> Path:
-    """Resolve the analysis JSON path for a recording directory.
+) -> tuple[Path, Path | None]:
+    """Resolve the analysis JSON path (and detected audio) for a recording dir.
 
     Args:
         recording_dir: Recording base directory.
@@ -41,7 +57,8 @@ def _resolve_analysis_file(
         main_audio: Optional main-audio filename hint for detection.
 
     Returns:
-        Path to the ``*_analysis.json`` file.
+        ``(analysis_path, audio_path_or_None)``. The audio path is ``None`` when
+        an explicit ``--analysis-file`` was given (no detection performed).
 
     Raises:
         FileNotFoundError: If the resolved analysis file does not exist.
@@ -50,25 +67,22 @@ def _resolve_analysis_file(
         path = Path(analysis_file)
         if not path.exists():
             raise FileNotFoundError(f"Analysis file not found: {path}")
-        return path
+        return path, None
 
     # Detect the main audio in extracted/ and derive its analysis path.
-    # AudioValidator takes the extracted/ dir, NOT the recording root.
-    from beatrix.core.audio_validator import AudioValidator
-
-    extracted_dir = recording_dir / RecordingStructureManager.EXTRACTED_DIRNAME
-    validator = AudioValidator()
-    audio_path = validator.detect_main_audio(extracted_dir, specified_audio=main_audio)
+    audio_path = _detect_audio(recording_dir, main_audio)
 
     analysis_path = (
-        recording_dir / "analysis" / f"{Path(audio_path).stem}_analysis.json"
+        recording_dir
+        / RecordingStructureManager.ANALYSIS_DIRNAME
+        / f"{Path(audio_path).stem}_analysis.json"
     )
     if not analysis_path.exists():
         raise FileNotFoundError(
             f"Analysis file not found: {analysis_path}. "
             "Run beatrix to generate the analysis first."
         )
-    return analysis_path
+    return analysis_path, Path(audio_path)
 
 
 def main(argv=None) -> int:
@@ -96,6 +110,11 @@ def main(argv=None) -> int:
         help="Explicit path to the beatrix *_analysis.json (overrides detection)",
     )
     parser.add_argument(
+        "--audio-file",
+        default=None,
+        help="Audio file to mux into the render (overrides auto-detection)",
+    )
+    parser.add_argument(
         "--fps", type=int, default=30, help="Render fps (default: 30)"
     )
     parser.add_argument(
@@ -108,18 +127,35 @@ def main(argv=None) -> int:
 
     recording_dir = Path(args.recording_dir)
     if not recording_dir.is_dir():
-        print(f"cymatic-render: recording directory not found: {recording_dir}")
+        print(
+            f"cymatic-render: recording directory not found: {recording_dir}",
+            file=sys.stderr,
+        )
         return 1
 
     try:
-        analysis_file = _resolve_analysis_file(
+        analysis_file, detected_audio = _resolve_analysis_file(
             recording_dir, args.analysis_file, args.main_audio
         )
-    except Exception as exc:
+    except (
+        FileNotFoundError,
+        NoAudioFileError,
+        MultipleAudioFilesError,
+        ValueError,
+    ) as exc:
         # Surfaces FileNotFoundError plus beatrix audio-validation errors
         # (NoAudioFileError / MultipleAudioFilesError, Polish messages).
-        print(f"cymatic-render: {exc}")
+        print(f"cymatic-render: {exc}", file=sys.stderr)
         return 1
+
+    # Forward audio so renders aren't silent: explicit --audio-file wins,
+    # otherwise the auto-detected main audio (if any).
+    if args.audio_file:
+        audio_file = args.audio_file
+    elif detected_audio is not None:
+        audio_file = str(detected_audio)
+    else:
+        audio_file = None
 
     config = VisualizerConfig(
         analysis_file=str(analysis_file),
@@ -127,12 +163,13 @@ def main(argv=None) -> int:
         base_directory=str(recording_dir),
         fps=args.fps,
         blender_executable=args.blender_executable,
+        audio_file=audio_file,
     )
 
     try:
         output = render(config)
-    except RuntimeError as exc:
-        print(f"cymatic-render: {exc}")
+    except (RuntimeError, FileNotFoundError, ValueError) as exc:
+        print(f"cymatic-render: {exc}", file=sys.stderr)
         return 1
 
     print(f"cymatic-render: output -> {output}")

--- a/packages/cymatic/src/cymatic/cli.py
+++ b/packages/cymatic/src/cymatic/cli.py
@@ -1,0 +1,143 @@
+# ABOUTME: CLI entry point for cymatic (cymatic-render).
+# ABOUTME: Builds a VisualizerConfig from a recording dir and drives the runner.
+
+"""Command-line interface for cymatic.
+
+Usage:
+    cymatic-render <recording_dir> [--main-audio NAME] [--analysis-file PATH]
+                   [--fps N] [--blender-executable PATH]
+
+Resolves the beatrix ``*_analysis.json`` (explicit ``--analysis-file`` or, when
+omitted, via ``AudioValidator.detect_main_audio`` on ``<recording_dir>/extracted``
+to pick the main audio and derive ``analysis/<stem>_analysis.json``), builds a
+:class:`VisualizerConfig`, and calls the host-side runner.
+
+The runner resolves the output path under ``blender/render/`` itself, so
+``output_mp4`` is left empty here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from setka_common.file_structure.specialized import RecordingStructureManager
+
+from cymatic.config import DEFAULT_BLENDER_EXECUTABLE, VisualizerConfig
+from cymatic.runner import render
+
+
+def _resolve_analysis_file(
+    recording_dir: Path,
+    analysis_file: str | None,
+    main_audio: str | None,
+) -> Path:
+    """Resolve the analysis JSON path for a recording directory.
+
+    Args:
+        recording_dir: Recording base directory.
+        analysis_file: Explicit analysis JSON path (takes precedence).
+        main_audio: Optional main-audio filename hint for detection.
+
+    Returns:
+        Path to the ``*_analysis.json`` file.
+
+    Raises:
+        FileNotFoundError: If the resolved analysis file does not exist.
+    """
+    if analysis_file:
+        path = Path(analysis_file)
+        if not path.exists():
+            raise FileNotFoundError(f"Analysis file not found: {path}")
+        return path
+
+    # Detect the main audio in extracted/ and derive its analysis path.
+    # AudioValidator takes the extracted/ dir, NOT the recording root.
+    from beatrix.core.audio_validator import AudioValidator
+
+    extracted_dir = recording_dir / RecordingStructureManager.EXTRACTED_DIRNAME
+    validator = AudioValidator()
+    audio_path = validator.detect_main_audio(extracted_dir, specified_audio=main_audio)
+
+    analysis_path = (
+        recording_dir / "analysis" / f"{Path(audio_path).stem}_analysis.json"
+    )
+    if not analysis_path.exists():
+        raise FileNotFoundError(
+            f"Analysis file not found: {analysis_path}. "
+            "Run beatrix to generate the analysis first."
+        )
+    return analysis_path
+
+
+def main(argv=None) -> int:
+    """Entry point for the ``cymatic-render`` script.
+
+    Returns:
+        int: process exit code (0 on success, non-zero on error).
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        prog="cymatic-render",
+        description="Render a 3D audio visualizer from a beatrix analysis.",
+    )
+    parser.add_argument("recording_dir", help="Path to the recording directory")
+    parser.add_argument(
+        "--main-audio",
+        default=None,
+        help="Main audio filename in extracted/ (when analysis file is auto-detected)",
+    )
+    parser.add_argument(
+        "--analysis-file",
+        default=None,
+        help="Explicit path to the beatrix *_analysis.json (overrides detection)",
+    )
+    parser.add_argument(
+        "--fps", type=int, default=30, help="Render fps (default: 30)"
+    )
+    parser.add_argument(
+        "--blender-executable",
+        default=DEFAULT_BLENDER_EXECUTABLE,
+        help="Path to the Blender executable",
+    )
+
+    args = parser.parse_args(argv)
+
+    recording_dir = Path(args.recording_dir)
+    if not recording_dir.is_dir():
+        print(f"cymatic-render: recording directory not found: {recording_dir}")
+        return 1
+
+    try:
+        analysis_file = _resolve_analysis_file(
+            recording_dir, args.analysis_file, args.main_audio
+        )
+    except Exception as exc:
+        # Surfaces FileNotFoundError plus beatrix audio-validation errors
+        # (NoAudioFileError / MultipleAudioFilesError, Polish messages).
+        print(f"cymatic-render: {exc}")
+        return 1
+
+    config = VisualizerConfig(
+        analysis_file=str(analysis_file),
+        output_mp4="",  # runner resolves the path under blender/render/
+        base_directory=str(recording_dir),
+        fps=args.fps,
+        blender_executable=args.blender_executable,
+    )
+
+    try:
+        output = render(config)
+    except RuntimeError as exc:
+        print(f"cymatic-render: {exc}")
+        return 1
+
+    print(f"cymatic-render: output -> {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/cymatic/src/cymatic/config.py
+++ b/packages/cymatic/src/cymatic/config.py
@@ -1,0 +1,127 @@
+# ABOUTME: Config dataclasses for the cymatic 3D audio visualizer (host-side)
+# ABOUTME: VisualizerConfig + PresetParams with lossless JSON/dict serialization
+
+"""Configuration dataclasses for cymatic.
+
+The serialized ``VisualizerConfig`` is what the host-side runner writes to a
+temporary file (via ``tempfile.NamedTemporaryFile``) and passes to the
+in-Blender ``build_scene.py`` through ``--config``.
+
+Notes:
+- ``fps`` lives here (beatrix does NOT emit fps) — the build script sets
+  ``scene.render.fps`` from this value, kept in sync with the harness.
+- ``n_tolerance_frames`` deliberately does NOT live here — it is an internal
+  constant of the sync-verification harness (Unit 10), not a config surface.
+- Serialization must round-trip losslessly: ``resolution`` survives as a tuple
+  even though JSON stores it as a list.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+DEFAULT_BLENDER_EXECUTABLE = "/Applications/Blender.app/Contents/MacOS/Blender"
+
+
+@dataclass
+class PresetParams:
+    """Visual preset parameters (the "look", codified for reproducibility).
+
+    The autoring loop (Unit 11 / Phase C) may only manipulate parameters
+    expressible here — otherwise INV2 (deterministic reproduction from
+    builder + params + analysis) does not hold.
+    """
+
+    palette: str = "default"
+    primitive: str = "icosphere"
+    accent_intensity: float = 0.5
+    decay: float = 0.25
+    tau: float = 0.15
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PresetParams":
+        return cls(
+            palette=data["palette"],
+            primitive=data["primitive"],
+            accent_intensity=data["accent_intensity"],
+            decay=data["decay"],
+            tau=data["tau"],
+        )
+
+    @classmethod
+    def from_json(cls, text: str) -> "PresetParams":
+        return cls.from_dict(json.loads(text))
+
+
+@dataclass
+class VisualizerConfig:
+    """Host-side configuration passed to the in-Blender build script.
+
+    Args:
+        analysis_file: Path to the beatrix ``*_analysis.json``.
+        output_mp4: Destination render path (under ``blender/render/``).
+        base_directory: Recording base directory (for audio resolution).
+        fps: Render fps. From config, NOT from analysis. Default 30.
+        resolution: ``(width, height)`` or ``None`` for the scene default.
+        blender_executable: Path to the Blender binary (default: macOS).
+        preset: Optional visual preset parameters.
+    """
+
+    analysis_file: str
+    output_mp4: str
+    base_directory: str
+    fps: int = 30
+    resolution: Optional[Tuple[int, int]] = None
+    blender_executable: str = DEFAULT_BLENDER_EXECUTABLE
+    preset: Optional[PresetParams] = field(default=None)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict. ``resolution`` becomes a list in JSON."""
+        return {
+            "analysis_file": self.analysis_file,
+            "output_mp4": self.output_mp4,
+            "base_directory": self.base_directory,
+            "fps": self.fps,
+            "resolution": (
+                list(self.resolution) if self.resolution is not None else None
+            ),
+            "blender_executable": self.blender_executable,
+            "preset": self.preset.to_dict() if self.preset is not None else None,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VisualizerConfig":
+        resolution = data.get("resolution")
+        if resolution is not None:
+            resolution = tuple(resolution)
+
+        preset = data.get("preset")
+        if preset is not None:
+            preset = PresetParams.from_dict(preset)
+
+        return cls(
+            analysis_file=data["analysis_file"],
+            output_mp4=data["output_mp4"],
+            base_directory=data["base_directory"],
+            fps=data.get("fps", 30),
+            resolution=resolution,
+            blender_executable=data.get(
+                "blender_executable", DEFAULT_BLENDER_EXECUTABLE
+            ),
+            preset=preset,
+        )
+
+    @classmethod
+    def from_json(cls, text: str) -> "VisualizerConfig":
+        return cls.from_dict(json.loads(text))

--- a/packages/cymatic/src/cymatic/config.py
+++ b/packages/cymatic/src/cymatic/config.py
@@ -82,6 +82,11 @@ class VisualizerConfig:
     resolution: Optional[Tuple[int, int]] = None
     blender_executable: str = DEFAULT_BLENDER_EXECUTABLE
     preset: Optional[PresetParams] = field(default=None)
+    # Render/mux fields (Unit 9 follow-up — frames -> ffmpeg mux):
+    audio_file: Optional[str] = None  # source wav/flac to mux into the mp4
+    frame_start: int = 1
+    frame_end: Optional[int] = None  # None -> derive from analysis duration
+    frames_dir: Optional[str] = None  # when set, build_scene renders PNG sequence here
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a plain dict. ``resolution`` becomes a list in JSON."""
@@ -95,6 +100,10 @@ class VisualizerConfig:
             ),
             "blender_executable": self.blender_executable,
             "preset": self.preset.to_dict() if self.preset is not None else None,
+            "audio_file": self.audio_file,
+            "frame_start": self.frame_start,
+            "frame_end": self.frame_end,
+            "frames_dir": self.frames_dir,
         }
 
     def to_json(self) -> str:
@@ -120,6 +129,10 @@ class VisualizerConfig:
                 "blender_executable", DEFAULT_BLENDER_EXECUTABLE
             ),
             preset=preset,
+            audio_file=data.get("audio_file"),
+            frame_start=data.get("frame_start", 1),
+            frame_end=data.get("frame_end"),
+            frames_dir=data.get("frames_dir"),
         )
 
     @classmethod

--- a/packages/cymatic/src/cymatic/config.py
+++ b/packages/cymatic/src/cymatic/config.py
@@ -19,10 +19,14 @@ Notes:
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+import shutil
+from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Dict, Optional, Tuple
 
-DEFAULT_BLENDER_EXECUTABLE = "/Applications/Blender.app/Contents/MacOS/Blender"
+# Cross-platform default: resolve "blender" on PATH. May be None when Blender is
+# not installed/on PATH — the runner raises a clear RuntimeError before spawning
+# a subprocess in that case (pass --blender-executable or set it in config).
+DEFAULT_BLENDER_EXECUTABLE: Optional[str] = shutil.which("blender")
 
 
 @dataclass
@@ -40,6 +44,12 @@ class PresetParams:
     decay: float = 0.25
     tau: float = 0.15
 
+    def __post_init__(self) -> None:
+        if self.decay <= 0:
+            raise ValueError(f"PresetParams.decay must be > 0, got {self.decay}")
+        if self.tau <= 0:
+            raise ValueError(f"PresetParams.tau must be > 0, got {self.tau}")
+
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
 
@@ -48,13 +58,9 @@ class PresetParams:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PresetParams":
-        return cls(
-            palette=data["palette"],
-            primitive=data["primitive"],
-            accent_intensity=data["accent_intensity"],
-            decay=data["decay"],
-            tau=data["tau"],
-        )
+        # Rebuild from the dataclass fields so adding a new field does not
+        # silently break round-trips (missing keys surface as a clear KeyError).
+        return cls(**{f.name: data[f.name] for f in fields(cls)})
 
     @classmethod
     def from_json(cls, text: str) -> "PresetParams":
@@ -71,8 +77,12 @@ class VisualizerConfig:
         base_directory: Recording base directory (for audio resolution).
         fps: Render fps. From config, NOT from analysis. Default 30.
         resolution: ``(width, height)`` or ``None`` for the scene default.
-        blender_executable: Path to the Blender binary (default: macOS).
+        blender_executable: Path to the Blender binary (default: ``shutil.which
+            ("blender")``, may be ``None`` if Blender is not on PATH — the
+            runner then raises a clear error before spawning a subprocess).
         preset: Optional visual preset parameters.
+        blender_timeout_sec: Hard timeout for the Blender render subprocess.
+        ffmpeg_timeout_sec: Hard timeout for the ffmpeg mux subprocess.
     """
 
     analysis_file: str
@@ -80,13 +90,16 @@ class VisualizerConfig:
     base_directory: str
     fps: int = 30
     resolution: Optional[Tuple[int, int]] = None
-    blender_executable: str = DEFAULT_BLENDER_EXECUTABLE
+    blender_executable: Optional[str] = DEFAULT_BLENDER_EXECUTABLE
     preset: Optional[PresetParams] = field(default=None)
     # Render/mux fields (Unit 9 follow-up — frames -> ffmpeg mux):
     audio_file: Optional[str] = None  # source wav/flac to mux into the mp4
     frame_start: int = 1
     frame_end: Optional[int] = None  # None -> derive from analysis duration
     frames_dir: Optional[str] = None  # when set, build_scene renders PNG sequence here
+    # Subprocess timeouts (seconds); None disables the timeout.
+    blender_timeout_sec: Optional[int] = 3600
+    ffmpeg_timeout_sec: Optional[int] = 600
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a plain dict. ``resolution`` becomes a list in JSON."""
@@ -104,6 +117,8 @@ class VisualizerConfig:
             "frame_start": self.frame_start,
             "frame_end": self.frame_end,
             "frames_dir": self.frames_dir,
+            "blender_timeout_sec": self.blender_timeout_sec,
+            "ffmpeg_timeout_sec": self.ffmpeg_timeout_sec,
         }
 
     def to_json(self) -> str:
@@ -133,6 +148,8 @@ class VisualizerConfig:
             frame_start=data.get("frame_start", 1),
             frame_end=data.get("frame_end"),
             frames_dir=data.get("frames_dir"),
+            blender_timeout_sec=data.get("blender_timeout_sec", 3600),
+            ffmpeg_timeout_sec=data.get("ffmpeg_timeout_sec", 600),
         )
 
     @classmethod

--- a/packages/cymatic/src/cymatic/normalization.py
+++ b/packages/cymatic/src/cymatic/normalization.py
@@ -1,0 +1,83 @@
+# ABOUTME: Per-track p99 band normalization + precomputed decay envelopes (host-side)
+# ABOUTME: Lifted from the proven Spike 1 norm()/env() in research/build_visualizer_v2.py
+
+"""Deterministic, per-track normalization and event-envelope precompute.
+
+Settled by Spike 1 (real CC0 jazz, 48k): the band anchor is the **p99**
+percentile — robust to single transients (max-scaling under-uses the range;
+p95 clips ~5%). Normalization is per-band, deterministic, and zero-guarded.
+
+Event envelopes (beats / energy_peaks) are precomputed in numpy as separate
+float channels — moving the event semantics out of the Geometry Nodes graph
+(approach C). For each event we fill a decaying ramp ``max(0, 1 - k*dt/decay)``
+from the event's nearest sample index onward, taking the elementwise max so
+overlapping events do not cancel.
+
+Both functions return ``float32`` arrays ready to be written as mesh attributes
+via ``foreach_set``.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import numpy as np
+
+ArrayLike = Union[Sequence[float], np.ndarray]
+
+
+def normalize_band(arr: ArrayLike) -> np.ndarray:
+    """Normalize a raw STFT band to ``[0, 1]`` using the p99 anchor.
+
+    ``clip(arr / p99, 0, 1)``. If ``p99 <= 0`` (constant/near-zero band) the
+    result is all zeros — the zero-guard prevents division by zero.
+
+    Args:
+        arr: Raw band magnitudes (e.g. ``frequency_bands.bass_energy``).
+
+    Returns:
+        ``float32`` array of the same length, values in ``[0, 1]``.
+    """
+    a = np.asarray(arr, dtype=float)
+    p = np.percentile(a, 99)
+    if p > 0:
+        out = np.clip(a / p, 0.0, 1.0)
+    else:
+        out = np.zeros_like(a)
+    return out.astype(np.float32)
+
+
+def precompute_envelope(
+    event_times: Sequence[float],
+    times: np.ndarray,
+    decay: float,
+) -> np.ndarray:
+    """Precompute a decaying envelope over the analysis time grid.
+
+    For each event time, the nearest sample index ``i = round(t/dt)`` is set to
+    ``1.0`` and a linear ramp ``max(0, 1 - k*dt/decay)`` decays over the
+    following ``int(decay/dt)`` samples. Overlapping events combine via
+    elementwise max, so a fresh event always re-peaks to ``1.0``.
+
+    Args:
+        event_times: Event timestamps in seconds (beats or energy_peaks).
+            An empty sequence yields an all-zeros envelope (no exception).
+        times: The analysis time grid (``frequency_bands.times``).
+        decay: Ramp length in seconds.
+
+    Returns:
+        ``float32`` array of length ``len(times)``, values in ``[0, 1]``.
+    """
+    times = np.asarray(times, dtype=float)
+    n = len(times)
+    dt = float(times[1] - times[0])
+    env = np.zeros(n, dtype=np.float32)
+
+    steps = int(decay / dt)
+    for t in event_times:
+        i = int(round(t / dt))
+        for k in range(0, steps + 1):
+            j = i + k
+            if 0 <= j < n:
+                env[j] = max(env[j], 1.0 - k * dt / decay)
+    return env

--- a/packages/cymatic/src/cymatic/normalization.py
+++ b/packages/cymatic/src/cymatic/normalization.py
@@ -19,9 +19,12 @@ via ``foreach_set``.
 
 from __future__ import annotations
 
+import logging
 from typing import Sequence, Union
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 ArrayLike = Union[Sequence[float], np.ndarray]
 
@@ -32,6 +35,10 @@ def normalize_band(arr: ArrayLike) -> np.ndarray:
     ``clip(arr / p99, 0, 1)``. If ``p99 <= 0`` (constant/near-zero band) the
     result is all zeros — the zero-guard prevents division by zero.
 
+    Non-finite values (NaN/inf, e.g. a corrupt analysis band) are coerced to
+    ``0`` with a logged warning before percentile/clip, so a single bad sample
+    does not poison ``np.percentile`` and make the whole band silently vanish.
+
     Args:
         arr: Raw band magnitudes (e.g. ``frequency_bands.bass_energy``).
 
@@ -39,6 +46,12 @@ def normalize_band(arr: ArrayLike) -> np.ndarray:
         ``float32`` array of the same length, values in ``[0, 1]``.
     """
     a = np.asarray(arr, dtype=float)
+    if not np.all(np.isfinite(a)):
+        logger.warning(
+            "normalize_band: non-finite values in band (n=%d), coercing to 0",
+            int(np.count_nonzero(~np.isfinite(a))),
+        )
+        a = np.nan_to_num(a, nan=0.0, posinf=0.0, neginf=0.0)
     p = np.percentile(a, 99)
     if p > 0:
         out = np.clip(a / p, 0.0, 1.0)
@@ -70,6 +83,10 @@ def precompute_envelope(
     """
     times = np.asarray(times, dtype=float)
     n = len(times)
+    # dt needs at least two samples; a degenerate grid yields a zero envelope
+    # instead of an IndexError on ``times[1]``.
+    if n < 2:
+        return np.zeros(n, dtype=np.float32)
     dt = float(times[1] - times[0])
     env = np.zeros(n, dtype=np.float32)
 

--- a/packages/cymatic/src/cymatic/runner.py
+++ b/packages/cymatic/src/cymatic/runner.py
@@ -1,0 +1,187 @@
+# ABOUTME: Host-side runner — builds the Blender subprocess command and renders.
+# ABOUTME: Mirrors cinemon's BlenderProjectManager (subprocess + "--" + --config).
+
+"""Host-side runner for the cymatic 3D audio visualizer.
+
+Builds the Blender headless command, serializes the ``VisualizerConfig`` to a
+temp file, runs ``build_scene.py`` inside Blender, and returns the output path
+under ``blender/render/``.
+
+Pattern mirrors ``cinemon`` (``BlenderProjectManager``):
+
+    [blender_exec, "--background", "--python", build_scene.py,
+     "--", "--config", <config_file>]
+
+with ``subprocess.run(..., capture_output=True, text=True, check=True)`` and a
+``RuntimeError`` carrying stderr on ``CalledProcessError``.
+
+macOS note: the default ``blender_executable`` in ``VisualizerConfig`` is the
+explicit ``/Applications/Blender.app/...`` path. The snap branch only fires for
+the literal ``"blender"`` command (Linux), mirroring cinemon.
+
+RENDER CAVEAT (documented, NOT solved here):
+    The dev Blender 5.1.2 has NO internal FFMPEG encoder and no system ``ffmpeg``
+    on PATH, so direct mp4 muxing is not yet possible. The intended target is a
+    frames -> mux approach: ``build_scene.py`` renders PNG frames, and a later
+    step muxes them to mp4 via external ffmpeg (exact codec deferred to
+    ``project_setup.py``, matching cinemon's FFMPEG/H264/AAC settings).
+    TODO(Unit 9 follow-up): add a frames->mp4 ffmpeg mux seam once ffmpeg is
+    available. For now the runner builds/executes the command and returns the
+    intended output path; it does not perform actual video encoding.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+from setka_common.file_structure.specialized import RecordingStructureManager
+
+from cymatic.config import VisualizerConfig
+
+logger = logging.getLogger(__name__)
+
+# Resolve the in-Blender script the same way cinemon's BlenderProjectManager
+# does: packages/cymatic/src/cymatic/runner.py -> packages/cymatic/blender_script/.
+BUILD_SCENE_SCRIPT = (
+    Path(__file__).parent.parent.parent / "blender_script" / "build_scene.py"
+)
+
+
+class CymaticRunner:
+    """Drives the headless Blender subprocess that builds + renders the scene."""
+
+    def __init__(
+        self,
+        config: VisualizerConfig,
+        script_path: Optional[Path] = None,
+    ) -> None:
+        """Initialize the runner.
+
+        Args:
+            config: The visualizer configuration (serialized and passed to
+                Blender via ``--config``).
+            script_path: Override for the in-Blender ``build_scene.py`` path
+                (defaults to the resolved package location).
+        """
+        self.config = config
+        self.script_path = Path(script_path) if script_path else BUILD_SCENE_SCRIPT
+
+    def _resolve_output_path(self) -> Path:
+        """Resolve the render output path under ``blender/render/``.
+
+        Uses ``RecordingStructureManager.ensure_blender_dir`` so directory names
+        are never hardcoded; appends the ``render/`` subdir it creates.
+
+        Returns:
+            Path to the intended ``<name>.mp4`` under ``blender/render/``.
+        """
+        base_directory = Path(self.config.base_directory)
+        blender_dir = RecordingStructureManager.ensure_blender_dir(base_directory)
+        render_dir = blender_dir / "render"
+
+        # Derive a stable output name from the analysis file stem
+        # (e.g. "song_analysis.json" -> "song_analysis.mp4").
+        name = Path(self.config.analysis_file).stem or base_directory.name
+        return render_dir / f"{name}.mp4"
+
+    def _build_command(self, config_path: str) -> List[str]:
+        """Build the Blender headless command list.
+
+        Args:
+            config_path: Path to the serialized config temp file.
+
+        Returns:
+            The argv list for ``subprocess.run``.
+        """
+        executable = self.config.blender_executable
+
+        # Snap branch is Linux-only and only for the literal "blender" command.
+        # On macOS the config default is the explicit Blender.app path -> direct.
+        if executable == "blender":
+            prefix: List[str] = ["snap", "run", "blender"]
+        else:
+            prefix = [executable]
+
+        return [
+            *prefix,
+            "--background",
+            "--python",
+            str(self.script_path),
+            "--",  # separator: Blender args vs build_scene.py args
+            "--config",
+            config_path,
+        ]
+
+    def run(self) -> Path:
+        """Serialize config, run Blender headless, return the output path.
+
+        Returns:
+            Path to the intended render output under ``blender/render/``.
+
+        Raises:
+            RuntimeError: If the in-Blender script is missing or Blender exits
+                with a non-zero status (stderr is propagated).
+        """
+        if not self.script_path.exists():
+            raise RuntimeError(f"cymatic build_scene script not found: {self.script_path}")
+
+        output_path = self._resolve_output_path()
+
+        # Serialize the config to a temp file passed via --config; cleaned up
+        # after the subprocess so we never leave config layout on disk.
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".json",
+            prefix="cymatic_config_",
+            delete=False,
+            encoding="utf-8",
+        )
+        config_path = tmp.name
+        try:
+            tmp.write(self.config.to_json())
+            tmp.close()
+
+            cmd = self._build_command(config_path)
+            logger.debug("Executing Blender command: %s", " ".join(cmd))
+            logger.debug("Working directory: %s", os.getcwd())
+
+            try:
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, check=True
+                )
+            except subprocess.CalledProcessError as exc:
+                logger.error("Blender execution failed (rc=%s)", exc.returncode)
+                logger.error("Blender stdout: %s", exc.stdout)
+                logger.error("Blender stderr: %s", exc.stderr)
+                raise RuntimeError(f"Blender execution failed: {exc.stderr}")
+
+            if result.stdout and result.stdout.strip():
+                logger.debug("Blender stdout: %s", result.stdout)
+            if result.stderr and result.stderr.strip():
+                logger.debug("Blender stderr: %s", result.stderr)
+
+            logger.info("cymatic render finished, output: %s", output_path)
+            return output_path
+        finally:
+            # Clean up the temp config regardless of success/failure.
+            try:
+                os.unlink(config_path)
+            except OSError:
+                logger.warning("Could not remove temp config: %s", config_path)
+
+
+def render(config: VisualizerConfig) -> Path:
+    """Convenience wrapper: build a :class:`CymaticRunner` and run it.
+
+    Args:
+        config: The visualizer configuration.
+
+    Returns:
+        Path to the intended render output under ``blender/render/``.
+    """
+    return CymaticRunner(config).run()

--- a/packages/cymatic/src/cymatic/runner.py
+++ b/packages/cymatic/src/cymatic/runner.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -132,6 +133,12 @@ class CymaticRunner:
 
         output_path = self._resolve_output_path()
 
+        # Render PNG frames to a temp dir, then mux to mp4 (this Blender build has
+        # no internal FFMPEG encoder). Point the in-Blender script at the frames
+        # dir via the config so build_scene renders the sequence.
+        frames_dir = Path(tempfile.mkdtemp(prefix="cymatic_frames_"))
+        self.config.frames_dir = str(frames_dir)
+
         # Serialize the config to a temp file passed via --config; cleaned up
         # after the subprocess so we never leave config layout on disk.
         tmp = tempfile.NamedTemporaryFile(
@@ -165,14 +172,65 @@ class CymaticRunner:
             if result.stderr and result.stderr.strip():
                 logger.debug("Blender stderr: %s", result.stderr)
 
+            # Mux the rendered PNG frames (+ optional audio) into the mp4.
+            self._mux_frames(frames_dir, output_path)
+
             logger.info("cymatic render finished, output: %s", output_path)
             return output_path
         finally:
-            # Clean up the temp config regardless of success/failure.
             try:
                 os.unlink(config_path)
             except OSError:
                 logger.warning("Could not remove temp config: %s", config_path)
+            shutil.rmtree(frames_dir, ignore_errors=True)
+
+    def _mux_frames(self, frames_dir: Path, output_path: Path) -> None:
+        """Mux a PNG frame sequence (+ optional audio) into mp4 via ffmpeg.
+
+        Blender writes frames named ``frame_0001.png`` (4-digit pad). We feed
+        them to ffmpeg as an image2 sequence starting at ``frame_start`` and
+        encode H.264 (yuv420p for broad compatibility), muxing the source audio
+        with ``-shortest`` when ``config.audio_file`` is set.
+
+        Args:
+            frames_dir: Directory holding the rendered ``frame_####.png`` files.
+            output_path: Destination ``.mp4`` path.
+
+        Raises:
+            RuntimeError: if ffmpeg is missing, no frames were produced, or the
+                ffmpeg invocation fails.
+        """
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg is None:
+            raise RuntimeError(
+                "ffmpeg not found on PATH — required to mux frames to mp4 "
+                "(this Blender build has no internal FFMPEG encoder)."
+            )
+
+        frames = sorted(frames_dir.glob("frame_*.png"))
+        if not frames:
+            raise RuntimeError(f"No frames rendered in {frames_dir}")
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        pattern = str(frames_dir / "frame_%04d.png")
+        cmd: List[str] = [
+            ffmpeg, "-y",
+            "-framerate", str(self.config.fps),
+            "-start_number", str(self.config.frame_start),
+            "-i", pattern,
+        ]
+        if self.config.audio_file and Path(self.config.audio_file).exists():
+            cmd += ["-i", str(self.config.audio_file)]
+        cmd += ["-c:v", "libx264", "-pix_fmt", "yuv420p"]
+        if self.config.audio_file and Path(self.config.audio_file).exists():
+            cmd += ["-c:a", "aac", "-b:a", "192k", "-shortest"]
+        cmd += [str(output_path)]
+
+        logger.debug("ffmpeg mux: %s", " ".join(cmd))
+        try:
+            subprocess.run(cmd, capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"ffmpeg mux failed: {exc.stderr}")
 
 
 def render(config: VisualizerConfig) -> Path:

--- a/packages/cymatic/src/cymatic/runner.py
+++ b/packages/cymatic/src/cymatic/runner.py
@@ -15,9 +15,11 @@ Pattern mirrors ``cinemon`` (``BlenderProjectManager``):
 with ``subprocess.run(..., capture_output=True, text=True, check=True)`` and a
 ``RuntimeError`` carrying stderr on ``CalledProcessError``.
 
-macOS note: the default ``blender_executable`` in ``VisualizerConfig`` is the
-explicit ``/Applications/Blender.app/...`` path. The snap branch only fires for
-the literal ``"blender"`` command (Linux), mirroring cinemon.
+Executable note: the default ``blender_executable`` is ``shutil.which("blender")``
+(cross-platform). The snap branch only fires for the literal ``"blender"`` command
+(Linux), mirroring cinemon; any other explicit path is used directly. If no
+executable resolves, ``run()`` raises a clear ``RuntimeError`` before spawning a
+subprocess.
 
 RENDER CAVEAT (documented, NOT solved here):
     The dev Blender 5.1.2 has NO internal FFMPEG encoder and no system ``ffmpeg``
@@ -32,6 +34,7 @@ RENDER CAVEAT (documented, NOT solved here):
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 import shutil
@@ -90,19 +93,18 @@ class CymaticRunner:
         name = Path(self.config.analysis_file).stem or base_directory.name
         return render_dir / f"{name}.mp4"
 
-    def _build_command(self, config_path: str) -> List[str]:
+    def _build_command(self, config_path: str, executable: str) -> List[str]:
         """Build the Blender headless command list.
 
         Args:
             config_path: Path to the serialized config temp file.
+            executable: Resolved (non-None) Blender executable.
 
         Returns:
             The argv list for ``subprocess.run``.
         """
-        executable = self.config.blender_executable
-
         # Snap branch is Linux-only and only for the literal "blender" command.
-        # On macOS the config default is the explicit Blender.app path -> direct.
+        # An explicit path (e.g. /Applications/Blender.app/...) -> direct.
         if executable == "blender":
             prefix: List[str] = ["snap", "run", "blender"]
         else:
@@ -125,41 +127,62 @@ class CymaticRunner:
             Path to the intended render output under ``blender/render/``.
 
         Raises:
-            RuntimeError: If the in-Blender script is missing or Blender exits
-                with a non-zero status (stderr is propagated).
+            RuntimeError: If the Blender executable cannot be found, the
+                in-Blender script is missing, Blender exits non-zero or times
+                out, or the rendered frame count is short of expectation.
         """
         if not self.script_path.exists():
             raise RuntimeError(f"cymatic build_scene script not found: {self.script_path}")
 
+        executable = self.config.blender_executable
+        if not executable:
+            raise RuntimeError(
+                "Blender executable not found; pass --blender-executable or set "
+                "it in config"
+            )
+
         output_path = self._resolve_output_path()
 
-        # Render PNG frames to a temp dir, then mux to mp4 (this Blender build has
-        # no internal FFMPEG encoder). Point the in-Blender script at the frames
-        # dir via the config so build_scene renders the sequence.
-        frames_dir = Path(tempfile.mkdtemp(prefix="cymatic_frames_"))
-        self.config.frames_dir = str(frames_dir)
-
-        # Serialize the config to a temp file passed via --config; cleaned up
-        # after the subprocess so we never leave config layout on disk.
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".json",
-            prefix="cymatic_config_",
-            delete=False,
-            encoding="utf-8",
-        )
-        config_path = tmp.name
+        # Do NOT mutate the caller's config. Work on a local copy carrying the
+        # frames_dir we render into; the caller's VisualizerConfig.frames_dir
+        # stays untouched.
+        config_path: Optional[str] = None
+        frames_dir: Optional[Path] = None
         try:
-            tmp.write(self.config.to_json())
+            # Allocate the temp frames dir inside the try so it can't leak if a
+            # later allocation raises; finally still cleans it up.
+            frames_dir = Path(tempfile.mkdtemp(prefix="cymatic_frames_"))
+            cfg = dataclasses.replace(self.config, frames_dir=str(frames_dir))
+
+            # Serialize the (local) config to a temp file passed via --config;
+            # cleaned up after the subprocess so we never leave config on disk.
+            tmp = tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".json",
+                prefix="cymatic_config_",
+                delete=False,
+                encoding="utf-8",
+            )
+            config_path = tmp.name
+            tmp.write(cfg.to_json())
             tmp.close()
 
-            cmd = self._build_command(config_path)
+            cmd = self._build_command(config_path, executable)
             logger.debug("Executing Blender command: %s", " ".join(cmd))
             logger.debug("Working directory: %s", os.getcwd())
 
             try:
                 result = subprocess.run(
-                    cmd, capture_output=True, text=True, check=True
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=cfg.blender_timeout_sec,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise RuntimeError(
+                    f"Blender render timed out after {cfg.blender_timeout_sec}s: "
+                    f"{exc}"
                 )
             except subprocess.CalledProcessError as exc:
                 logger.error("Blender execution failed (rc=%s)", exc.returncode)
@@ -172,34 +195,74 @@ class CymaticRunner:
             if result.stderr and result.stderr.strip():
                 logger.debug("Blender stderr: %s", result.stderr)
 
+            # Validate the rendered frame count against expectation before mux,
+            # so a partial/aborted render fails loudly instead of silently
+            # producing a short clip.
+            self._validate_frame_count(frames_dir, cfg)
+
             # Mux the rendered PNG frames (+ optional audio) into the mp4.
-            self._mux_frames(frames_dir, output_path)
+            self._mux_frames(frames_dir, output_path, cfg)
 
             logger.info("cymatic render finished, output: %s", output_path)
             return output_path
         finally:
-            try:
-                os.unlink(config_path)
-            except OSError:
-                logger.warning("Could not remove temp config: %s", config_path)
-            shutil.rmtree(frames_dir, ignore_errors=True)
+            if config_path is not None:
+                try:
+                    os.unlink(config_path)
+                except OSError:
+                    logger.warning("Could not remove temp config: %s", config_path)
+            if frames_dir is not None:
+                shutil.rmtree(frames_dir, ignore_errors=True)
 
-    def _mux_frames(self, frames_dir: Path, output_path: Path) -> None:
+    def _expected_frame_count(self, cfg: VisualizerConfig) -> int:
+        """Expected rendered frame count: ``frame_end - frame_start + 1``.
+
+        ``frame_end`` falls back to ``int(duration * fps)`` derived from the
+        analysis (consistent with how ``build_scene.py`` sets the frame range).
+        """
+        frame_end = cfg.frame_end
+        if frame_end is None:
+            from cymatic.analysis_loader import load_analysis
+
+            data = load_analysis(cfg)
+            frame_end = int(data.duration * cfg.fps)
+        return int(frame_end) - int(cfg.frame_start) + 1
+
+    def _validate_frame_count(self, frames_dir: Path, cfg: VisualizerConfig) -> None:
+        """Raise if fewer frames were rendered than expected."""
+        expected = self._expected_frame_count(cfg)
+        actual = len(list(frames_dir.glob("frame_*.png")))
+        if actual < expected:
+            raise RuntimeError(
+                f"Render produced {actual} frame(s) but expected {expected} "
+                f"(frame_start={cfg.frame_start}, frame_end={cfg.frame_end}); "
+                "the render appears incomplete."
+            )
+
+    def _mux_frames(
+        self,
+        frames_dir: Path,
+        output_path: Path,
+        cfg: Optional[VisualizerConfig] = None,
+    ) -> None:
         """Mux a PNG frame sequence (+ optional audio) into mp4 via ffmpeg.
 
         Blender writes frames named ``frame_0001.png`` (4-digit pad). We feed
         them to ffmpeg as an image2 sequence starting at ``frame_start`` and
         encode H.264 (yuv420p for broad compatibility), muxing the source audio
-        with ``-shortest`` when ``config.audio_file`` is set.
+        with ``-shortest`` when ``audio_file`` is set.
 
         Args:
             frames_dir: Directory holding the rendered ``frame_####.png`` files.
             output_path: Destination ``.mp4`` path.
+            cfg: The (local) config to read fps/frame_start/audio/timeout from;
+                defaults to ``self.config`` for direct callers/tests.
 
         Raises:
-            RuntimeError: if ffmpeg is missing, no frames were produced, or the
-                ffmpeg invocation fails.
+            RuntimeError: if ffmpeg is missing, no frames were produced, the
+                ffmpeg invocation fails, or it times out.
         """
+        cfg = cfg if cfg is not None else self.config
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg is None:
             raise RuntimeError(
@@ -215,20 +278,30 @@ class CymaticRunner:
         pattern = str(frames_dir / "frame_%04d.png")
         cmd: List[str] = [
             ffmpeg, "-y",
-            "-framerate", str(self.config.fps),
-            "-start_number", str(self.config.frame_start),
+            "-framerate", str(cfg.fps),
+            "-start_number", str(cfg.frame_start),
             "-i", pattern,
         ]
-        if self.config.audio_file and Path(self.config.audio_file).exists():
-            cmd += ["-i", str(self.config.audio_file)]
+        if cfg.audio_file and Path(cfg.audio_file).exists():
+            cmd += ["-i", str(cfg.audio_file)]
         cmd += ["-c:v", "libx264", "-pix_fmt", "yuv420p"]
-        if self.config.audio_file and Path(self.config.audio_file).exists():
+        if cfg.audio_file and Path(cfg.audio_file).exists():
             cmd += ["-c:a", "aac", "-b:a", "192k", "-shortest"]
         cmd += [str(output_path)]
 
         logger.debug("ffmpeg mux: %s", " ".join(cmd))
         try:
-            subprocess.run(cmd, capture_output=True, text=True, check=True)
+            subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=cfg.ffmpeg_timeout_sec,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"ffmpeg mux timed out after {cfg.ffmpeg_timeout_sec}s: {exc}"
+            )
         except subprocess.CalledProcessError as exc:
             raise RuntimeError(f"ffmpeg mux failed: {exc.stderr}")
 

--- a/packages/cymatic/src/cymatic/sync_verification.py
+++ b/packages/cymatic/src/cymatic/sync_verification.py
@@ -10,10 +10,12 @@ It verifies two pieces of *data-timing arithmetic*:
 
 1. **Beat impulse placement.** The ``beat_env`` channel is precomputed in numpy
    to peak at index ``round(t / dt)`` for each beat time ``t`` (see
-   :func:`cymatic.normalization.precompute_envelope`). Converting that
-   peak *index* back to a render *frame* is ``round((index * dt) * fps)``. We
-   compare that to the frame a renderer would target for the beat,
-   ``round(t * fps)``, and assert the deviation is ``<= N`` frames.
+   :func:`cymatic.normalization.precompute_envelope`). For each ORIGINAL beat
+   time ``t`` from the analysis JSON we find the envelope's argmax-peak frame in
+   a window around ``t`` (``round((index * dt) * fps)``) and compare it to the
+   frame a renderer would target, ``round(t * fps)``, asserting the deviation is
+   ``<= N`` frames. Using the original times (not times reconstructed from the
+   same envelope) is what makes a wrong placement produce a real deviation.
 
 2. **Value sampling (``Seconds/dt`` mapping).** At render frame ``f`` the live
    Geometry Nodes graph computes scene time ``f / fps`` and indexes the stored
@@ -153,22 +155,29 @@ class SyncReport:
     dt: float = 0.0
 
 
+# Search window half-width, expressed in render frames. It must be strictly
+# wider than the tolerance so a misplaced impulse can land *outside* tolerance
+# and still be found by the argmax — that is what lets the harness FAIL on a
+# wrong envelope instead of silently clamping the search to the expected index.
+_SEARCH_HALF_FRAMES = DEFAULT_N_TOLERANCE_FRAMES + 4
+
+
 def _peak_frame_near(beat_env: np.ndarray, beat_time: float, dt: float, fps: int) -> int:
-    """Frame of the ``beat_env`` peak sample nearest ``beat_time``.
+    """Frame of the ``beat_env`` peak sample near ``beat_time``.
 
     The envelope was precomputed to peak (==1.0) at ``round(beat_time/dt)`` and
-    decay afterward. We search a small index window around that expected index
-    for the argmax, then convert the winning *index* to a *frame* via
-    ``round((index * dt) * fps)``. Searching a window (rather than trusting the
-    exact index) is what makes this a measurement, not a tautology restatement:
-    if the precompute or the index arithmetic were off, the argmax would land
-    on a different sample and the deviation would grow.
+    decay afterward. We search an index window around the expected index
+    (``+/- _SEARCH_HALF_FRAMES`` render frames, converted to samples) for the
+    argmax, then convert the winning *index* to a *frame* via
+    ``round((index * dt) * fps)``. The window is deliberately WIDER than the
+    tolerance: if the precompute or the index arithmetic were off, the argmax
+    lands on a different sample and the deviation grows past tolerance — this is
+    what makes the harness a real measurement, not a tautology against itself.
     """
     n = len(beat_env)
     center = _clamp_index(int(round(beat_time / dt)), n)
-    # Window spans roughly +/- one frame in samples (>= 1), so the argmax is
-    # free to drift to an adjacent sample if the placement were wrong.
-    half = max(1, int(round((1.0 / fps) / dt)))
+    # Window spans +/- several render frames in samples (>= 1).
+    half = max(1, int(round((_SEARCH_HALF_FRAMES / fps) / dt)))
     lo = _clamp_index(center - half, n)
     hi = _clamp_index(center + half, n)
     window = beat_env[lo : hi + 1]
@@ -182,13 +191,19 @@ def verify_sync(
 ) -> SyncReport:
     """Verify data-timing sync of the precomputed beat envelope (R2/R3).
 
-    For each beat time ``t`` derived from ``beat_env`` (reconstructed from the
-    envelope's peaks): the expected render frame is ``round(t * fps)``; the
-    measured peak frame comes from the envelope's argmax near ``t`` converted
-    to a frame. The deviation is ``|peak_frame - round(t * fps)|`` and must be
-    ``<= n_tolerance_frames``.
+    For each ORIGINAL beat time ``t`` taken from the analysis JSON
+    (``analysis_data.raw_beat_times`` — the ground truth, NOT reconstructed from
+    the envelope): the expected render frame is ``round(t * fps)``; the measured
+    peak frame comes from the ``beat_env`` argmax in a small window around ``t``
+    converted to a frame. The deviation is ``|peak_frame - round(t * fps)|`` and
+    must be ``<= n_tolerance_frames``.
 
-    A beatless track (all-zero ``beat_env``) yields an empty, vacuously-passing
+    Comparing against the original times (rather than times reconstructed from
+    the same envelope) keeps the harness honest: if the precompute placed the
+    impulse at the wrong index, the argmax frame diverges from ``round(t*fps)``
+    and the deviation grows — a tautology would have hidden that.
+
+    A beatless track (no ``raw_beat_times``) yields an empty, vacuously-passing
     report — it does not crash.
 
     See the module docstring for the scope/honesty note: this is a proof of
@@ -206,7 +221,7 @@ def verify_sync(
     dt = analysis_data.dt
     fps = analysis_data.fps
 
-    beat_times = _reconstruct_beat_times(beat_env, dt)
+    beat_times = analysis_data.raw_beat_times
 
     deviations: List[BeatDeviation] = []
     for t in beat_times:
@@ -231,27 +246,3 @@ def verify_sync(
         fps=fps,
         dt=dt,
     )
-
-
-def _reconstruct_beat_times(beat_env: np.ndarray, dt: float) -> List[float]:
-    """Recover beat times (seconds) from the precomputed ``beat_env`` peaks.
-
-    A beat sets its sample to exactly ``1.0`` (the envelope's max) and then
-    decays. We treat the rising edges into a ``1.0`` sample as beat onsets:
-    indices where ``env == 1.0`` whose previous sample is strictly smaller (or
-    which start the array). Converting index -> seconds is ``index * dt``.
-
-    Working from the envelope (rather than re-reading the source beat list)
-    keeps this harness honest about what was actually baked into the data
-    object the GN graph samples.
-    """
-    if len(beat_env) == 0:
-        return []
-    is_peak = np.isclose(beat_env, 1.0)
-    if not is_peak.any():
-        return []
-    prev = np.empty_like(beat_env)
-    prev[0] = -1.0
-    prev[1:] = beat_env[:-1]
-    onsets = np.flatnonzero(is_peak & (beat_env > prev))
-    return [float(i * dt) for i in onsets]

--- a/packages/cymatic/src/cymatic/sync_verification.py
+++ b/packages/cymatic/src/cymatic/sync_verification.py
@@ -129,6 +129,7 @@ class BeatDeviation:
     expected_frame: int  # round(beat_time * fps)
     peak_frame: int  # frame of the beat_env peak nearest beat_time
     deviation: int  # |peak_frame - expected_frame|
+    present: bool = True  # a fresh impulse (~1.0) exists at the expected index
 
 
 @dataclass
@@ -139,8 +140,9 @@ class SyncReport:
         deviations: per-beat measurements (empty for a beatless track).
         max_deviation: largest per-beat deviation in frames (0 if no beats).
         n_tolerance_frames: the internal tolerance applied.
-        passed: ``True`` iff ``max_deviation <= n_tolerance_frames`` (vacuously
-            ``True`` for a beatless track).
+        passed: ``True`` iff every beat is on-time (``max_deviation <=
+            n_tolerance_frames``) AND has its own fresh impulse in the envelope
+            (``all(d.present)``); vacuously ``True`` for a beatless track.
         sample_rate: source track sample rate (R3 traceability).
         fps: fps used for the frame arithmetic.
         dt: sample spacing used.
@@ -160,6 +162,26 @@ class SyncReport:
 # and still be found by the argmax — that is what lets the harness FAIL on a
 # wrong envelope instead of silently clamping the search to the expected index.
 _SEARCH_HALF_FRAMES = DEFAULT_N_TOLERANCE_FRAMES + 4
+
+# A beat is "present" only when its OWN fresh impulse sits at the expected index.
+# precompute_envelope sets env[round(t/dt)] to exactly 1.0 for every event time,
+# so a genuine beat always reads 1.0 there; any value below means there is no
+# fresh impulse at that index — only the decay tail of a NEIGHBORING beat. That
+# distinction is what closes adjacent-beat masking: when a beat is absent from
+# the envelope but a neighbor's peak falls inside the search window, the argmax
+# would report a small deviation (a false pass); the presence check fails it.
+# The threshold sits just below 1.0 so float round-trips never false-fail a real
+# beat, while any decayed-neighbor value (strictly < 1.0) is rejected.
+_PRESENCE_THRESHOLD = 0.999
+
+
+def _impulse_present(beat_env: np.ndarray, beat_time: float, dt: float) -> bool:
+    """True iff a fresh impulse (~1.0) sits at the beat's expected index."""
+    n = len(beat_env)
+    if n == 0:
+        return False
+    index = _clamp_index(int(round(beat_time / dt)), n)
+    return float(beat_env[index]) >= _PRESENCE_THRESHOLD
 
 
 def _peak_frame_near(beat_env: np.ndarray, beat_time: float, dt: float, fps: int) -> int:
@@ -233,15 +255,21 @@ def verify_sync(
                 expected_frame=expected_frame,
                 peak_frame=peak_frame,
                 deviation=abs(peak_frame - expected_frame),
+                present=_impulse_present(beat_env, t, dt),
             )
         )
 
     max_dev = max((d.deviation for d in deviations), default=0)
+    all_present = all(d.present for d in deviations)
     return SyncReport(
         deviations=deviations,
         max_deviation=max_dev,
         n_tolerance_frames=n_tolerance_frames,
-        passed=max_dev <= n_tolerance_frames,
+        # Pass requires BOTH on-time placement AND a fresh impulse per beat: the
+        # presence check defeats adjacent-beat masking, where a neighbor's peak
+        # inside the search window would otherwise yield a small (passing)
+        # deviation for a beat that has no impulse of its own.
+        passed=max_dev <= n_tolerance_frames and all_present,
         sample_rate=analysis_data.sample_rate,
         fps=fps,
         dt=dt,

--- a/packages/cymatic/src/cymatic/sync_verification.py
+++ b/packages/cymatic/src/cymatic/sync_verification.py
@@ -1,0 +1,257 @@
+# ABOUTME: Host-side, pure-python DATA-timing sync verification harness (R2/R3)
+# ABOUTME: Proves Seconds/dt arithmetic + beat-impulse frame placement, NOT visuals.
+
+"""Data-grounded sync verification for the cymatic visualizer (Unit 10).
+
+WHAT THIS PROVES (and what it does NOT)
+---------------------------------------
+This harness is a **pure-python, host-side** check — it never touches ``bpy``.
+It verifies two pieces of *data-timing arithmetic*:
+
+1. **Beat impulse placement.** The ``beat_env`` channel is precomputed in numpy
+   to peak at index ``round(t / dt)`` for each beat time ``t`` (see
+   :func:`cymatic.normalization.precompute_envelope`). Converting that
+   peak *index* back to a render *frame* is ``round((index * dt) * fps)``. We
+   compare that to the frame a renderer would target for the beat,
+   ``round(t * fps)``, and assert the deviation is ``<= N`` frames.
+
+2. **Value sampling (``Seconds/dt`` mapping).** At render frame ``f`` the live
+   Geometry Nodes graph computes scene time ``f / fps`` and indexes the stored
+   channel at ``round((f / fps) / dt)`` with clamping (Spike 2, verified live
+   on Blender 5.1.2). :func:`sample_channel_at_frame` re-confirms that exact
+   index arithmetic in pure python — a host-side mirror of what Spike 2 proved
+   on the GPU.
+
+HONESTY NOTE (plan: "Zakres tego dowodu", review: adversarial)
+--------------------------------------------------------------
+Because the envelope is precomputed in numpy and sampled by index, this harness
+primarily validates the ``Seconds/dt`` arithmetic and envelope placement, plus
+the ``dt`` vs ``1/fps`` quantization. It does **NOT** prove the *perceptual*
+claim "the accent is visibly on the beat": preset easing, motion blur, and the
+linear blur of the impulse between samples (dt ~11-23 ms) may soften the accent.
+Perceptual verification is creator acceptance (R4), not this harness. MVP
+criterion 2 here = proof of *data timing*, not *visual timing*.
+
+TOLERANCE N
+-----------
+``n_tolerance_frames`` is an **internal constant of this harness**
+(:data:`DEFAULT_N_TOLERANCE_FRAMES`), deliberately NOT a config field (plan:
+scope — premature config surface). It is governed by ``dt`` vs ``1/fps``: the
+beat lands on a sample grid quantized to ``dt`` (~11 ms @ 48k, ~23 ms @ 22k),
+which at 30 fps (~33 ms/frame) is within one frame; the impulse then resolves
+to a frame via two roundings, so a 2-frame tolerance comfortably covers the
+quantization floor.
+
+FPS CONSISTENCY
+---------------
+The ``fps`` used here for ``round(beat_sec * fps)`` MUST equal
+``VisualizerConfig.fps`` (which ``build_scene.py`` writes to
+``scene.render.fps``). :func:`assert_fps_consistency` guards the host-side half
+of that invariant; the live ``scene.render.fps == config.fps`` assertion is an
+integration concern (it requires a running Blender), not part of this pure
+harness.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+import numpy as np
+
+from .analysis_loader import AnalysisData
+
+# Internal tolerance, NOT a config field (plan: scope). See module docstring.
+DEFAULT_N_TOLERANCE_FRAMES = 2
+
+
+def assert_fps_consistency(config_fps: int, harness_fps: int) -> None:
+    """Assert the harness fps equals the config fps (host-side half of INV).
+
+    Guards against time-based vs frame-based drift: ``round(beat_sec * fps)``
+    must use the same fps that ``build_scene.py`` writes to
+    ``scene.render.fps``. The live ``scene.render.fps == config.fps`` check
+    belongs to integration (needs a running Blender) and is out of scope here.
+
+    Raises:
+        ValueError: when the two fps values disagree.
+    """
+    if int(config_fps) != int(harness_fps):
+        raise ValueError(
+            f"fps mismatch: config.fps={config_fps} but harness used "
+            f"{harness_fps}; round(beat_sec*fps) would drift from the rendered "
+            f"scene time. They must be identical."
+        )
+
+
+def _clamp_index(index: int, length: int) -> int:
+    """Clamp ``index`` into ``[0, length - 1]`` (mirrors GN SampleIndex clamp)."""
+    if index < 0:
+        return 0
+    if index >= length:
+        return length - 1
+    return index
+
+
+def sample_channel_at_frame(
+    channel: np.ndarray, frame: int, fps: int, dt: float
+) -> float:
+    """Sample a stored channel at a render frame via the ``Seconds/dt`` mapping.
+
+    Pure-python mirror of the live Geometry Nodes index sampling (Spike 2):
+    scene time is ``frame / fps``; the channel index is
+    ``round((frame / fps) / dt)`` clamped into range. Returns the *nearest
+    sample* value (no inter-sample interpolation — this checks the index
+    arithmetic, which is what the GN graph clamps and floors against).
+
+    Args:
+        channel: stored per-sample channel (e.g. ``beat_env``).
+        frame: render frame number.
+        fps: render fps (must match ``VisualizerConfig.fps``).
+        dt: sample spacing in seconds (``times[1] - times[0]``).
+
+    Returns:
+        The channel value at the clamped index, as a python float.
+    """
+    seconds = frame / fps
+    index = int(round(seconds / dt))
+    index = _clamp_index(index, len(channel))
+    return float(channel[index])
+
+
+@dataclass
+class BeatDeviation:
+    """Per-beat sync measurement."""
+
+    beat_time: float
+    expected_frame: int  # round(beat_time * fps)
+    peak_frame: int  # frame of the beat_env peak nearest beat_time
+    deviation: int  # |peak_frame - expected_frame|
+
+
+@dataclass
+class SyncReport:
+    """Structured result of :func:`verify_sync`.
+
+    Attributes:
+        deviations: per-beat measurements (empty for a beatless track).
+        max_deviation: largest per-beat deviation in frames (0 if no beats).
+        n_tolerance_frames: the internal tolerance applied.
+        passed: ``True`` iff ``max_deviation <= n_tolerance_frames`` (vacuously
+            ``True`` for a beatless track).
+        sample_rate: source track sample rate (R3 traceability).
+        fps: fps used for the frame arithmetic.
+        dt: sample spacing used.
+    """
+
+    deviations: List[BeatDeviation] = field(default_factory=list)
+    max_deviation: int = 0
+    n_tolerance_frames: int = DEFAULT_N_TOLERANCE_FRAMES
+    passed: bool = True
+    sample_rate: int = 0
+    fps: int = 0
+    dt: float = 0.0
+
+
+def _peak_frame_near(beat_env: np.ndarray, beat_time: float, dt: float, fps: int) -> int:
+    """Frame of the ``beat_env`` peak sample nearest ``beat_time``.
+
+    The envelope was precomputed to peak (==1.0) at ``round(beat_time/dt)`` and
+    decay afterward. We search a small index window around that expected index
+    for the argmax, then convert the winning *index* to a *frame* via
+    ``round((index * dt) * fps)``. Searching a window (rather than trusting the
+    exact index) is what makes this a measurement, not a tautology restatement:
+    if the precompute or the index arithmetic were off, the argmax would land
+    on a different sample and the deviation would grow.
+    """
+    n = len(beat_env)
+    center = _clamp_index(int(round(beat_time / dt)), n)
+    # Window spans roughly +/- one frame in samples (>= 1), so the argmax is
+    # free to drift to an adjacent sample if the placement were wrong.
+    half = max(1, int(round((1.0 / fps) / dt)))
+    lo = _clamp_index(center - half, n)
+    hi = _clamp_index(center + half, n)
+    window = beat_env[lo : hi + 1]
+    peak_index = lo + int(np.argmax(window))
+    return int(round((peak_index * dt) * fps))
+
+
+def verify_sync(
+    analysis_data: AnalysisData,
+    n_tolerance_frames: int = DEFAULT_N_TOLERANCE_FRAMES,
+) -> SyncReport:
+    """Verify data-timing sync of the precomputed beat envelope (R2/R3).
+
+    For each beat time ``t`` derived from ``beat_env`` (reconstructed from the
+    envelope's peaks): the expected render frame is ``round(t * fps)``; the
+    measured peak frame comes from the envelope's argmax near ``t`` converted
+    to a frame. The deviation is ``|peak_frame - round(t * fps)|`` and must be
+    ``<= n_tolerance_frames``.
+
+    A beatless track (all-zero ``beat_env``) yields an empty, vacuously-passing
+    report — it does not crash.
+
+    See the module docstring for the scope/honesty note: this is a proof of
+    DATA timing, not visual/perceptual timing (R4).
+
+    Args:
+        analysis_data: loaded, normalized analysis (from ``load_analysis``).
+        n_tolerance_frames: internal tolerance (default
+            :data:`DEFAULT_N_TOLERANCE_FRAMES`); not a config field.
+
+    Returns:
+        A :class:`SyncReport`.
+    """
+    beat_env = np.asarray(analysis_data.beat_env)
+    dt = analysis_data.dt
+    fps = analysis_data.fps
+
+    beat_times = _reconstruct_beat_times(beat_env, dt)
+
+    deviations: List[BeatDeviation] = []
+    for t in beat_times:
+        expected_frame = int(round(t * fps))
+        peak_frame = _peak_frame_near(beat_env, t, dt, fps)
+        deviations.append(
+            BeatDeviation(
+                beat_time=float(t),
+                expected_frame=expected_frame,
+                peak_frame=peak_frame,
+                deviation=abs(peak_frame - expected_frame),
+            )
+        )
+
+    max_dev = max((d.deviation for d in deviations), default=0)
+    return SyncReport(
+        deviations=deviations,
+        max_deviation=max_dev,
+        n_tolerance_frames=n_tolerance_frames,
+        passed=max_dev <= n_tolerance_frames,
+        sample_rate=analysis_data.sample_rate,
+        fps=fps,
+        dt=dt,
+    )
+
+
+def _reconstruct_beat_times(beat_env: np.ndarray, dt: float) -> List[float]:
+    """Recover beat times (seconds) from the precomputed ``beat_env`` peaks.
+
+    A beat sets its sample to exactly ``1.0`` (the envelope's max) and then
+    decays. We treat the rising edges into a ``1.0`` sample as beat onsets:
+    indices where ``env == 1.0`` whose previous sample is strictly smaller (or
+    which start the array). Converting index -> seconds is ``index * dt``.
+
+    Working from the envelope (rather than re-reading the source beat list)
+    keeps this harness honest about what was actually baked into the data
+    object the GN graph samples.
+    """
+    if len(beat_env) == 0:
+        return []
+    is_peak = np.isclose(beat_env, 1.0)
+    if not is_peak.any():
+        return []
+    prev = np.empty_like(beat_env)
+    prev[0] = -1.0
+    prev[1:] = beat_env[:-1]
+    onsets = np.flatnonzero(is_peak & (beat_env > prev))
+    return [float(i * dt) for i in onsets]

--- a/packages/cymatic/tests/conftest.py
+++ b/packages/cymatic/tests/conftest.py
@@ -16,6 +16,18 @@ if str(blender_script_path) not in sys.path:
     sys.path.insert(0, str(blender_script_path))
 
 
+# Markers are registered in pyproject.toml. Tests are unit tests by default, so
+# tag any test that carries no explicit marker as `unit` — this keeps
+# ``pytest -m unit`` meaningful (non-empty) without retagging every module.
+_EXPLICIT_MARKERS = {"integration", "slow", "unit"}
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if not any(m.name in _EXPLICIT_MARKERS for m in item.iter_markers()):
+            item.add_marker(pytest.mark.unit)
+
+
 @pytest.fixture(autouse=True)
 def mock_bpy(monkeypatch):
     """Mock bpy module for tests running outside Blender."""

--- a/packages/cymatic/tests/conftest.py
+++ b/packages/cymatic/tests/conftest.py
@@ -1,0 +1,51 @@
+# ABOUTME: Pytest configuration and fixtures for cymatic tests
+# ABOUTME: Provides mock bpy + mock subprocess; injects blender_script/ on sys.path
+
+"""Pytest configuration for cymatic tests (pattern from cinemon)."""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+# Add blender_script to Python path so tests can import in-Blender modules.
+blender_script_path = Path(__file__).parent.parent / "blender_script"
+if str(blender_script_path) not in sys.path:
+    sys.path.insert(0, str(blender_script_path))
+
+
+@pytest.fixture(autouse=True)
+def mock_bpy(monkeypatch):
+    """Mock bpy module for tests running outside Blender."""
+    if "bpy" not in sys.modules:
+        mock = Mock()
+
+        # Mock scene render settings
+        mock.context.scene.render.resolution_x = 1920
+        mock.context.scene.render.resolution_y = 1080
+        mock.context.scene.render.fps = 30
+        mock.context.scene.frame_start = 1
+        mock.context.scene.frame_end = 900  # 30 seconds at 30fps
+
+        # Add to sys.modules
+        monkeypatch.setitem(sys.modules, "bpy", mock)
+
+        # Return mock for tests that need to configure it further
+        return mock
+
+    # If bpy already exists, return it
+    return sys.modules["bpy"]
+
+
+@pytest.fixture(autouse=True)
+def mock_subprocess(monkeypatch):
+    """Mock subprocess.run to prevent actual Blender execution in tests."""
+    mock_result = Mock()
+    mock_result.stdout = "Blender execution mocked"
+    mock_result.stderr = ""
+    mock_result.returncode = 0
+
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=mock_result))
+    monkeypatch.setattr(subprocess, "Popen", Mock())

--- a/packages/cymatic/tests/test_analysis_loader.py
+++ b/packages/cymatic/tests/test_analysis_loader.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 
 from cymatic.analysis_loader import load_analysis
-from cymatic.config import VisualizerConfig
+from cymatic.config import PresetParams, VisualizerConfig
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIX_48K = REPO_ROOT / "research/audio/analysis/jazz_120s_48k_analysis.json"
@@ -147,6 +147,57 @@ class TestErrorPaths:
         missing = tmp_path / "does_not_exist_analysis.json"
         with pytest.raises(FileNotFoundError):
             load_analysis(_config(missing))
+
+    def test_missing_required_key_raises_value_error_with_path(self, tmp_path):
+        # Malformed JSON missing 'frequency_bands' -> clear ValueError naming the
+        # missing key AND the file path (not a bare KeyError).
+        bad = {"sample_rate": 44100, "duration": 1.0}
+        p = tmp_path / "broken_analysis.json"
+        p.write_text(json.dumps(bad))
+        with pytest.raises(ValueError) as exc:
+            load_analysis(_config(p))
+        msg = str(exc.value)
+        assert "frequency_bands" in msg
+        assert str(p) in msg
+
+    def test_missing_sample_rate_key_raises_value_error(self, tmp_path):
+        d = json.loads(FIX_48K.read_text())
+        del d["sample_rate"]
+        p = tmp_path / "nosr_analysis.json"
+        p.write_text(json.dumps(d))
+        with pytest.raises(ValueError) as exc:
+            load_analysis(_config(p))
+        assert "sample_rate" in str(exc.value)
+
+
+class TestRawEventTimesAndPreset:
+    def test_raw_beat_times_populated_from_json(self):
+        d = json.loads(FIX_48K.read_text())
+        res = load_analysis(_config(FIX_48K))
+        # raw times are the ORIGINAL JSON beats, kept as sync ground truth.
+        assert res.raw_beat_times == [
+            float(t) for t in d["animation_events"]["beats"]
+        ]
+
+    def test_preset_decay_changes_beat_envelope(self):
+        cfg_fast = _config(FIX_48K)
+        cfg_fast.preset = PresetParams(decay=0.05, tau=0.05)
+        cfg_slow = _config(FIX_48K)
+        cfg_slow.preset = PresetParams(decay=0.5, tau=0.5)
+
+        env_fast = load_analysis(cfg_fast).beat_env
+        env_slow = load_analysis(cfg_slow).beat_env
+        # Different decay -> different envelope (slower decay holds higher).
+        assert not np.array_equal(env_fast, env_slow)
+        assert env_slow.sum() > env_fast.sum()
+
+    def test_analysis_data_equality_does_not_raise(self):
+        # eq=False on AnalysisData means identity comparison; comparing two
+        # results must not raise the ambiguous-array-truth ValueError.
+        a = load_analysis(_config(FIX_48K))
+        b = load_analysis(_config(FIX_48K))
+        assert (a == b) is False  # distinct instances, identity-based eq
+        assert (a == a) is True
 
 
 class TestFullPipeline:

--- a/packages/cymatic/tests/test_analysis_loader.py
+++ b/packages/cymatic/tests/test_analysis_loader.py
@@ -1,0 +1,172 @@
+# ABOUTME: Tests for cymatic.analysis_loader (load beatrix JSON -> normalized arrays + dt)
+# ABOUTME: Uses real fixtures of different sample_rate (R3): 48k and 44k jazz.
+
+"""Tests for analysis_loader.load_analysis.
+
+Covers Unit 5 scenarios:
+- bands normalized to [0,1], length == len(times)
+- dt derived per sample_rate (R3: 48k and 44k give different dt)
+- len(times) < 2 -> clear error (not IndexError)
+- empty energy_peaks -> peak_env all zeros, no exception
+- fps read from VisualizerConfig, not from JSON
+- full loader pipeline on a real file -> equal-length arrays
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cymatic.analysis_loader import load_analysis
+from cymatic.config import VisualizerConfig
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIX_48K = REPO_ROOT / "research/audio/analysis/jazz_120s_48k_analysis.json"
+FIX_44K = REPO_ROOT / "research/audio/analysis/jazz_120s_44k_analysis.json"
+FIX_BEATRIX = (
+    REPO_ROOT
+    / "packages/beatrix/tests/fixtures/audio/beats_120bpm_5s_analysis.json"
+)
+
+
+def _config(analysis_file: Path, fps: int = 30, base_directory: str = "") -> VisualizerConfig:
+    return VisualizerConfig(
+        analysis_file=str(analysis_file),
+        output_mp4="/tmp/out.mp4",
+        base_directory=base_directory or str(analysis_file.parent),
+        fps=fps,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _require_fixtures():
+    for f in (FIX_48K, FIX_44K, FIX_BEATRIX):
+        if not f.exists():
+            pytest.skip(f"fixture missing: {f}")
+
+
+class TestBandsNormalized:
+    def test_bands_in_unit_interval(self):
+        res = load_analysis(_config(FIX_48K))
+        for band in (res.bass, res.mid, res.high):
+            assert band.min() >= 0.0
+            assert band.max() <= 1.0
+
+    def test_band_lengths_equal_times(self):
+        res = load_analysis(_config(FIX_48K))
+        d = json.loads(FIX_48K.read_text())
+        n = len(d["frequency_bands"]["times"])
+        assert len(res.bass) == n
+        assert len(res.mid) == n
+        assert len(res.high) == n
+
+
+class TestDtPerSampleRate:
+    def test_dt_48k(self):
+        res = load_analysis(_config(FIX_48K))
+        assert res.sample_rate == 48000
+        assert res.dt == pytest.approx(0.010667, abs=1e-5)
+
+    def test_dt_44k(self):
+        res = load_analysis(_config(FIX_44K))
+        assert res.sample_rate == 44100
+        assert res.dt == pytest.approx(0.011610, abs=1e-5)
+
+    def test_dt_differs_across_sample_rates(self):
+        r48 = load_analysis(_config(FIX_48K))
+        r44 = load_analysis(_config(FIX_44K))
+        assert r48.dt != r44.dt
+
+    def test_dt_consistent_with_hop_over_sr(self):
+        # dt should equal hop_length(512)/sample_rate
+        res = load_analysis(_config(FIX_48K))
+        assert res.dt == pytest.approx(512 / 48000, abs=1e-5)
+
+
+class TestDegenerateTimes:
+    def test_len_times_below_two_raises_clear_error(self, tmp_path):
+        bad = {
+            "duration": 0.0,
+            "sample_rate": 44100,
+            "animation_events": {"beats": [], "energy_peaks": []},
+            "frequency_bands": {
+                "times": [0.0],
+                "bass_energy": [0.0],
+                "mid_energy": [0.0],
+                "high_energy": [0.0],
+            },
+        }
+        p = tmp_path / "x_analysis.json"
+        p.write_text(json.dumps(bad))
+        with pytest.raises(ValueError) as exc:
+            load_analysis(_config(p))
+        # must be a clear domain error, not a raw IndexError
+        assert not isinstance(exc.value, IndexError)
+        msg = str(exc.value).lower()
+        assert "times" in msg
+
+
+class TestEnvelopes:
+    def test_empty_energy_peaks_zeros(self, tmp_path):
+        d = json.loads(FIX_48K.read_text())
+        d["animation_events"]["energy_peaks"] = []
+        p = tmp_path / "nopeaks_analysis.json"
+        p.write_text(json.dumps(d))
+        res = load_analysis(_config(p))
+        assert np.all(res.peak_env == 0.0)
+        assert len(res.peak_env) == len(res.bass)
+
+    def test_envelopes_equal_length(self):
+        res = load_analysis(_config(FIX_48K))
+        n = len(res.bass)
+        assert len(res.beat_env) == n
+        assert len(res.peak_env) == n
+
+    def test_beat_env_has_signal(self):
+        res = load_analysis(_config(FIX_48K))
+        assert res.beat_env.max() > 0.0
+
+
+class TestFpsFromConfig:
+    def test_fps_read_from_config_not_json(self):
+        # beatrix JSON has NO fps key; loader must take it from config.
+        d = json.loads(FIX_48K.read_text())
+        assert "fps" not in d
+        res = load_analysis(_config(FIX_48K, fps=60))
+        assert res.fps == 60
+
+    def test_missing_fps_key_no_error(self):
+        # absence of 'fps' in JSON must not raise
+        res = load_analysis(_config(FIX_48K, fps=24))
+        assert res.fps == 24
+
+
+class TestErrorPaths:
+    def test_missing_analysis_file(self, tmp_path):
+        missing = tmp_path / "does_not_exist_analysis.json"
+        with pytest.raises(FileNotFoundError):
+            load_analysis(_config(missing))
+
+
+class TestFullPipeline:
+    def test_real_file_equal_length_arrays(self):
+        res = load_analysis(_config(FIX_44K))
+        n = len(res.bass)
+        for arr in (res.bass, res.mid, res.high, res.beat_env, res.peak_env):
+            assert len(arr) == n
+            assert arr.dtype == np.float32
+
+    def test_metadata_populated(self):
+        res = load_analysis(_config(FIX_44K))
+        assert res.sample_rate == 44100
+        assert res.duration == pytest.approx(120.0)
+        assert res.dt > 0
+
+    def test_beatrix_synthetic_fixture(self):
+        # different source (synthetic beatrix fixture, sr 44100)
+        res = load_analysis(_config(FIX_BEATRIX))
+        n = len(res.bass)
+        assert res.sample_rate == 44100
+        assert len(res.beat_env) == n
+        assert len(res.peak_env) == n

--- a/packages/cymatic/tests/test_analysis_loader.py
+++ b/packages/cymatic/tests/test_analysis_loader.py
@@ -200,6 +200,42 @@ class TestRawEventTimesAndPreset:
         assert (a == a) is True
 
 
+class TestNonFiniteEventTimes:
+    def test_nan_beat_time_filtered_not_loaded(self, tmp_path):
+        # A corrupt/hand-crafted analysis with NaN/inf beat times must not reach
+        # verify_sync as a non-finite value (int(round(nan*fps)) -> ValueError).
+        # The loader drops non-finite event times with a warning.
+        d = json.loads(FIX_48K.read_text())
+        good = [float(t) for t in d["animation_events"]["beats"][:3]]
+        d["animation_events"]["beats"] = [float("nan"), good[0], float("inf"), good[1]]
+        d["animation_events"]["energy_peaks"] = [good[2], float("-inf")]
+        p = tmp_path / "nan_analysis.json"
+        p.write_text(json.dumps(d))
+
+        res = load_analysis(_config(p))
+
+        assert all(np.isfinite(t) for t in res.raw_beat_times)
+        assert all(np.isfinite(t) for t in res.raw_peak_times)
+        # Only the finite originals survive, order preserved.
+        assert res.raw_beat_times == [good[0], good[1]]
+        assert res.raw_peak_times == [good[2]]
+
+    def test_nan_beat_time_does_not_crash_verify_sync(self, tmp_path):
+        from cymatic.sync_verification import verify_sync
+
+        d = json.loads(FIX_48K.read_text())
+        d["animation_events"]["beats"] = [float("nan")] + [
+            float(t) for t in d["animation_events"]["beats"][:5]
+        ]
+        p = tmp_path / "nan2_analysis.json"
+        p.write_text(json.dumps(d))
+
+        res = load_analysis(_config(p))
+        # Must produce a SyncReport, not raise ValueError on the NaN.
+        report = verify_sync(res)
+        assert report is not None
+
+
 class TestFullPipeline:
     def test_real_file_equal_length_arrays(self):
         res = load_analysis(_config(FIX_44K))

--- a/packages/cymatic/tests/test_build_scene.py
+++ b/packages/cymatic/tests/test_build_scene.py
@@ -1,0 +1,168 @@
+# ABOUTME: Tests for the in-Blender orchestration entry point (Unit 8)
+# ABOUTME: Structural via mock bpy + spies; live correctness proven in Spike 0/2
+
+"""Unit 8 tests: build_scene.main() ties config -> data-object -> sampler -> preset.
+
+These are STRUCTURAL assertions against the autouse ``mock_bpy`` fixture
+(conftest). Live visual correctness was already proven in Spike 0/2 (Blender
+5.1.2). Here we only verify orchestration:
+
+  - ``main()`` parses ``--config`` and loads the ``VisualizerConfig``,
+  - it calls data_object builder, then sampler builder, then the preset's
+    ``build_scene`` in that order, threading the loaded analysis through,
+  - it returns 0 on success,
+  - a missing ``--config`` yields a non-zero code with a clear error.
+
+The host-side numpy modules (analysis_loader / normalization) are pure-numpy
+(no bpy) and are imported by build_scene by injecting the package ``src/`` onto
+sys.path; the loader itself is spied so these tests stay structural.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# Make the in-Blender module importable (also done in conftest; defensive).
+blender_script_path = Path(__file__).parent.parent / "blender_script"
+if str(blender_script_path) not in sys.path:
+    sys.path.insert(0, str(blender_script_path))
+
+import build_scene  # noqa: E402
+
+
+def _write_config(tmp_path: Path) -> Path:
+    """Write a minimal serialized VisualizerConfig to a temp file."""
+    cfg = {
+        "analysis_file": str(tmp_path / "song_analysis.json"),
+        "output_mp4": str(tmp_path / "out.mp4"),
+        "base_directory": str(tmp_path),
+        "fps": 30,
+        "resolution": [1280, 720],
+        "blender_executable": "/bin/true",
+        "preset": {
+            "palette": "default",
+            "primitive": "icosphere",
+            "accent_intensity": 0.5,
+            "decay": 0.13,
+            "tau": 0.15,
+        },
+    }
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg))
+    return p
+
+
+def _fake_analysis():
+    """A MagicMock standing in for analysis_loader.AnalysisData."""
+    n = 16
+    data = MagicMock(name="AnalysisData")
+    data.bass = np.linspace(0, 1, n, dtype=np.float32)
+    data.mid = np.linspace(0, 1, n, dtype=np.float32)
+    data.high = np.linspace(0, 1, n, dtype=np.float32)
+    data.beat_env = np.zeros(n, dtype=np.float32)
+    data.peak_env = np.zeros(n, dtype=np.float32)
+    data.times = np.arange(n, dtype=float) * 0.01
+    data.dt = 0.01
+    data.sample_rate = 48000
+    data.duration = n * 0.01
+    data.fps = 30
+    return data
+
+
+@pytest.fixture
+def spies(tmp_path):
+    """Patch the three collaborators build_scene orchestrates and the loader."""
+    cfg_path = _write_config(tmp_path)
+    analysis = _fake_analysis()
+
+    with patch.object(
+        build_scene, "load_analysis", return_value=analysis
+    ) as load, patch.object(
+        build_scene, "build_data_object", return_value=MagicMock(name="data_obj")
+    ) as data_obj, patch.object(
+        build_scene, "build_sampler_group", return_value=MagicMock(name="sampler")
+    ) as sampler, patch.object(
+        build_scene, "build_preset_scene", return_value=MagicMock(name="scene")
+    ) as preset:
+        yield {
+            "cfg_path": cfg_path,
+            "analysis": analysis,
+            "load": load,
+            "data_obj": data_obj,
+            "sampler": sampler,
+            "preset": preset,
+        }
+
+
+def test_main_returns_zero_on_success(mock_bpy, spies):
+    rc = build_scene.main(["--config", str(spies["cfg_path"])])
+    assert rc == 0
+
+
+def test_main_loads_config_and_analysis(mock_bpy, spies):
+    build_scene.main(["--config", str(spies["cfg_path"])])
+    spies["load"].assert_called_once()
+    # load_analysis received a VisualizerConfig with our analysis_file.
+    (cfg_arg,), _ = spies["load"].call_args
+    assert cfg_arg.fps == 30
+    assert cfg_arg.analysis_file.endswith("song_analysis.json")
+
+
+def test_main_calls_collaborators_in_order(mock_bpy, spies):
+    """data_object -> sampler -> preset, threading analysis + sampler through."""
+    manager = MagicMock()
+    manager.attach_mock(spies["load"], "load")
+    manager.attach_mock(spies["data_obj"], "data_obj")
+    manager.attach_mock(spies["sampler"], "sampler")
+    manager.attach_mock(spies["preset"], "preset")
+
+    build_scene.main(["--config", str(spies["cfg_path"])])
+
+    order = [c[0] for c in manager.mock_calls if c[0] in
+             ("load", "data_obj", "sampler", "preset")]
+    assert order == ["load", "data_obj", "sampler", "preset"]
+
+
+def test_sampler_receives_data_object(mock_bpy, spies):
+    build_scene.main(["--config", str(spies["cfg_path"])])
+    data_obj_ret = spies["data_obj"].return_value
+    _, sampler_kwargs = spies["sampler"].call_args
+    sampler_args = spies["sampler"].call_args.args
+    assert data_obj_ret in sampler_args or data_obj_ret in sampler_kwargs.values()
+
+
+def test_preset_receives_sampler(mock_bpy, spies):
+    build_scene.main(["--config", str(spies["cfg_path"])])
+    sampler_ret = spies["sampler"].return_value
+    preset_args = spies["preset"].call_args.args
+    preset_kwargs = spies["preset"].call_args.kwargs
+    assert sampler_ret in preset_args or sampler_ret in preset_kwargs.values()
+
+
+def test_data_object_built_from_five_channels(mock_bpy, spies):
+    build_scene.main(["--config", str(spies["cfg_path"])])
+    _, kwargs = spies["data_obj"].call_args
+    args = spies["data_obj"].call_args.args
+    # channels mapping is passed positionally or by keyword.
+    channels = kwargs.get("channels")
+    if channels is None:
+        channels = next((a for a in args if isinstance(a, dict)), None)
+    assert channels is not None
+    for name in ("bass_n", "mid_n", "high_n", "beat_env", "peak_env"):
+        assert name in channels
+
+
+def test_missing_config_returns_nonzero(mock_bpy):
+    rc = build_scene.main([])
+    assert rc != 0
+
+
+def test_missing_config_does_not_call_collaborators(mock_bpy):
+    with patch.object(build_scene, "load_analysis") as load:
+        rc = build_scene.main([])
+        assert rc != 0
+        load.assert_not_called()

--- a/packages/cymatic/tests/test_cli.py
+++ b/packages/cymatic/tests/test_cli.py
@@ -1,0 +1,130 @@
+# ABOUTME: Tests for the cymatic CLI (cymatic-render) — arg handling + error routing.
+# ABOUTME: Mocks the runner so no Blender/ffmpeg is needed; checks stdout/stderr split.
+
+"""Tests for cymatic.cli.main.
+
+Covers:
+- missing recording directory -> stderr + nonzero exit
+- missing analysis file -> stderr + nonzero exit
+- successful path (runner mocked) -> output path on stdout, exit 0
+- runner RuntimeError -> stderr + nonzero exit
+- audio forwarding: auto-detected and explicit --audio-file
+"""
+
+from pathlib import Path
+
+import pytest
+
+import cymatic.cli as cli
+
+
+@pytest.fixture
+def recording_dir(tmp_path):
+    """A recording dir with analysis/<stem>_analysis.json present."""
+    (tmp_path / "analysis").mkdir()
+    (tmp_path / "analysis" / "song_analysis.json").write_text("{}")
+    return tmp_path
+
+
+def test_missing_recording_dir_writes_stderr_and_returns_nonzero(tmp_path, capsys):
+    missing = tmp_path / "nope"
+    rc = cli.main([str(missing)])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "recording directory not found" in captured.err
+    assert captured.out == ""
+
+
+def test_missing_analysis_file_writes_stderr_and_returns_nonzero(
+    recording_dir, capsys
+):
+    rc = cli.main(
+        [str(recording_dir), "--analysis-file", str(recording_dir / "absent.json")]
+    )
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "Analysis file not found" in captured.err
+    assert captured.out == ""
+
+
+def test_successful_path_prints_output_on_stdout(recording_dir, capsys, monkeypatch):
+    analysis = recording_dir / "analysis" / "song_analysis.json"
+    fake_output = recording_dir / "blender" / "render" / "song.mp4"
+
+    captured_cfg = {}
+
+    def fake_render(config):
+        captured_cfg["config"] = config
+        return fake_output
+
+    monkeypatch.setattr(cli, "render", fake_render)
+
+    rc = cli.main([str(recording_dir), "--analysis-file", str(analysis), "--fps", "24"])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert str(fake_output) in out.out
+    assert out.err == ""
+    assert captured_cfg["config"].fps == 24
+    assert captured_cfg["config"].analysis_file == str(analysis)
+
+
+def test_runner_error_routes_to_stderr_and_nonzero(recording_dir, capsys, monkeypatch):
+    analysis = recording_dir / "analysis" / "song_analysis.json"
+
+    def boom(config):
+        raise RuntimeError("Blender execution failed: GN build error")
+
+    monkeypatch.setattr(cli, "render", boom)
+
+    rc = cli.main([str(recording_dir), "--analysis-file", str(analysis)])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "GN build error" in captured.err
+    assert captured.out == ""
+
+
+def test_explicit_audio_file_forwarded_to_config(recording_dir, monkeypatch):
+    analysis = recording_dir / "analysis" / "song_analysis.json"
+    audio = recording_dir / "my_audio.wav"
+    audio.write_bytes(b"RIFF")
+
+    captured_cfg = {}
+    monkeypatch.setattr(
+        cli, "render", lambda config: captured_cfg.setdefault("c", config) or Path("/x.mp4")
+    )
+
+    rc = cli.main(
+        [
+            str(recording_dir),
+            "--analysis-file",
+            str(analysis),
+            "--audio-file",
+            str(audio),
+        ]
+    )
+    assert rc == 0
+    assert captured_cfg["c"].audio_file == str(audio)
+
+
+def test_detected_audio_forwarded_when_no_explicit_flag(
+    recording_dir, monkeypatch
+):
+    # When detection runs (no --analysis-file), the detected audio is forwarded.
+    detected = recording_dir / "extracted" / "main.wav"
+
+    monkeypatch.setattr(
+        cli,
+        "_resolve_analysis_file",
+        lambda rd, af, ma: (
+            recording_dir / "analysis" / "song_analysis.json",
+            detected,
+        ),
+    )
+    captured_cfg = {}
+    monkeypatch.setattr(
+        cli, "render", lambda config: captured_cfg.setdefault("c", config) or Path("/x.mp4")
+    )
+
+    rc = cli.main([str(recording_dir)])
+    assert rc == 0
+    assert captured_cfg["c"].audio_file == str(detected)

--- a/packages/cymatic/tests/test_config.py
+++ b/packages/cymatic/tests/test_config.py
@@ -1,0 +1,143 @@
+# ABOUTME: Tests for cymatic config dataclasses (VisualizerConfig, PresetParams)
+# ABOUTME: TDD — round-trip serialization, defaults, and import smoke
+
+"""Tests for cymatic.config dataclasses."""
+
+import json
+
+import pytest
+
+
+def test_import_cymatic_smoke():
+    """Smoke test: the package imports cleanly."""
+    import cymatic  # noqa: F401
+
+
+def test_import_config_symbols():
+    """VisualizerConfig and PresetParams are importable from cymatic.config."""
+    from cymatic.config import PresetParams, VisualizerConfig  # noqa: F401
+
+
+class TestVisualizerConfig:
+    def _make(self):
+        from cymatic.config import VisualizerConfig
+
+        return VisualizerConfig(
+            analysis_file="/rec/analysis/song_analysis.json",
+            output_mp4="/rec/blender/render/song.mp4",
+            base_directory="/rec",
+            fps=60,
+            resolution=(1920, 1080),
+            blender_executable="/usr/bin/blender",
+        )
+
+    def test_to_dict_from_dict_roundtrip_lossless(self):
+        from cymatic.config import VisualizerConfig
+
+        cfg = self._make()
+        restored = VisualizerConfig.from_dict(cfg.to_dict())
+        assert restored == cfg
+
+    def test_to_json_from_json_roundtrip_lossless(self):
+        from cymatic.config import VisualizerConfig
+
+        cfg = self._make()
+        restored = VisualizerConfig.from_json(cfg.to_json())
+        assert restored == cfg
+
+    def test_json_is_valid_json_string(self):
+        cfg = self._make()
+        # Must parse as JSON and contain the resolution as a 2-element list
+        data = json.loads(cfg.to_json())
+        assert data["resolution"] == [1920, 1080]
+        assert data["fps"] == 60
+
+    def test_resolution_tuple_survives_roundtrip(self):
+        """resolution must come back as a tuple, not a list."""
+        from cymatic.config import VisualizerConfig
+
+        cfg = self._make()
+        restored = VisualizerConfig.from_json(cfg.to_json())
+        assert restored.resolution == (1920, 1080)
+        assert isinstance(restored.resolution, tuple)
+
+    def test_defaults_fps_and_resolution_and_executable(self):
+        """fps defaults to 30, resolution defaults to None, executable to macOS path."""
+        from cymatic.config import VisualizerConfig
+
+        cfg = VisualizerConfig(
+            analysis_file="/a.json",
+            output_mp4="/o.mp4",
+            base_directory="/b",
+        )
+        assert cfg.fps == 30
+        assert cfg.resolution is None
+        assert cfg.blender_executable == (
+            "/Applications/Blender.app/Contents/MacOS/Blender"
+        )
+
+    def test_resolution_none_roundtrip(self):
+        """resolution=None survives serialization round-trip."""
+        from cymatic.config import VisualizerConfig
+
+        cfg = VisualizerConfig(
+            analysis_file="/a.json",
+            output_mp4="/o.mp4",
+            base_directory="/b",
+        )
+        restored = VisualizerConfig.from_json(cfg.to_json())
+        assert restored.resolution is None
+        assert restored == cfg
+
+    def test_no_n_tolerance_frames_field(self):
+        """n_tolerance_frames belongs to the sync harness (Unit 10), not config."""
+        cfg = self._make()
+        assert not hasattr(cfg, "n_tolerance_frames")
+
+
+class TestPresetParams:
+    def _make(self):
+        from cymatic.config import PresetParams
+
+        return PresetParams(
+            palette="neon",
+            primitive="icosphere",
+            accent_intensity=0.8,
+            decay=0.25,
+            tau=0.15,
+        )
+
+    def test_to_dict_from_dict_roundtrip_lossless(self):
+        from cymatic.config import PresetParams
+
+        params = self._make()
+        restored = PresetParams.from_dict(params.to_dict())
+        assert restored == params
+
+    def test_to_json_from_json_roundtrip_lossless(self):
+        from cymatic.config import PresetParams
+
+        params = self._make()
+        restored = PresetParams.from_json(params.to_json())
+        assert restored == params
+
+
+def test_visualizer_config_can_embed_preset_params():
+    """A VisualizerConfig carrying a PresetParams round-trips losslessly."""
+    from cymatic.config import PresetParams, VisualizerConfig
+
+    cfg = VisualizerConfig(
+        analysis_file="/a.json",
+        output_mp4="/o.mp4",
+        base_directory="/b",
+        preset=PresetParams(
+            palette="vintage",
+            primitive="cube",
+            accent_intensity=0.5,
+            decay=0.3,
+            tau=0.2,
+        ),
+    )
+    restored = VisualizerConfig.from_json(cfg.to_json())
+    assert restored == cfg
+    assert restored.preset.palette == "vintage"

--- a/packages/cymatic/tests/test_config.py
+++ b/packages/cymatic/tests/test_config.py
@@ -62,7 +62,14 @@ class TestVisualizerConfig:
         assert isinstance(restored.resolution, tuple)
 
     def test_defaults_fps_and_resolution_and_executable(self):
-        """fps defaults to 30, resolution defaults to None, executable to macOS path."""
+        """fps defaults to 30, resolution defaults to None, executable resolves via PATH.
+
+        The executable default is ``shutil.which("blender")`` (cross-platform),
+        so it equals that lookup rather than a hardcoded platform path — it may
+        legitimately be ``None`` when Blender is not installed.
+        """
+        import shutil
+
         from cymatic.config import VisualizerConfig
 
         cfg = VisualizerConfig(
@@ -72,9 +79,7 @@ class TestVisualizerConfig:
         )
         assert cfg.fps == 30
         assert cfg.resolution is None
-        assert cfg.blender_executable == (
-            "/Applications/Blender.app/Contents/MacOS/Blender"
-        )
+        assert cfg.blender_executable == shutil.which("blender")
 
     def test_resolution_none_roundtrip(self):
         """resolution=None survives serialization round-trip."""
@@ -120,6 +125,61 @@ class TestPresetParams:
         params = self._make()
         restored = PresetParams.from_json(params.to_json())
         assert restored == params
+
+    def test_from_dict_rebuilds_from_fields(self):
+        # from_dict iterates dataclass fields, so a full dict round-trips and a
+        # missing key surfaces as a clear KeyError (not a silent wrong value).
+        from cymatic.config import PresetParams
+
+        params = self._make()
+        assert PresetParams.from_dict(params.to_dict()) == params
+        with pytest.raises(KeyError):
+            PresetParams.from_dict({"palette": "x"})
+
+    def test_decay_must_be_positive(self):
+        from cymatic.config import PresetParams
+
+        with pytest.raises(ValueError, match="decay"):
+            PresetParams(decay=0.0)
+
+    def test_tau_must_be_positive(self):
+        from cymatic.config import PresetParams
+
+        with pytest.raises(ValueError, match="tau"):
+            PresetParams(tau=-0.1)
+
+
+class TestExecutableDefaultAndTimeouts:
+    def test_executable_default_matches_which_blender(self):
+        import shutil
+
+        from cymatic.config import DEFAULT_BLENDER_EXECUTABLE
+
+        assert DEFAULT_BLENDER_EXECUTABLE == shutil.which("blender")
+
+    def test_timeout_fields_roundtrip(self):
+        from cymatic.config import VisualizerConfig
+
+        cfg = VisualizerConfig(
+            analysis_file="/a.json",
+            output_mp4="/o.mp4",
+            base_directory="/b",
+            blender_timeout_sec=120,
+            ffmpeg_timeout_sec=45,
+        )
+        restored = VisualizerConfig.from_json(cfg.to_json())
+        assert restored.blender_timeout_sec == 120
+        assert restored.ffmpeg_timeout_sec == 45
+        assert restored == cfg
+
+    def test_timeout_defaults(self):
+        from cymatic.config import VisualizerConfig
+
+        cfg = VisualizerConfig(
+            analysis_file="/a.json", output_mp4="/o.mp4", base_directory="/b"
+        )
+        assert cfg.blender_timeout_sec == 3600
+        assert cfg.ffmpeg_timeout_sec == 600
 
 
 def test_visualizer_config_can_embed_preset_params():

--- a/packages/cymatic/tests/test_data_object.py
+++ b/packages/cymatic/tests/test_data_object.py
@@ -1,0 +1,126 @@
+# ABOUTME: Tests for the in-Blender data-object builder (numpy -> mesh + attrs)
+# ABOUTME: Structural assertions via mock bpy; GN-sampling correctness proven in Spike 2
+
+"""Unit 6 tests: build_data_object turns numpy channels into a Blender mesh.
+
+These are structural assertions against the autouse ``mock_bpy`` fixture
+(conftest). Real GN-sampling correctness was already proven empirically in
+Spike 2 (research/spike2_gn_sampling.py, Blender 5.1.2). Here we only verify
+that the builder calls the bpy API correctly:
+
+  - one FLOAT/POINT attribute per channel via ``attributes.new``,
+  - ``vertices.add(N)`` with the right N,
+  - ``foreach_set`` receives a length-N buffer,
+  - mismatched channel lengths raise.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Make the in-Blender module importable (also done in conftest, kept defensive).
+blender_script_path = Path(__file__).parent.parent / "blender_script"
+if str(blender_script_path) not in sys.path:
+    sys.path.insert(0, str(blender_script_path))
+
+import data_object  # noqa: E402
+
+build_data_object = data_object.build_data_object
+
+
+CHANNEL_NAMES = ["bass_n", "mid_n", "high_n", "beat_env", "peak_env"]
+
+
+def _channels(n):
+    """Five equal-length float channels of length ``n``."""
+    return {name: np.linspace(0.0, 1.0, n, dtype=np.float64) for name in CHANNEL_NAMES}
+
+
+def test_creates_attribute_for_each_channel(mock_bpy):
+    n = 8
+    build_data_object("audio_data", dt=0.01, channels=_channels(n))
+
+    mesh = mock_bpy.data.meshes.new.return_value
+    created = [c.kwargs.get("name") for c in mesh.attributes.new.call_args_list]
+    for name in CHANNEL_NAMES:
+        assert name in created
+    assert mesh.attributes.new.call_count == len(CHANNEL_NAMES)
+
+
+def test_attributes_are_float_point(mock_bpy):
+    build_data_object("audio_data", dt=0.01, channels=_channels(8))
+
+    mesh = mock_bpy.data.meshes.new.return_value
+    for call in mesh.attributes.new.call_args_list:
+        assert call.kwargs.get("type") == "FLOAT"
+        assert call.kwargs.get("domain") == "POINT"
+
+
+def test_vertices_add_called_with_n(mock_bpy):
+    n = 13
+    build_data_object("audio_data", dt=0.01, channels=_channels(n))
+
+    mesh = mock_bpy.data.meshes.new.return_value
+    mesh.vertices.add.assert_called_once_with(n)
+
+
+def test_attribute_foreach_set_receives_length_n_buffer(mock_bpy):
+    n = 10
+    build_data_object("audio_data", dt=0.01, channels=_channels(n))
+
+    mesh = mock_bpy.data.meshes.new.return_value
+    attr = mesh.attributes.new.return_value
+    # One foreach_set("value", buf) per channel.
+    assert attr.data.foreach_set.call_count == len(CHANNEL_NAMES)
+    for call in attr.data.foreach_set.call_args_list:
+        key, buf = call.args
+        assert key == "value"
+        assert len(buf) == n
+
+
+def test_attribute_buffer_is_float32_contiguous(mock_bpy):
+    build_data_object("audio_data", dt=0.01, channels=_channels(7))
+
+    mesh = mock_bpy.data.meshes.new.return_value
+    attr = mesh.attributes.new.return_value
+    for call in attr.data.foreach_set.call_args_list:
+        _, buf = call.args
+        assert isinstance(buf, np.ndarray)
+        assert buf.dtype == np.float32
+        assert buf.flags["C_CONTIGUOUS"]
+
+
+def test_x_positions_are_arange_times_dt(mock_bpy):
+    n = 6
+    dt = 0.0125
+    build_data_object("audio_data", dt=dt, channels=_channels(n))
+
+    mesh = mock_bpy.data.meshes.new.return_value
+    # vertices.foreach_set("co", co) where co[0::3] == arange(N)*dt
+    co_calls = [
+        c for c in mesh.vertices.foreach_set.call_args_list if c.args and c.args[0] == "co"
+    ]
+    assert len(co_calls) == 1
+    co = co_calls[0].args[1]
+    assert len(co) == n * 3
+    np.testing.assert_allclose(co[0::3], np.arange(n) * dt)
+
+
+def test_mismatched_channel_lengths_raise(mock_bpy):
+    channels = _channels(8)
+    channels["mid_n"] = np.linspace(0.0, 1.0, 5, dtype=np.float64)  # wrong length
+
+    with pytest.raises(ValueError):
+        build_data_object("audio_data", dt=0.01, channels=channels)
+
+
+def test_empty_channels_raise(mock_bpy):
+    with pytest.raises(ValueError):
+        build_data_object("audio_data", dt=0.01, channels={})
+
+
+def test_returns_object(mock_bpy):
+    obj = build_data_object("audio_data", dt=0.01, channels=_channels(8))
+    assert obj is mock_bpy.data.objects.new.return_value

--- a/packages/cymatic/tests/test_gn_sampler.py
+++ b/packages/cymatic/tests/test_gn_sampler.py
@@ -1,0 +1,213 @@
+# ABOUTME: Tests for the in-Blender GN sampler builder (bridge-B, Spike 2)
+# ABOUTME: Structural / API-shape assertions via mock bpy; live correctness proven in Spike 2
+
+"""Unit 7 tests: build_sampler_group builds the GN time-sampling node group.
+
+These are STRUCTURAL assertions against the autouse ``mock_bpy`` fixture
+(conftest). Real sampling correctness was already proven live in Spike 2
+(research/spike2_gn_sampling.py, Blender 5.1.2, max abs err ~6e-08). Here we
+only guard structure / API shape:
+
+  - a ``GeometryNodeTree`` node group is created,
+  - sockets are created via ``interface.new_socket`` (the 4.0+ API), NOT via the
+    removed ``node_group.inputs`` / ``node_group.outputs`` collections,
+  - the expected node ``bl_idname``s are instantiated,
+  - ``clamp=True`` and ``data_type='FLOAT'`` are set on the Sample Index nodes,
+  - ``dt`` is threaded through as a node default (not hardcoded).
+
+NOTE (plan/feasibility review): a plain ``Mock`` fabricates every attribute, so a
+naive ``mock_ng.inputs`` and ``mock_ng.interface`` are indistinguishably truthy
+and a mock test cannot detect a 3.x->4.x regression by attribute existence. We
+therefore use a ``spec``-restricted node-group mock whose ``inputs``/``outputs``
+attributes do NOT exist: touching them raises ``AttributeError``. That asserts on
+the *code path* — the builder must route through ``interface.new_socket``.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make the in-Blender module importable (also done in conftest; defensive).
+blender_script_path = Path(__file__).parent.parent / "blender_script"
+if str(blender_script_path) not in sys.path:
+    sys.path.insert(0, str(blender_script_path))
+
+import gn_sampler  # noqa: E402
+
+build_sampler_group = gn_sampler.build_sampler_group
+DEFAULT_CHANNELS = gn_sampler.DEFAULT_CHANNELS
+
+
+class _NodeGroup:
+    """Stand-in for a GeometryNodeTree.
+
+    Crucially has ``interface``, ``nodes``, ``links`` but NO ``inputs`` /
+    ``outputs`` attributes — so any use of the removed 3.x API raises
+    ``AttributeError`` rather than being silently fabricated by ``Mock``.
+    """
+
+    def __init__(self):
+        self.interface = MagicMock()
+        self.nodes = MagicMock()
+        self.links = MagicMock()
+        # Each nodes.new(bl_idname) returns a fresh node recording its idname.
+        self.created_nodes = []
+
+        def _new_node(bl_idname, *args, **kwargs):
+            node = MagicMock()
+            node.bl_idname = bl_idname
+            self.created_nodes.append(node)
+            return node
+
+        self.nodes.new.side_effect = _new_node
+
+
+@pytest.fixture
+def node_group(mock_bpy):
+    """Wire ``bpy.data.node_groups.new`` to return our spec'd node group."""
+    ng = _NodeGroup()
+    mock_bpy.data.node_groups.new.return_value = ng
+    return ng
+
+
+def _build(node_group, channels=DEFAULT_CHANNELS):
+    data_obj = MagicMock(name="data_obj")
+    return build_sampler_group("sampler", dt=0.010667, data_obj=data_obj, channels=channels)
+
+
+def test_creates_geometry_node_tree(mock_bpy, node_group):
+    result = _build(node_group)
+    args, _ = mock_bpy.data.node_groups.new.call_args
+    assert args[1] == "GeometryNodeTree"
+    assert result is node_group
+
+
+def test_sockets_created_via_interface_new_socket(mock_bpy, node_group):
+    """Geometry IN/OUT + one FLOAT OUT per channel, all via interface.new_socket."""
+    _build(node_group)
+    calls = node_group.interface.new_socket.call_args_list
+    # 2 geometry sockets + one per channel.
+    assert len(calls) == 2 + len(DEFAULT_CHANNELS)
+
+    geo_in = [c for c in calls if c.kwargs.get("socket_type") == "NodeSocketGeometry"
+              and c.kwargs.get("in_out") == "INPUT"]
+    geo_out = [c for c in calls if c.kwargs.get("socket_type") == "NodeSocketGeometry"
+               and c.kwargs.get("in_out") == "OUTPUT"]
+    assert len(geo_in) == 1
+    assert len(geo_out) == 1
+
+    float_out_names = [
+        c.args[0] for c in calls
+        if c.kwargs.get("socket_type") == "NodeSocketFloat"
+        and c.kwargs.get("in_out") == "OUTPUT"
+    ]
+    for name in DEFAULT_CHANNELS:
+        assert name in float_out_names
+
+
+def test_does_not_use_removed_inputs_outputs_api(mock_bpy, node_group):
+    """The 3.x ng.inputs / ng.outputs collections must never be touched."""
+    # _NodeGroup has no such attributes; if the builder used them this raises.
+    assert not hasattr(node_group, "inputs")
+    assert not hasattr(node_group, "outputs")
+    _build(node_group)  # must complete without AttributeError
+
+
+def test_expected_node_bl_idnames_instantiated(mock_bpy, node_group):
+    _build(node_group)
+    idnames = [n.bl_idname for n in node_group.created_nodes]
+    for expected in (
+        "NodeGroupInput",
+        "NodeGroupOutput",
+        "GeometryNodeInputSceneTime",
+        "ShaderNodeMath",
+        "GeometryNodeObjectInfo",
+        "GeometryNodeInputNamedAttribute",
+        "GeometryNodeSampleIndex",
+        "ShaderNodeMix",
+    ):
+        assert expected in idnames, f"missing node {expected}"
+
+
+def test_single_scene_time_shared_across_channels(mock_bpy, node_group):
+    _build(node_group)
+    scene_times = [
+        n for n in node_group.created_nodes
+        if n.bl_idname == "GeometryNodeInputSceneTime"
+    ]
+    assert len(scene_times) == 1
+
+
+def test_two_sample_index_per_channel(mock_bpy, node_group):
+    _build(node_group)
+    sample_nodes = [
+        n for n in node_group.created_nodes
+        if n.bl_idname == "GeometryNodeSampleIndex"
+    ]
+    assert len(sample_nodes) == 2 * len(DEFAULT_CHANNELS)
+
+
+def test_sample_index_clamp_and_data_type(mock_bpy, node_group):
+    _build(node_group)
+    sample_nodes = [
+        n for n in node_group.created_nodes
+        if n.bl_idname == "GeometryNodeSampleIndex"
+    ]
+    assert sample_nodes
+    for sample in sample_nodes:
+        assert sample.clamp is True
+        assert sample.data_type == "FLOAT"
+        assert sample.domain == "POINT"
+
+
+def test_named_attribute_is_float(mock_bpy, node_group):
+    _build(node_group)
+    named = [
+        n for n in node_group.created_nodes
+        if n.bl_idname == "GeometryNodeInputNamedAttribute"
+    ]
+    assert named
+    for n in named:
+        assert n.data_type == "FLOAT"
+
+
+def test_mix_node_is_float(mock_bpy, node_group):
+    _build(node_group)
+    mixes = [n for n in node_group.created_nodes if n.bl_idname == "ShaderNodeMix"]
+    assert len(mixes) == len(DEFAULT_CHANNELS)
+    for m in mixes:
+        assert m.data_type == "FLOAT"
+
+
+def test_dt_threaded_into_divide_default(mock_bpy, node_group):
+    """dt is set as a node default (param), not hardcoded constant."""
+    dt = 0.011610
+    data_obj = MagicMock()
+    build_sampler_group("sampler", dt=dt, data_obj=data_obj, channels=("bass_n",))
+
+    divides = [
+        n for n in node_group.created_nodes
+        if n.bl_idname == "ShaderNodeMath" and getattr(n, "operation", None) == "DIVIDE"
+    ]
+    assert divides, "expected a DIVIDE math node (index = Seconds / dt)"
+    # The divide's second input default_value must have been set to dt.
+    set_to_dt = any(
+        d.inputs.__getitem__.return_value.default_value == dt for d in divides
+    )
+    assert set_to_dt
+
+
+def test_custom_channels_subset(mock_bpy, node_group):
+    _build(node_group, channels=("bass_n", "mid_n"))
+    float_out_names = [
+        c.args[0] for c in node_group.interface.new_socket.call_args_list
+        if c.kwargs.get("socket_type") == "NodeSocketFloat"
+    ]
+    assert float_out_names == ["bass_n", "mid_n"]
+
+
+def test_empty_channels_raise(mock_bpy, node_group):
+    with pytest.raises(ValueError):
+        _build(node_group, channels=())

--- a/packages/cymatic/tests/test_normalization.py
+++ b/packages/cymatic/tests/test_normalization.py
@@ -139,3 +139,30 @@ class TestPrecomputeEnvelope:
         times = np.arange(100) * 0.01
         env = precompute_envelope([0.0, 0.5], times, decay=0.05)
         assert env.min() >= 0.0
+
+    def test_single_sample_times_returns_zeros_no_index_error(self):
+        # len(times) < 2 must not raise IndexError on times[1]; it yields a
+        # zero envelope of the same length.
+        env = precompute_envelope([0.0], np.array([0.0]), decay=0.05)
+        assert env.shape == (1,)
+        assert np.all(env == 0.0)
+        assert env.dtype == np.float32
+
+    def test_empty_times_returns_empty(self):
+        env = precompute_envelope([0.0], np.array([]), decay=0.05)
+        assert len(env) == 0
+
+
+class TestNonFiniteBands:
+    def test_non_finite_values_coerced_to_zero(self, caplog):
+        # NaN/inf must not poison percentile or make the band vanish; they are
+        # coerced to 0 with a logged warning, leaving finite values intact.
+        arr = np.array([0.0, np.nan, 1.0, np.inf, 2.0, -np.inf])
+        with caplog.at_level("WARNING"):
+            out = normalize_band(arr)
+        assert np.all(np.isfinite(out))
+        assert out.max() <= 1.0
+        assert out.min() >= 0.0
+        # the finite, non-zero entries still produce signal
+        assert out.max() > 0.0
+        assert any("non-finite" in r.message for r in caplog.records)

--- a/packages/cymatic/tests/test_normalization.py
+++ b/packages/cymatic/tests/test_normalization.py
@@ -1,0 +1,141 @@
+# ABOUTME: Tests for cymatic.normalization (per-track p99 norm + envelope precompute)
+# ABOUTME: Settled by Spike 1 — p99 anchor, per-band, deterministic, zero-guard.
+
+"""Tests for normalization.normalize_band and precompute_envelope.
+
+Method settled by Spike 1: per-track p99 normalization with a zero-guard,
+deterministic. Envelope precompute uses the proven env() pattern from
+research/build_visualizer_v2.py: for each event, fill a decaying ramp
+``max(0, 1 - k*dt/decay)`` from the event index onward.
+"""
+
+import numpy as np
+import pytest
+
+from cymatic.normalization import normalize_band, precompute_envelope
+
+
+class TestNormalizeBand:
+    def test_output_in_unit_interval(self):
+        arr = np.array([0.0, 1.0, 2.0, 5.0, 10.0])
+        out = normalize_band(arr)
+        assert out.min() >= 0.0
+        assert out.max() <= 1.0
+
+    def test_length_preserved(self):
+        arr = np.linspace(0.0, 7.0, 137)
+        out = normalize_band(arr)
+        assert len(out) == len(arr)
+
+    def test_p99_anchor_clips_above(self):
+        # A single big transient must not collapse the rest of the range:
+        # p99 anchor clips the outlier to 1.0 rather than scaling everything
+        # down. With ~1% of samples above the bulk, p99 sits near the bulk so
+        # the bulk maps high, and the transient clips to 1.0.
+        bulk = np.full(990, 1.0)
+        transients = np.full(10, 100.0)
+        arr = np.concatenate([bulk, transients])
+        out = normalize_band(arr)
+        # The transients clip to 1.0 rather than defining the scale.
+        assert out.max() == pytest.approx(1.0)
+        assert out[-1] == pytest.approx(1.0)
+        # Anchor is p99, so the divisor stays far below the 100.0 transient
+        # peak — the bulk is not crushed to near-zero the way max-scaling
+        # (divide by 100) would crush it.
+        p99 = np.percentile(arr, 99)
+        assert p99 < 100.0
+        assert out[0] == pytest.approx(min(1.0, 1.0 / p99))
+
+    def test_zero_guard_all_zeros(self):
+        # Constant (near-)zero energy band: p99 == 0 -> zeros, no div-by-zero.
+        arr = np.zeros(50)
+        out = normalize_band(arr)
+        assert np.all(out == 0.0)
+        assert len(out) == 50
+
+    def test_zero_guard_no_exception_and_finite(self):
+        arr = np.zeros(10)
+        out = normalize_band(arr)
+        assert np.all(np.isfinite(out))
+
+    def test_deterministic_bit_for_bit(self):
+        rng = np.random.default_rng(0)
+        arr = rng.random(200) * 13.0
+        a = normalize_band(arr)
+        b = normalize_band(arr)
+        assert np.array_equal(a, b)
+
+    def test_returns_float32(self):
+        arr = np.array([1.0, 2.0, 3.0])
+        out = normalize_band(arr)
+        assert out.dtype == np.float32
+
+    def test_accepts_plain_list(self):
+        out = normalize_band([0.0, 1.0, 2.0, 3.0])
+        assert isinstance(out, np.ndarray)
+        assert out.max() <= 1.0
+
+
+class TestPrecomputeEnvelope:
+    def test_event_on_sample_peaks_at_index(self):
+        dt = 0.01
+        times = np.arange(100) * dt
+        # event exactly on sample index 10 (t = 0.10)
+        env = precompute_envelope([0.10], times, decay=0.05)
+        assert env[10] == pytest.approx(1.0)
+        # decays afterwards
+        assert env[11] < env[10]
+
+    def test_event_between_samples_rounds_to_nearest(self):
+        dt = 0.01
+        times = np.arange(100) * dt
+        # event at 0.104 -> round(0.104/0.01) = 10
+        env = precompute_envelope([0.104], times, decay=0.05)
+        assert env[10] == pytest.approx(1.0)
+
+    def test_decaying_ramp_values(self):
+        dt = 0.01
+        times = np.arange(100) * dt
+        decay = 0.05  # ramp spans 5 samples
+        env = precompute_envelope([0.0], times, decay=decay)
+        # k=0 -> 1.0; k=1 -> 1 - 1*dt/decay = 0.8; k=2 -> 0.6 ...
+        assert env[0] == pytest.approx(1.0)
+        assert env[1] == pytest.approx(0.8, abs=1e-6)
+        assert env[2] == pytest.approx(0.6, abs=1e-6)
+
+    def test_empty_events_all_zeros_no_exception(self):
+        dt = 0.01
+        times = np.arange(50) * dt
+        env = precompute_envelope([], times, decay=0.1)
+        assert np.all(env == 0.0)
+        assert len(env) == len(times)
+
+    def test_length_matches_times(self):
+        times = np.arange(73) * 0.011
+        env = precompute_envelope([0.1, 0.3], times, decay=0.05)
+        assert len(env) == len(times)
+
+    def test_overlapping_events_take_max(self):
+        dt = 0.01
+        times = np.arange(100) * dt
+        decay = 0.05
+        # two close events; at a shared index the later event's fresh ramp wins via max
+        env = precompute_envelope([0.0, 0.02], times, decay=decay)
+        # index 2 is k=2 from event0 (0.6) and k=0 from event1 (1.0) -> max 1.0
+        assert env[2] == pytest.approx(1.0)
+
+    def test_deterministic(self):
+        times = np.arange(100) * 0.01
+        a = precompute_envelope([0.1, 0.5, 0.9], times, decay=0.07)
+        b = precompute_envelope([0.1, 0.5, 0.9], times, decay=0.07)
+        assert np.array_equal(a, b)
+
+    def test_returns_float32(self):
+        times = np.arange(20) * 0.01
+        env = precompute_envelope([0.05], times, decay=0.03)
+        assert env.dtype == np.float32
+
+    def test_no_negative_values(self):
+        times = np.arange(100) * 0.01
+        env = precompute_envelope([0.0, 0.5], times, decay=0.05)
+        assert env.min() >= 0.0

--- a/packages/cymatic/tests/test_runner.py
+++ b/packages/cymatic/tests/test_runner.py
@@ -8,6 +8,7 @@ Mirrors cinemon's BlenderProjectManager subprocess pattern:
 with capture_output/text/check, RuntimeError carrying stderr on failure.
 """
 
+import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import Mock
@@ -16,6 +17,21 @@ import pytest
 
 from cymatic.config import VisualizerConfig
 from cymatic.runner import CymaticRunner, render
+
+# Capture the real mux before the autouse fixture below patches it to a no-op,
+# so the dedicated mux test can exercise the real implementation.
+_REAL_MUX = CymaticRunner._mux_frames
+
+
+@pytest.fixture(autouse=True)
+def _skip_mux(monkeypatch):
+    """Stub out frame muxing for command/subprocess/cleanup tests.
+
+    These tests verify the Blender invocation, not video encoding; the mocked
+    subprocess never renders real frames, so the real _mux_frames would raise
+    "No frames rendered". The dedicated mux test uses _REAL_MUX directly.
+    """
+    monkeypatch.setattr(CymaticRunner, "_mux_frames", lambda self, fdir, out: None)
 
 
 @pytest.fixture
@@ -149,3 +165,42 @@ def test_render_convenience_function(config, recording_dir):
     """The module-level render() helper drives the runner end-to-end."""
     output = render(config)
     assert Path(output).parent == recording_dir / "blender" / "render"
+
+
+def test_mux_frames_builds_ffmpeg_command(config, tmp_path, monkeypatch):
+    """_mux_frames feeds the PNG sequence (+audio) to ffmpeg with H.264/yuv420p."""
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    (frames_dir / "frame_0001.png").write_bytes(b"\x89PNG\r\n")  # fake frame
+    output = tmp_path / "out.mp4"
+
+    config.fps = 24
+    config.frame_start = 1
+    config.audio_file = str(tmp_path / "a.wav")
+    (tmp_path / "a.wav").write_bytes(b"RIFF")  # exists -> audio muxed
+
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/ffmpeg")
+    captured = {}
+
+    def fake_run(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+        return Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    _REAL_MUX(CymaticRunner(config), frames_dir, output)
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "/usr/bin/ffmpeg"
+    assert "-framerate" in cmd and "24" in cmd
+    assert "-start_number" in cmd
+    assert "libx264" in cmd and "yuv420p" in cmd
+    assert "aac" in cmd and "-shortest" in cmd  # audio present
+    assert str(output) == cmd[-1]
+
+
+def test_mux_frames_no_frames_raises(config, tmp_path, monkeypatch):
+    """Empty frames dir -> clear RuntimeError (not a silent empty mp4)."""
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/ffmpeg")
+    with pytest.raises(RuntimeError, match="No frames"):
+        _REAL_MUX(CymaticRunner(config), tmp_path / "empty", tmp_path / "o.mp4")

--- a/packages/cymatic/tests/test_runner.py
+++ b/packages/cymatic/tests/test_runner.py
@@ -1,0 +1,151 @@
+# ABOUTME: Tests for the host-side cymatic runner (Blender subprocess orchestration).
+# ABOUTME: Uses the autouse mock_subprocess fixture from conftest; no real Blender.
+
+"""Unit 9 — host-side runner tests.
+
+Mirrors cinemon's BlenderProjectManager subprocess pattern:
+  [blender_exec, "--background", "--python", build_scene.py, "--", "--config", <file>]
+with capture_output/text/check, RuntimeError carrying stderr on failure.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from cymatic.config import VisualizerConfig
+from cymatic.runner import CymaticRunner, render
+
+
+@pytest.fixture
+def recording_dir(tmp_path):
+    """A recording directory with the expected analysis layout."""
+    (tmp_path / "analysis").mkdir()
+    analysis_file = tmp_path / "analysis" / "song_analysis.json"
+    analysis_file.write_text("{}")
+    return tmp_path
+
+
+@pytest.fixture
+def config(recording_dir):
+    return VisualizerConfig(
+        analysis_file=str(recording_dir / "analysis" / "song_analysis.json"),
+        output_mp4="",  # runner resolves it under blender/render/
+        base_directory=str(recording_dir),
+        blender_executable="/Applications/Blender.app/Contents/MacOS/Blender",
+    )
+
+
+def _captured_cmd(mock_run):
+    """Return the command list passed to the mocked subprocess.run."""
+    assert mock_run.called, "subprocess.run was not called"
+    args, _kwargs = mock_run.call_args
+    return list(args[0])
+
+
+def test_command_built_with_config_and_build_scene_path(config):
+    """Command includes --config <file> and the resolved build_scene.py path."""
+    runner = CymaticRunner(config)
+    runner.run()
+
+    cmd = _captured_cmd(subprocess.run)
+
+    # Resolved build_scene.py path (mirrors cinemon resolution from runner.py).
+    expected_script = (
+        Path(__file__).parent.parent / "blender_script" / "build_scene.py"
+    )
+    assert str(expected_script) in cmd
+    assert expected_script.exists()
+
+    # Blender headless invocation structure.
+    assert "--background" in cmd
+    assert "--python" in cmd
+    assert "--" in cmd  # separator between Blender args and script args
+    assert "--config" in cmd
+
+    # --config is followed by a path, and after the "--" separator.
+    cfg_idx = cmd.index("--config")
+    assert cfg_idx > cmd.index("--")
+    config_path = cmd[cfg_idx + 1]
+    assert Path(config_path).name  # non-empty path token
+
+
+def test_explicit_executable_used_directly_macos(config):
+    """An explicit blender_executable path is used directly (no snap wrapper)."""
+    config.blender_executable = "/Applications/Blender.app/Contents/MacOS/Blender"
+    runner = CymaticRunner(config)
+    runner.run()
+
+    cmd = _captured_cmd(subprocess.run)
+    assert cmd[0] == "/Applications/Blender.app/Contents/MacOS/Blender"
+    assert "snap" not in cmd
+
+
+def test_default_blender_executable_uses_snap_branch_linux(config):
+    """blender_executable == 'blender' -> snap run blender (Linux branch)."""
+    config.blender_executable = "blender"
+    runner = CymaticRunner(config)
+    runner.run()
+
+    cmd = _captured_cmd(subprocess.run)
+    assert cmd[:3] == ["snap", "run", "blender"]
+
+
+def test_called_process_error_raises_runtime_error_with_stderr(config, monkeypatch):
+    """CalledProcessError is re-raised as RuntimeError carrying stderr."""
+    error = subprocess.CalledProcessError(
+        returncode=1, cmd=["blender"], output="", stderr="boom: GN build failed"
+    )
+    monkeypatch.setattr(subprocess, "run", Mock(side_effect=error))
+
+    runner = CymaticRunner(config)
+    with pytest.raises(RuntimeError) as exc_info:
+        runner.run()
+
+    assert "boom: GN build failed" in str(exc_info.value)
+
+
+def test_output_path_under_blender_render(config, recording_dir):
+    """Output mp4 is resolved under blender/render/ via ensure_blender_dir."""
+    runner = CymaticRunner(config)
+    output = runner.run()
+
+    output = Path(output)
+    assert output.parent == recording_dir / "blender" / "render"
+    assert output.suffix == ".mp4"
+    # ensure_blender_dir created the directory tree.
+    assert (recording_dir / "blender" / "render").is_dir()
+
+
+def test_temp_config_file_cleaned_up(config):
+    """The serialized temp config file is removed after the subprocess."""
+    runner = CymaticRunner(config)
+
+    captured_paths = []
+
+    real_run = subprocess.run  # the mock from conftest
+
+    def capturing_run(cmd, *a, **k):
+        # Record the --config path and confirm it exists DURING the call.
+        cmd = list(cmd)
+        idx = cmd.index("--config")
+        cfg_path = cmd[idx + 1]
+        captured_paths.append(cfg_path)
+        assert Path(cfg_path).exists(), "config file must exist during subprocess"
+        return real_run(cmd, *a, **k)
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(subprocess, "run", side_effect=capturing_run):
+        runner.run()
+
+    assert captured_paths, "subprocess.run was not invoked"
+    for p in captured_paths:
+        assert not Path(p).exists(), f"temp config not cleaned up: {p}"
+
+
+def test_render_convenience_function(config, recording_dir):
+    """The module-level render() helper drives the runner end-to-end."""
+    output = render(config)
+    assert Path(output).parent == recording_dir / "blender" / "render"

--- a/packages/cymatic/tests/test_runner.py
+++ b/packages/cymatic/tests/test_runner.py
@@ -21,17 +21,24 @@ from cymatic.runner import CymaticRunner, render
 # Capture the real mux before the autouse fixture below patches it to a no-op,
 # so the dedicated mux test can exercise the real implementation.
 _REAL_MUX = CymaticRunner._mux_frames
+_REAL_VALIDATE = CymaticRunner._validate_frame_count
 
 
 @pytest.fixture(autouse=True)
 def _skip_mux(monkeypatch):
-    """Stub out frame muxing for command/subprocess/cleanup tests.
+    """Stub out frame muxing + frame-count validation for invocation tests.
 
     These tests verify the Blender invocation, not video encoding; the mocked
     subprocess never renders real frames, so the real _mux_frames would raise
-    "No frames rendered". The dedicated mux test uses _REAL_MUX directly.
+    "No frames rendered" and _validate_frame_count would have nothing to count.
+    The dedicated mux test uses _REAL_MUX directly.
     """
-    monkeypatch.setattr(CymaticRunner, "_mux_frames", lambda self, fdir, out: None)
+    monkeypatch.setattr(
+        CymaticRunner, "_mux_frames", lambda self, fdir, out, cfg=None: None
+    )
+    monkeypatch.setattr(
+        CymaticRunner, "_validate_frame_count", lambda self, fdir, cfg: None
+    )
 
 
 @pytest.fixture
@@ -204,3 +211,98 @@ def test_mux_frames_no_frames_raises(config, tmp_path, monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/ffmpeg")
     with pytest.raises(RuntimeError, match="No frames"):
         _REAL_MUX(CymaticRunner(config), tmp_path / "empty", tmp_path / "o.mp4")
+
+
+def test_run_does_not_mutate_caller_config(config):
+    """run() must not mutate the caller's VisualizerConfig.frames_dir."""
+    assert config.frames_dir is None
+    runner = CymaticRunner(config)
+    runner.run()
+    # The runner works on a dataclasses.replace() copy; caller's stays None.
+    assert config.frames_dir is None
+
+
+def test_missing_blender_executable_raises_before_subprocess(config, monkeypatch):
+    """A None/empty executable raises a clear RuntimeError before spawning."""
+    config.blender_executable = None
+    called = {"ran": False}
+
+    def boom(*a, **k):
+        called["ran"] = True
+        raise AssertionError("subprocess.run must not be called")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    runner = CymaticRunner(config)
+    with pytest.raises(RuntimeError, match="Blender executable not found"):
+        runner.run()
+    assert called["ran"] is False
+
+
+def test_blender_timeout_raises_runtime_error(config, monkeypatch):
+    """A Blender subprocess timeout becomes a RuntimeError with context."""
+    config.blender_timeout_sec = 5
+    timeout = subprocess.TimeoutExpired(cmd=["blender"], timeout=5)
+    monkeypatch.setattr(subprocess, "run", Mock(side_effect=timeout))
+
+    runner = CymaticRunner(config)
+    with pytest.raises(RuntimeError, match="timed out after 5s"):
+        runner.run()
+
+
+def test_blender_timeout_value_forwarded(config):
+    """The configured blender_timeout_sec is forwarded to subprocess.run."""
+    config.blender_timeout_sec = 1234
+    CymaticRunner(config).run()
+    _args, kwargs = subprocess.run.call_args
+    assert kwargs.get("timeout") == 1234
+
+
+def test_short_frame_count_raises(config, monkeypatch, tmp_path):
+    """Fewer rendered frames than expected -> RuntimeError (incomplete render)."""
+    # Re-enable the real validator (the autouse fixture stubbed it).
+    monkeypatch.setattr(
+        CymaticRunner, "_validate_frame_count", _REAL_VALIDATE
+    )
+    # frame_end set explicitly so we don't need a real analysis file.
+    config.frame_start = 1
+    config.frame_end = 10  # expect 10 frames
+
+    # Make build_scene render only 3 frames into the temp frames_dir.
+    def fake_run(cmd, *a, **k):
+        cmd = list(cmd)
+        cfg_path = cmd[cmd.index("--config") + 1]
+        import json as _json
+
+        cfg = _json.loads(Path(cfg_path).read_text())
+        fdir = Path(cfg["frames_dir"])
+        for i in range(1, 4):  # only 3 frames
+            (fdir / f"frame_{i:04d}.png").write_bytes(b"\x89PNG")
+        return Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    runner = CymaticRunner(config)
+    with pytest.raises(RuntimeError, match="expected 10"):
+        runner.run()
+
+
+def test_full_frame_count_passes(config, monkeypatch):
+    """Exactly the expected frame count passes validation."""
+    monkeypatch.setattr(CymaticRunner, "_validate_frame_count", _REAL_VALIDATE)
+    config.frame_start = 1
+    config.frame_end = 5
+
+    def fake_run(cmd, *a, **k):
+        cmd = list(cmd)
+        cfg_path = cmd[cmd.index("--config") + 1]
+        import json as _json
+
+        cfg = _json.loads(Path(cfg_path).read_text())
+        fdir = Path(cfg["frames_dir"])
+        for i in range(1, 6):  # exactly 5 frames
+            (fdir / f"frame_{i:04d}.png").write_bytes(b"\x89PNG")
+        return Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    # mux is still stubbed by the autouse fixture; should not raise.
+    CymaticRunner(config).run()

--- a/packages/cymatic/tests/test_sync_verification.py
+++ b/packages/cymatic/tests/test_sync_verification.py
@@ -1,0 +1,202 @@
+# ABOUTME: Tests for cymatic.sync_verification — DATA-timing sync proof (R2/R3)
+# ABOUTME: Runs on synthetic + real fixtures of different sample_rate (48k, 44k).
+
+"""Tests for the data-grounded sync-verification harness (Unit 10).
+
+SCOPE / HONESTY (mirrors the plan's "Zakres tego dowodu"):
+This harness proves the **data-timing arithmetic** only — that the precomputed
+``beat_env`` impulse peaks at the render frame ``round(beat_sec * fps)`` within
+``N`` frames, and that the ``Seconds/dt`` index-sampling that the live Geometry
+Nodes graph performs (Spike 2) reproduces the stored channel value in pure
+python. It does **NOT** prove perceptual / visual timing ("you can see the
+accent land on the beat") — preset easing, motion blur, and linear blur of the
+impulse between samples (dt ~11-23 ms) may soften the accent. Perceptual
+verification belongs to creator acceptance (R4), not here.
+
+R3 is exercised by running the same harness on two real tracks of different
+sample_rate (48 kHz and 44.1 kHz) — therefore different ``dt`` — and asserting
+sync holds on both.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cymatic.analysis_loader import AnalysisData, load_analysis
+from cymatic.config import VisualizerConfig
+from cymatic.normalization import precompute_envelope
+from cymatic.sync_verification import (
+    DEFAULT_N_TOLERANCE_FRAMES,
+    SyncReport,
+    assert_fps_consistency,
+    sample_channel_at_frame,
+    verify_sync,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIX_48K = REPO_ROOT / "research/audio/analysis/jazz_120s_48k_analysis.json"
+FIX_44K = REPO_ROOT / "research/audio/analysis/jazz_120s_44k_analysis.json"
+FIX_120BPM = REPO_ROOT / "research/audio/analysis/beat_120bpm_12s_analysis.json"
+
+
+@pytest.fixture(autouse=True)
+def _require_fixtures():
+    for f in (FIX_48K, FIX_44K, FIX_120BPM):
+        if not f.exists():
+            pytest.skip(f"fixture missing: {f}")
+
+
+def _config(analysis_file: Path, fps: int = 30) -> VisualizerConfig:
+    return VisualizerConfig(
+        analysis_file=str(analysis_file),
+        output_mp4="/tmp/out.mp4",
+        base_directory=str(analysis_file.parent),
+        fps=fps,
+    )
+
+
+def _synthetic(
+    beats, fps=30, dt=0.01, duration=None, decay=0.13, sample_rate=48000
+) -> AnalysisData:
+    """Build a minimal AnalysisData with a beat_env precomputed for ``beats``."""
+    if duration is None:
+        duration = (max(beats) + 1.0) if beats else 2.0
+    n = int(round(duration / dt))
+    times = np.arange(n, dtype=float) * dt
+    beat_env = precompute_envelope(beats, times, decay=decay)
+    zeros = np.zeros(n, dtype=np.float32)
+    return AnalysisData(
+        bass=zeros,
+        mid=zeros.copy(),
+        high=zeros.copy(),
+        beat_env=beat_env,
+        peak_env=zeros.copy(),
+        times=times,
+        dt=dt,
+        sample_rate=sample_rate,
+        duration=duration,
+        fps=fps,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Value-sampling arithmetic (mirrors the live Seconds/dt mapping from Spike 2) #
+# --------------------------------------------------------------------------- #
+class TestValueSampling:
+    def test_sample_channel_matches_clamped_index(self):
+        data = _synthetic([0.5, 1.0], fps=30, dt=0.01)
+        chan = data.beat_env
+        for frame in range(0, 60):
+            expected_idx = int(round((frame / data.fps) / data.dt))
+            expected_idx = max(0, min(expected_idx, len(chan) - 1))
+            assert sample_channel_at_frame(chan, frame, data.fps, data.dt) == (
+                chan[expected_idx]
+            )
+
+    def test_sample_clamps_beyond_track_end(self):
+        data = _synthetic([0.5], fps=30, dt=0.01, duration=1.0)
+        # Frame far past the end must clamp to the last sample, not raise.
+        val = sample_channel_at_frame(
+            data.beat_env, frame=10_000, fps=data.fps, dt=data.dt
+        )
+        assert val == data.beat_env[-1]
+
+
+# --------------------------------------------------------------------------- #
+# Happy path: synthetic beat at a known time peaks within +/- N frames         #
+# --------------------------------------------------------------------------- #
+class TestHappyPath:
+    def test_single_beat_peaks_at_expected_frame(self):
+        # Beat at 1.0s, fps=30 -> expected frame 30.
+        data = _synthetic([1.0], fps=30, dt=0.01)
+        report = verify_sync(data)
+        assert report.passed
+        assert report.max_deviation <= DEFAULT_N_TOLERANCE_FRAMES
+        assert len(report.deviations) == 1
+        dev = report.deviations[0]
+        assert dev.beat_time == pytest.approx(1.0)
+        assert dev.expected_frame == 30
+        assert abs(dev.peak_frame - 30) <= DEFAULT_N_TOLERANCE_FRAMES
+
+    def test_multiple_beats_all_within_tolerance(self):
+        data = _synthetic([0.5, 1.0, 2.5, 4.0], fps=30, dt=0.01)
+        report = verify_sync(data)
+        assert report.passed
+        assert all(d.deviation <= DEFAULT_N_TOLERANCE_FRAMES for d in report.deviations)
+
+
+# --------------------------------------------------------------------------- #
+# R3: real fixtures of different sample_rate -> sync holds on both              #
+# --------------------------------------------------------------------------- #
+class TestR3RealFixturesBothSampleRates:
+    def test_48k_sync_holds(self):
+        data = load_analysis(_config(FIX_48K, fps=30))
+        report = verify_sync(data)
+        assert report.sample_rate == 48000
+        assert report.passed, (
+            f"48k max deviation {report.max_deviation} > "
+            f"{DEFAULT_N_TOLERANCE_FRAMES}"
+        )
+
+    def test_44k_sync_holds(self):
+        data = load_analysis(_config(FIX_44K, fps=30))
+        report = verify_sync(data)
+        assert report.sample_rate == 44100
+        assert report.passed, (
+            f"44k max deviation {report.max_deviation} > "
+            f"{DEFAULT_N_TOLERANCE_FRAMES}"
+        )
+
+    def test_both_sample_rates_have_different_dt(self):
+        d48 = load_analysis(_config(FIX_48K, fps=30))
+        d44 = load_analysis(_config(FIX_44K, fps=30))
+        # Distinct dt is precisely the R3 regression a single-sr spike misses.
+        assert d48.dt != d44.dt
+
+    def test_120bpm_synthetic_fixture_sync_holds(self):
+        data = load_analysis(_config(FIX_120BPM, fps=30))
+        report = verify_sync(data)
+        assert report.passed
+
+
+# --------------------------------------------------------------------------- #
+# Edge: beat near end of track -> clamp, no out-of-range index                  #
+# --------------------------------------------------------------------------- #
+class TestEdgeBeatNearEnd:
+    def test_beat_at_last_sample_does_not_raise(self):
+        # Beat at the very last representable time.
+        data = _synthetic([1.99], fps=30, dt=0.01, duration=2.0)
+        report = verify_sync(data)  # must not raise IndexError
+        assert len(report.deviations) == 1
+        # Peak frame is clamped within the renderable frame range.
+        last_frame = int(round((len(data.beat_env) - 1) * data.dt * data.fps))
+        assert report.deviations[0].peak_frame <= last_frame
+
+
+# --------------------------------------------------------------------------- #
+# Error path: track with no beats -> graceful report, no crash                  #
+# --------------------------------------------------------------------------- #
+class TestEdgeNoBeats:
+    def test_no_beats_reports_gracefully(self):
+        data = _synthetic([], fps=30, dt=0.01, duration=2.0)
+        report = verify_sync(data)
+        assert isinstance(report, SyncReport)
+        assert report.deviations == []
+        # No beats means nothing to violate -> vacuously passing, max dev 0.
+        assert report.passed
+        assert report.max_deviation == 0
+
+
+# --------------------------------------------------------------------------- #
+# fps-consistency helper                                                        #
+# --------------------------------------------------------------------------- #
+class TestFpsConsistency:
+    def test_matching_fps_ok(self):
+        # config.fps must equal the fps used for round(beat_sec*fps);
+        # the live scene.render.fps == config.fps check is integration-only.
+        assert_fps_consistency(config_fps=30, harness_fps=30)
+
+    def test_mismatched_fps_raises(self):
+        with pytest.raises(ValueError):
+            assert_fps_consistency(config_fps=30, harness_fps=60)

--- a/packages/cymatic/tests/test_sync_verification.py
+++ b/packages/cymatic/tests/test_sync_verification.py
@@ -157,6 +157,53 @@ class TestHarnessCanFail:
 
 
 # --------------------------------------------------------------------------- #
+# Regression: adjacent-beat MASKING. A beat present in raw_beat_times but with  #
+# no fresh impulse in beat_env must FAIL even when a NEIGHBOR's peak sits inside #
+# the search window within tolerance — the argmax alone would mask it.          #
+# --------------------------------------------------------------------------- #
+class TestHarnessCatchesMaskedBeat:
+    def test_masked_beat_fails_when_neighbor_peak_in_window(self):
+        # Two beats 40 ms apart: 1.0s (frame 30) and 1.04s (frame 31). The
+        # envelope is built from ONLY the first beat, so 1.04s has no fresh
+        # impulse. Its expected index (104) holds just the DECAY TAIL of beat A
+        # (~0.69), and beat A's fresh 1.0 peak at index 100 sits inside the
+        # search window — argmax would report peak_frame=30, deviation=1 <= tol,
+        # a FALSE pass. The presence check (value ~1.0 at the expected index)
+        # must catch the absent impulse and fail the report.
+        fps, dt = 30, 0.01
+        raw_beats = [1.0, 1.04]
+        n = int(round(2.0 / dt))
+        times = np.arange(n, dtype=float) * dt
+        # Envelope deliberately MISSING the second beat (precompute from [1.0]).
+        beat_env = precompute_envelope([1.0], times, decay=0.13)
+        zeros = np.zeros(n, dtype=np.float32)
+        data = AnalysisData(
+            bass=zeros, mid=zeros.copy(), high=zeros.copy(),
+            beat_env=beat_env, peak_env=zeros.copy(), times=times,
+            dt=dt, sample_rate=48000, duration=2.0, fps=fps,
+            raw_beat_times=list(raw_beats),
+        )
+
+        report = verify_sync(data)
+
+        assert not report.passed, "masked beat must fail, not be hidden by neighbor"
+        masked = report.deviations[1]
+        assert masked.beat_time == pytest.approx(1.04)
+        assert masked.present is False  # no fresh impulse at the expected index
+        # The first beat IS present and on-time.
+        assert report.deviations[0].present is True
+
+    def test_consistent_close_beats_still_pass(self):
+        # Same two close beats, but the envelope is built from BOTH — each has a
+        # fresh 1.0 impulse at its own index. No false-fail: presence holds and
+        # deviations stay within tolerance.
+        data = _synthetic([1.0, 1.04], fps=30, dt=0.01, duration=2.0)
+        report = verify_sync(data)
+        assert report.passed
+        assert all(d.present for d in report.deviations)
+
+
+# --------------------------------------------------------------------------- #
 # R3: real fixtures of different sample_rate -> sync holds on both              #
 # --------------------------------------------------------------------------- #
 class TestR3RealFixturesBothSampleRates:

--- a/packages/cymatic/tests/test_sync_verification.py
+++ b/packages/cymatic/tests/test_sync_verification.py
@@ -77,6 +77,7 @@ def _synthetic(
         sample_rate=sample_rate,
         duration=duration,
         fps=fps,
+        raw_beat_times=list(beats),
     )
 
 
@@ -124,6 +125,35 @@ class TestHappyPath:
         report = verify_sync(data)
         assert report.passed
         assert all(d.deviation <= DEFAULT_N_TOLERANCE_FRAMES for d in report.deviations)
+
+
+# --------------------------------------------------------------------------- #
+# Regression: a deliberately SHIFTED envelope must fail (harness can detect a   #
+# wrong placement — proves the check is not a tautology against itself).        #
+# --------------------------------------------------------------------------- #
+class TestHarnessCanFail:
+    def test_shifted_envelope_exceeds_tolerance(self):
+        # Build a correct envelope for a beat at 1.0s (expected frame 30), then
+        # move the impulse 4 render frames later while leaving raw_beat_times
+        # claiming the beat is still at 1.0s. The shift (4 frames) sits inside
+        # the search window but well beyond the 2-frame tolerance, so the
+        # harness must report a failure — proving it is NOT a tautology.
+        fps = 30
+        dt = 0.01
+        beat_time = 1.0
+        data = _synthetic([beat_time], fps=fps, dt=dt, duration=3.0)
+
+        shift_frames = 4
+        correct_index = int(round(beat_time / dt))
+        wrong_index = correct_index + int(round((shift_frames / fps) / dt))
+        shifted = np.zeros_like(data.beat_env)
+        shifted[wrong_index] = 1.0
+        data.beat_env = shifted  # envelope no longer matches the claimed beat
+
+        report = verify_sync(data)
+        assert not report.passed
+        assert report.max_deviation > DEFAULT_N_TOLERANCE_FRAMES
+        assert report.deviations[0].expected_frame == 30
 
 
 # --------------------------------------------------------------------------- #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ members = [
     "packages/cinemon",
     "packages/medusa",
     "packages/beatrix",
+    "packages/cymatic",
 ]
 
 [project]
@@ -23,6 +24,7 @@ obsession = { workspace = true }
 cinemon = { workspace = true }
 medusa = { workspace = true }
 beatrix = { workspace = true }
+cymatic = { workspace = true }
 
 [tool.pytest.ini_options]
 testpaths = [
@@ -31,6 +33,7 @@ testpaths = [
     "packages/cinemon/tests",
     "packages/medusa/tests",
     "packages/beatrix/tests",
+    "packages/cymatic/tests",
 ]
 pythonpath = [
     "packages/obsession/src",
@@ -38,6 +41,7 @@ pythonpath = [
     "packages/cinemon/src",
     "packages/medusa/src",
     "packages/beatrix/src",
+    "packages/cymatic/src",
 ]
 addopts = [
     "--strict-markers",

--- a/research/build_visualizer_v1.py
+++ b/research/build_visualizer_v1.py
@@ -1,0 +1,206 @@
+"""Minimalny wizualizer (Spike 0 artefakt) — napedza ZYWY Blender przez socket.
+Buduje: data-object (5 atrybutow z realnej analizy jazz), GN scrolling-bars ring
+sterowany pasmami, srodek pulsujacy na beat_env. Screenshoty do /tmp.
+Run: python3 research/build_visualizer_v1.py
+"""
+import json, socket, sys, time
+
+HOST, PORT = "localhost", 9876
+
+def send(code, strict_json=False, timeout=120):
+    req = json.dumps({"type": "execute", "code": code, "strict_json": strict_json}) + "\0"
+    with socket.socket() as s:
+        s.settimeout(timeout); s.connect((HOST, PORT)); s.sendall(req.encode())
+        buf = bytearray()
+        while True:
+            c = s.recv(65536)
+            if not c: break
+            buf.extend(c)
+            if b"\0" in buf: break
+    resp = json.loads(bytes(buf).partition(b"\0")[0].decode())
+    if resp.get("status") != "ok":
+        print("  !! ERROR:", json.dumps(resp, indent=2)[:1200]); sys.exit(1)
+    return resp.get("result")
+
+ANALYSIS = "/Users/wokoziej/dev/setka-monorepo/research/audio/analysis/jazz_120s_48k_analysis.json"
+
+# ---------------- STAGE A: scene + data prep + data-object ----------------
+stage_a = r'''
+import bpy, json, numpy as np
+
+ANALYSIS = "%s"
+FPS = 30
+d = json.load(open(ANALYSIS))
+fb = d["frequency_bands"]; ae = d["animation_events"]
+times = np.array(fb["times"], float); dt = float(times[1]-times[0]); N = len(times)
+def norm(a):
+    a = np.array(a, float); p = np.percentile(a, 99)
+    return (np.clip(a/p, 0, 1) if p > 0 else np.zeros_like(a)).astype(np.float32)
+bass_n, mid_n, high_n = norm(fb["bass_energy"]), norm(fb["mid_energy"]), norm(fb["high_energy"])
+# decay envelopes for beats / peaks (precomputed, approach C)
+def env(events, decay=0.18):
+    e = np.zeros(N, np.float32)
+    for t in events:
+        i = int(round(t/dt))
+        for k in range(0, int(decay/dt)+1):
+            j = i+k
+            if 0 <= j < N: e[j] = max(e[j], 1.0 - k*dt/decay)
+    return e
+beat_env = env(ae.get("beats", [])); peak_env = env(ae.get("energy_peaks", []), 0.25)
+
+# dedicated collection (nie ruszamy reszty)
+for c in list(bpy.data.collections):
+    if c.name == "cymatic_viz":
+        for o in list(c.objects): bpy.data.objects.remove(o, do_unlink=True)
+        bpy.data.collections.remove(c)
+coll = bpy.data.collections.new("cymatic_viz"); bpy.context.scene.collection.children.link(coll)
+
+# data-object: N verts, X=time, 5 float attrs
+me = bpy.data.meshes.new("audio_data"); me.vertices.add(N)
+co = np.zeros(N*3, np.float32); co[0::3] = np.arange(N, dtype=np.float32)*dt
+me.vertices.foreach_set("co", co)
+for name, arr in [("bass_n",bass_n),("mid_n",mid_n),("high_n",high_n),("beat_env",beat_env),("peak_env",peak_env)]:
+    a = me.attributes.new(name=name, type='FLOAT', domain='POINT'); a.data.foreach_set("value", arr)
+me.update()
+obj = bpy.data.objects.new("audio_data", me); coll.objects.link(obj); obj.hide_render = True; obj.hide_viewport = True
+
+# scene/render
+sc = bpy.context.scene; sc.render.fps = FPS; sc.frame_start = 1; sc.frame_end = int(d["duration"]*FPS)
+sc.render.resolution_x = 1280; sc.render.resolution_y = 720
+try:
+    sc.render.engine = 'BLENDER_EEVEE_NEXT'
+except Exception:
+    sc.render.engine = 'BLENDER_EEVEE'
+# dark world
+w = bpy.data.worlds.get("cymatic_world") or bpy.data.worlds.new("cymatic_world")
+w.use_nodes = True; bg = w.node_tree.nodes.get("Background")
+if bg: bg.inputs[0].default_value = (0.01,0.01,0.02,1); bg.inputs[1].default_value = 0.3
+sc.world = w
+result = {"N": N, "dt": round(dt,6), "frame_end": sc.frame_end,
+          "bass_max": float(bass_n.max()), "beats": len(ae.get("beats",[])), "engine": sc.render.engine}
+''' % ANALYSIS
+
+print("STAGE A: scene + data-object ...")
+print(" ", send(stage_a))
+
+# ---------------- STAGE B: GN ring of bars + material + camera + light ----------------
+stage_b = r'''
+import bpy, math
+from mathutils import Vector
+coll = bpy.data.collections["cymatic_viz"]
+audio = bpy.data.objects["audio_data"]
+DT = %f
+M = 128            # liczba slupkow w pierscieniu
+STRIDE = 0.045     # offset czasu na slupek -> okno historii ~5.8s
+RAD = 5.0
+
+def ring(name, attr_name, radius, zcol):
+    ng = bpy.data.node_groups.new(name, 'GeometryNodeTree')
+    ng.interface.new_socket("Geometry", in_out='INPUT', socket_type='NodeSocketGeometry')
+    ng.interface.new_socket("Geometry", in_out='OUTPUT', socket_type='NodeSocketGeometry')
+    nd, lk = ng.nodes, ng.links
+    gin = nd.new('NodeGroupInput'); gout = nd.new('NodeGroupOutput')
+    circ = nd.new('GeometryNodeMeshCircle'); circ.fill_type='NONE'; circ.inputs['Vertices'].default_value=M; circ.inputs['Radius'].default_value=radius
+    cube = nd.new('GeometryNodeMeshCube'); cube.inputs['Size'].default_value=(0.18,0.18,1.0)
+    iop = nd.new('GeometryNodeInstanceOnPoints')
+    lk.new(circ.outputs['Mesh'], iop.inputs['Points']); lk.new(cube.outputs['Mesh'], iop.inputs['Instance'])
+    # h-field: sample band at (SceneTime - index*STRIDE)
+    idx = nd.new('GeometryNodeInputIndex')
+    st = nd.new('GeometryNodeInputSceneTime')
+    offs = nd.new('ShaderNodeMath'); offs.operation='MULTIPLY'; offs.inputs[1].default_value=STRIDE
+    lk.new(idx.outputs['Index'], offs.inputs[0])
+    tsec = nd.new('ShaderNodeMath'); tsec.operation='SUBTRACT'
+    lk.new(st.outputs['Seconds'], tsec.inputs[0]); lk.new(offs.outputs[0], tsec.inputs[1])
+    sidx = nd.new('ShaderNodeMath'); sidx.operation='DIVIDE'; sidx.inputs[1].default_value=DT
+    lk.new(tsec.outputs[0], sidx.inputs[0])
+    flo = nd.new('ShaderNodeMath'); flo.operation='FLOOR'; lk.new(sidx.outputs[0], flo.inputs[0])
+    oinfo = nd.new('GeometryNodeObjectInfo'); oinfo.inputs['Object'].default_value=audio; oinfo.transform_space='ORIGINAL'
+    na = nd.new('GeometryNodeInputNamedAttribute'); na.data_type='FLOAT'; na.inputs['Name'].default_value=attr_name
+    si = nd.new('GeometryNodeSampleIndex'); si.data_type='FLOAT'; si.domain='POINT'; si.clamp=True
+    lk.new(oinfo.outputs['Geometry'], si.inputs['Geometry']); lk.new(na.outputs['Attribute'], si.inputs['Value']); lk.new(flo.outputs[0], si.inputs['Index'])
+    # scale Z = 0.1 + h*6
+    hsc = nd.new('ShaderNodeMath'); hsc.operation='MULTIPLY_ADD'; hsc.inputs[1].default_value=6.0; hsc.inputs[2].default_value=0.1
+    lk.new(si.outputs[0], hsc.inputs[0])
+    comb = nd.new('ShaderNodeCombineXYZ'); comb.inputs['X'].default_value=1; comb.inputs['Y'].default_value=1
+    lk.new(hsc.outputs[0], comb.inputs['Z'])
+    scl = nd.new('GeometryNodeScaleInstances')
+    lk.new(iop.outputs['Instances'], scl.inputs['Instances']); lk.new(comb.outputs[0], scl.inputs['Scale'])
+    setm = nd.new('GeometryNodeSetMaterial')
+    lk.new(scl.outputs[0], setm.inputs['Geometry'])
+    # material: emission, color by world Z
+    mat = bpy.data.materials.new(name+"_mat"); mat.use_nodes=True
+    mt=mat.node_tree; mt.nodes.clear()
+    out=mt.nodes.new('ShaderNodeOutputMaterial'); em=mt.nodes.new('ShaderNodeEmission')
+    geo=mt.nodes.new('ShaderNodeNewGeometry'); sep=mt.nodes.new('ShaderNodeSeparateXYZ')
+    mr=mt.nodes.new('ShaderNodeMapRange'); mr.inputs['From Min'].default_value=0; mr.inputs['From Max'].default_value=6
+    ramp=mt.nodes.new('ShaderNodeValToRGB')
+    e=ramp.color_ramp.elements; e[0].position=0.0; e[0].color=zcol[0]; e[1].position=1.0; e[1].color=zcol[1]
+    mt.links.new(geo.outputs['Position'], sep.inputs['Vector'])
+    mt.links.new(sep.outputs['Z'], mr.inputs['Value']); mt.links.new(mr.outputs['Result'], ramp.inputs['Fac'])
+    mt.links.new(ramp.outputs['Color'], em.inputs['Color']); em.inputs['Strength'].default_value=4.0
+    mt.links.new(em.outputs['Emission'], out.inputs['Surface'])
+    setm.inputs['Material'].default_value=mat
+    lk.new(setm.outputs['Geometry'], gout.inputs[0])
+    o = bpy.data.objects.new(name, bpy.data.meshes.new(name)); coll.objects.link(o)
+    m = o.modifiers.new("gn",'NODES'); m.node_group=ng
+    return o
+
+ring("viz_bass","bass_n",RAD,        [(0.0,0.2,1.0,1),(0.2,0.9,1.0,1)])
+ring("viz_mid","mid_n",  RAD+1.4,    [(0.0,1.0,0.4,1),(1.0,1.0,0.2,1)])
+ring("viz_high","high_n",RAD+2.8,    [(1.0,0.3,0.6,1),(1.0,0.9,0.9,1)])
+
+# center sphere pulsing on beat_env (own GN)
+ng2 = bpy.data.node_groups.new("viz_core_gn",'GeometryNodeTree')
+ng2.interface.new_socket("Geometry", in_out='INPUT', socket_type='NodeSocketGeometry')
+ng2.interface.new_socket("Geometry", in_out='OUTPUT', socket_type='NodeSocketGeometry')
+nd,lk=ng2.nodes,ng2.links
+gin=nd.new('NodeGroupInput'); gout=nd.new('NodeGroupOutput')
+ico=nd.new('GeometryNodeMeshIcoSphere'); ico.inputs['Radius'].default_value=1.0; ico.inputs['Subdivisions'].default_value=3
+st=nd.new('GeometryNodeInputSceneTime')
+sidx=nd.new('ShaderNodeMath'); sidx.operation='DIVIDE'; sidx.inputs[1].default_value=DT; lk.new(st.outputs['Seconds'],sidx.inputs[0])
+flo=nd.new('ShaderNodeMath'); flo.operation='FLOOR'; lk.new(sidx.outputs[0],flo.inputs[0])
+oinfo=nd.new('GeometryNodeObjectInfo'); oinfo.inputs['Object'].default_value=audio; oinfo.transform_space='ORIGINAL'
+na=nd.new('GeometryNodeInputNamedAttribute'); na.data_type='FLOAT'; na.inputs['Name'].default_value="beat_env"
+si=nd.new('GeometryNodeSampleIndex'); si.data_type='FLOAT'; si.domain='POINT'; si.clamp=True
+lk.new(oinfo.outputs['Geometry'],si.inputs['Geometry']); lk.new(na.outputs['Attribute'],si.inputs['Value']); lk.new(flo.outputs[0],si.inputs['Index'])
+sc=nd.new('ShaderNodeMath'); sc.operation='MULTIPLY_ADD'; sc.inputs[1].default_value=1.6; sc.inputs[2].default_value=0.8; lk.new(si.outputs[0],sc.inputs[0])
+tr=nd.new('GeometryNodeTransform');
+# scale via Combine
+cmb=nd.new('ShaderNodeCombineXYZ'); lk.new(sc.outputs[0],cmb.inputs['X']); lk.new(sc.outputs[0],cmb.inputs['Y']); lk.new(sc.outputs[0],cmb.inputs['Z'])
+lk.new(ico.outputs['Mesh'],tr.inputs['Geometry']); lk.new(cmb.outputs[0],tr.inputs['Scale'])
+setm=nd.new('GeometryNodeSetMaterial'); lk.new(tr.outputs[0],setm.inputs['Geometry'])
+cmat=bpy.data.materials.new("core_mat"); cmat.use_nodes=True; ct=cmat.node_tree; ct.nodes.clear()
+co=ct.nodes.new('ShaderNodeOutputMaterial'); ce=ct.nodes.new('ShaderNodeEmission'); ce.inputs['Color'].default_value=(1.0,0.6,0.1,1); ce.inputs['Strength'].default_value=6.0
+ct.links.new(ce.outputs['Emission'],co.inputs['Surface']); setm.inputs['Material'].default_value=cmat
+lk.new(setm.outputs[0],gout.inputs[0])
+core=bpy.data.objects.new("viz_core", bpy.data.meshes.new("viz_core")); coll.objects.link(core)
+core.modifiers.new("gn",'NODES').node_group=ng2
+
+# camera + sun
+cam_d=bpy.data.cameras.new("viz_cam"); cam=bpy.data.objects.new("viz_cam",cam_d); coll.objects.link(cam)
+cam.location=(0,-16,11); cam.rotation_euler=(math.radians(58),0,0)
+bpy.context.scene.camera=cam
+sun_d=bpy.data.lights.new("viz_sun",'SUN'); sun_d.energy=1.5; sun=bpy.data.objects.new("viz_sun",sun_d); coll.objects.link(sun); sun.rotation_euler=(math.radians(50),0,0.6)
+result = {"rings":3, "core":True, "cam":"viz_cam"}
+''' % (0.010667, )
+
+print("STAGE B: GN rings + core + camera/light ...")
+print(" ", send(stage_b))
+
+# ---------------- STAGE C: render 3 frames (rozne momenty energii) ----------------
+def render_frame(fr, path):
+    code = r'''
+import bpy
+sc=bpy.context.scene; sc.frame_set(%d)
+sc.render.filepath="%s"; sc.render.image_settings.file_format='PNG'
+bpy.ops.render.render(write_still=True)
+result={"frame":%d,"path":"%s"}
+''' % (fr, path, fr, path)
+    return send(code, timeout=180)
+
+frames = {30:"/tmp/viz_f030.png", 90:"/tmp/viz_f090.png", 600:"/tmp/viz_f600.png"}
+print("STAGE C: render klatek ...")
+for fr, p in frames.items():
+    print(" ", render_frame(fr, p))
+print("DONE")
+

--- a/research/build_visualizer_v2.py
+++ b/research/build_visualizer_v2.py
@@ -1,0 +1,158 @@
+"""V2 — klarowny rytm 120BPM, dramatyczny beat-punch. Render klatek na-beacie vs miedzy
+=> dowod sync z danych (rdzen/pierscien duzy na beacie, maly miedzy)."""
+import json, socket, sys
+
+def send(code, t=180):
+    req = json.dumps({"type": "execute", "code": code, "strict_json": False}) + "\0"
+    with socket.socket() as s:
+        s.settimeout(t); s.connect(("localhost", 9876)); s.sendall(req.encode())
+        buf = bytearray()
+        while True:
+            c = s.recv(65536)
+            if not c: break
+            buf.extend(c)
+            if b"\0" in buf: break
+    r = json.loads(bytes(buf).partition(b"\0")[0].decode())
+    if r.get("status") != "ok":
+        print("  !! ERROR:", str(r.get("message"))[:1500]); sys.exit(1)
+    return r.get("result")
+
+ANALYSIS = "/Users/wokoziej/dev/setka-monorepo/research/audio/analysis/beat_120bpm_12s_analysis.json"
+
+stage_a = r'''
+import bpy, json, numpy as np
+d = json.load(open("%s")); fb=d["frequency_bands"]; ae=d["animation_events"]
+times=np.array(fb["times"],float); dt=float(times[1]-times[0]); N=len(times)
+def norm(a):
+    a=np.array(a,float); p=np.percentile(a,99); return (np.clip(a/p,0,1) if p>0 else np.zeros_like(a)).astype(np.float32)
+bass_n,mid_n,high_n=norm(fb["bass_energy"]),norm(fb["mid_energy"]),norm(fb["high_energy"])
+def env(events, decay):
+    e=np.zeros(N,np.float32)
+    for t in events:
+        i=int(round(t/dt))
+        for k in range(0,int(decay/dt)+1):
+            j=i+k
+            if 0<=j<N: e[j]=max(e[j],1.0-k*dt/decay)
+    return e
+beat_env=env(ae.get("beats",[]),0.13); peak_env=env(ae.get("energy_peaks",[]),0.25)
+for c in list(bpy.data.collections):
+    if c.name=="cymatic_viz":
+        for o in list(c.objects): bpy.data.objects.remove(o,do_unlink=True)
+        bpy.data.collections.remove(c)
+coll=bpy.data.collections.new("cymatic_viz"); bpy.context.scene.collection.children.link(coll)
+me=bpy.data.meshes.new("audio_data"); me.vertices.add(N)
+co=np.zeros(N*3,np.float32); co[0::3]=np.arange(N,dtype=np.float32)*dt; me.vertices.foreach_set("co",co)
+for name,arr in [("bass_n",bass_n),("mid_n",mid_n),("high_n",high_n),("beat_env",beat_env),("peak_env",peak_env)]:
+    a=me.attributes.new(name=name,type='FLOAT',domain='POINT'); a.data.foreach_set("value",arr)
+me.update()
+obj=bpy.data.objects.new("audio_data",me); coll.objects.link(obj); obj.hide_render=True; obj.hide_viewport=True
+sc=bpy.context.scene; sc.render.fps=30; sc.frame_start=1; sc.frame_end=int(d["duration"]*30)
+sc.render.resolution_x=1280; sc.render.resolution_y=720
+try: sc.render.engine='BLENDER_EEVEE_NEXT'
+except Exception: sc.render.engine='BLENDER_EEVEE'
+w=bpy.data.worlds.get("cymatic_world") or bpy.data.worlds.new("cymatic_world"); w.use_nodes=True
+bg=w.node_tree.nodes.get("Background")
+if bg: bg.inputs[0].default_value=(0.01,0.01,0.02,1); bg.inputs[1].default_value=0.25
+sc.world=w
+result={"N":N,"beats":len(ae["beats"]),"frame_end":sc.frame_end}
+''' % ANALYSIS
+
+stage_b = r'''
+import bpy, math
+coll=bpy.data.collections["cymatic_viz"]; audio=bpy.data.objects["audio_data"]; DT=%f
+M=128; STRIDE=0.045
+
+def band_field(nd,lk,attr,with_beat):
+    idx=nd.new('GeometryNodeInputIndex'); st=nd.new('GeometryNodeInputSceneTime')
+    offs=nd.new('ShaderNodeMath'); offs.operation='MULTIPLY'; offs.inputs[1].default_value=STRIDE; lk.new(idx.outputs['Index'],offs.inputs[0])
+    tsec=nd.new('ShaderNodeMath'); tsec.operation='SUBTRACT'; lk.new(st.outputs['Seconds'],tsec.inputs[0]); lk.new(offs.outputs[0],tsec.inputs[1])
+    sidx=nd.new('ShaderNodeMath'); sidx.operation='DIVIDE'; sidx.inputs[1].default_value=DT; lk.new(tsec.outputs[0],sidx.inputs[0])
+    flo=nd.new('ShaderNodeMath'); flo.operation='FLOOR'; lk.new(sidx.outputs[0],flo.inputs[0])
+    oi=nd.new('GeometryNodeObjectInfo'); oi.inputs['Object'].default_value=audio; oi.transform_space='ORIGINAL'
+    na=nd.new('GeometryNodeInputNamedAttribute'); na.data_type='FLOAT'; na.inputs['Name'].default_value=attr
+    si=nd.new('GeometryNodeSampleIndex'); si.data_type='FLOAT'; si.domain='POINT'; si.clamp=True
+    lk.new(oi.outputs['Geometry'],si.inputs['Geometry']); lk.new(na.outputs['Attribute'],si.inputs['Value']); lk.new(flo.outputs[0],si.inputs['Index'])
+    out=si
+    if with_beat:  # global beat punch: + beat_env(current time) * 3
+        sidx0=nd.new('ShaderNodeMath'); sidx0.operation='DIVIDE'; sidx0.inputs[1].default_value=DT; lk.new(st.outputs['Seconds'],sidx0.inputs[0])
+        flo0=nd.new('ShaderNodeMath'); flo0.operation='FLOOR'; lk.new(sidx0.outputs[0],flo0.inputs[0])
+        nb=nd.new('GeometryNodeInputNamedAttribute'); nb.data_type='FLOAT'; nb.inputs['Name'].default_value="beat_env"
+        sb=nd.new('GeometryNodeSampleIndex'); sb.data_type='FLOAT'; sb.domain='POINT'; sb.clamp=True
+        lk.new(oi.outputs['Geometry'],sb.inputs['Geometry']); lk.new(nb.outputs['Attribute'],sb.inputs['Value']); lk.new(flo0.outputs[0],sb.inputs['Index'])
+        bp=nd.new('ShaderNodeMath'); bp.operation='MULTIPLY'; bp.inputs[1].default_value=3.0; lk.new(sb.outputs[0],bp.inputs[0])
+        add=nd.new('ShaderNodeMath'); add.operation='ADD'; lk.new(si.outputs[0],add.inputs[0]); lk.new(bp.outputs[0],add.inputs[1]); out=add
+    return out
+
+def ring(name,attr,radius,zcol):
+    ng=bpy.data.node_groups.new(name,'GeometryNodeTree')
+    ng.interface.new_socket("Geometry",in_out='INPUT',socket_type='NodeSocketGeometry')
+    ng.interface.new_socket("Geometry",in_out='OUTPUT',socket_type='NodeSocketGeometry')
+    nd,lk=ng.nodes,ng.links; gout=nd.new('NodeGroupOutput')
+    circ=nd.new('GeometryNodeMeshCircle'); circ.fill_type='NONE'; circ.inputs['Vertices'].default_value=M; circ.inputs['Radius'].default_value=radius
+    cube=nd.new('GeometryNodeMeshCube'); cube.inputs['Size'].default_value=(0.18,0.18,1.0)
+    iop=nd.new('GeometryNodeInstanceOnPoints'); lk.new(circ.outputs['Mesh'],iop.inputs['Points']); lk.new(cube.outputs['Mesh'],iop.inputs['Instance'])
+    h=band_field(nd,lk,attr,True)
+    hsc=nd.new('ShaderNodeMath'); hsc.operation='MULTIPLY_ADD'; hsc.inputs[1].default_value=5.0; hsc.inputs[2].default_value=0.1; lk.new(h.outputs[0],hsc.inputs[0])
+    comb=nd.new('ShaderNodeCombineXYZ'); comb.inputs['X'].default_value=1; comb.inputs['Y'].default_value=1; lk.new(hsc.outputs[0],comb.inputs['Z'])
+    scl=nd.new('GeometryNodeScaleInstances'); lk.new(iop.outputs['Instances'],scl.inputs['Instances']); lk.new(comb.outputs[0],scl.inputs['Scale'])
+    setm=nd.new('GeometryNodeSetMaterial'); lk.new(scl.outputs[0],setm.inputs['Geometry'])
+    mat=bpy.data.materials.new(name+"_m"); mat.use_nodes=True; mt=mat.node_tree; mt.nodes.clear()
+    out=mt.nodes.new('ShaderNodeOutputMaterial'); em=mt.nodes.new('ShaderNodeEmission')
+    geo=mt.nodes.new('ShaderNodeNewGeometry'); sep=mt.nodes.new('ShaderNodeSeparateXYZ'); mr=mt.nodes.new('ShaderNodeMapRange')
+    mr.inputs['From Min'].default_value=0; mr.inputs['From Max'].default_value=6; ramp=mt.nodes.new('ShaderNodeValToRGB')
+    e=ramp.color_ramp.elements; e[0].position=0; e[0].color=zcol[0]; e[1].position=1; e[1].color=zcol[1]
+    mt.links.new(geo.outputs['Position'],sep.inputs['Vector']); mt.links.new(sep.outputs['Z'],mr.inputs['Value']); mt.links.new(mr.outputs['Result'],ramp.inputs['Fac'])
+    mt.links.new(ramp.outputs['Color'],em.inputs['Color']); em.inputs['Strength'].default_value=4.0; mt.links.new(em.outputs['Emission'],out.inputs['Surface'])
+    setm.inputs['Material'].default_value=mat; lk.new(setm.outputs['Geometry'],gout.inputs[0])
+    o=bpy.data.objects.new(name,bpy.data.meshes.new(name)); coll.objects.link(o); o.modifiers.new("gn",'NODES').node_group=ng
+
+ring("viz_bass","bass_n",5.0,[(0.0,0.2,1.0,1),(0.2,0.9,1.0,1)])
+ring("viz_mid","mid_n",6.4,[(0.0,1.0,0.4,1),(1.0,1.0,0.2,1)])
+ring("viz_high","high_n",7.8,[(1.0,0.3,0.6,1),(1.0,0.9,0.9,1)])
+
+# core: scale = 0.5 + beat_env*3 (dramatyczny puls)
+ng2=bpy.data.node_groups.new("viz_core_gn",'GeometryNodeTree')
+ng2.interface.new_socket("Geometry",in_out='INPUT',socket_type='NodeSocketGeometry')
+ng2.interface.new_socket("Geometry",in_out='OUTPUT',socket_type='NodeSocketGeometry')
+nd,lk=ng2.nodes,ng2.links; gout=nd.new('NodeGroupOutput')
+ico=nd.new('GeometryNodeMeshIcoSphere'); ico.inputs['Radius'].default_value=1.0; ico.inputs['Subdivisions'].default_value=3
+st=nd.new('GeometryNodeInputSceneTime'); sidx=nd.new('ShaderNodeMath'); sidx.operation='DIVIDE'; sidx.inputs[1].default_value=DT; lk.new(st.outputs['Seconds'],sidx.inputs[0])
+flo=nd.new('ShaderNodeMath'); flo.operation='FLOOR'; lk.new(sidx.outputs[0],flo.inputs[0])
+oi=nd.new('GeometryNodeObjectInfo'); oi.inputs['Object'].default_value=audio; oi.transform_space='ORIGINAL'
+na=nd.new('GeometryNodeInputNamedAttribute'); na.data_type='FLOAT'; na.inputs['Name'].default_value="beat_env"
+si=nd.new('GeometryNodeSampleIndex'); si.data_type='FLOAT'; si.domain='POINT'; si.clamp=True
+lk.new(oi.outputs['Geometry'],si.inputs['Geometry']); lk.new(na.outputs['Attribute'],si.inputs['Value']); lk.new(flo.outputs[0],si.inputs['Index'])
+sc2=nd.new('ShaderNodeMath'); sc2.operation='MULTIPLY_ADD'; sc2.inputs[1].default_value=3.0; sc2.inputs[2].default_value=0.5; lk.new(si.outputs[0],sc2.inputs[0])
+tr=nd.new('GeometryNodeTransform'); cmb=nd.new('ShaderNodeCombineXYZ')
+lk.new(sc2.outputs[0],cmb.inputs['X']); lk.new(sc2.outputs[0],cmb.inputs['Y']); lk.new(sc2.outputs[0],cmb.inputs['Z'])
+lk.new(ico.outputs['Mesh'],tr.inputs['Geometry']); lk.new(cmb.outputs[0],tr.inputs['Scale'])
+setm=nd.new('GeometryNodeSetMaterial'); lk.new(tr.outputs[0],setm.inputs['Geometry'])
+cmat=bpy.data.materials.new("core_m"); cmat.use_nodes=True; ct=cmat.node_tree; ct.nodes.clear()
+co=ct.nodes.new('ShaderNodeOutputMaterial'); ce=ct.nodes.new('ShaderNodeEmission'); ce.inputs['Color'].default_value=(1.0,0.5,0.05,1); ce.inputs['Strength'].default_value=8.0
+ct.links.new(ce.outputs['Emission'],co.inputs['Surface']); setm.inputs['Material'].default_value=cmat
+lk.new(setm.outputs[0],gout.inputs[0])
+core=bpy.data.objects.new("viz_core",bpy.data.meshes.new("viz_core")); coll.objects.link(core); core.modifiers.new("gn",'NODES').node_group=ng2
+
+cam_d=bpy.data.cameras.new("viz_cam"); cam=bpy.data.objects.new("viz_cam",cam_d); coll.objects.link(cam)
+cam.location=(0,-17,12); cam.rotation_euler=(math.radians(57),0,0); bpy.context.scene.camera=cam
+sun_d=bpy.data.lights.new("viz_sun",'SUN'); sun_d.energy=1.2; sun=bpy.data.objects.new("viz_sun",sun_d); coll.objects.link(sun); sun.rotation_euler=(math.radians(50),0,0.6)
+result={"ok":1}
+''' % (0.010667,)
+
+print("A:", send(stage_a))
+print("B:", send(stage_b))
+
+# render: beat frames vs between (beats ~0.76,1.26,1.76 -> f23,38,53; between 1.0,1.5 -> f30,45)
+def rndr(fr, path):
+    return send(r'''
+import bpy
+sc=bpy.context.scene; sc.frame_set(%d); sc.render.filepath="%s"; sc.render.image_settings.file_format='PNG'
+bpy.ops.render.render(write_still=True); result={"f":%d}
+''' % (fr, path, fr))
+
+for fr, p in [(23,"/tmp/v2_beat_f23.png"),(30,"/tmp/v2_between_f30.png"),(38,"/tmp/v2_beat_f38.png"),(45,"/tmp/v2_between_f45.png")]:
+    print("render", fr, send(r'''
+import bpy
+sc=bpy.context.scene; sc.frame_set(%d); sc.render.filepath="%s"; sc.render.image_settings.file_format='PNG'
+bpy.ops.render.render(write_still=True); result={"f":%d}''' % (fr,p,fr)))
+print("DONE")

--- a/research/spike2_gn_sampling.py
+++ b/research/spike2_gn_sampling.py
@@ -1,0 +1,121 @@
+"""Spike 2: GN time-sampling (most B). Throwaway — weryfikuje czy drzewo GN
+czyta atrybut po czasie (Seconds/dt -> Sample Index) z poprawnym time->index.
+Run: blender --background --python spike2_gn_sampling.py -- <analysis.json> [fps]
+Czyta wartosc z powrotem przez depsgraph (probe vertex Z = sampled bass).
+"""
+import bpy, json, sys
+import numpy as np
+
+argv = sys.argv[sys.argv.index("--") + 1:]
+analysis_path = argv[0]
+fps = int(argv[1]) if len(argv) > 1 else 30
+
+d = json.load(open(analysis_path))
+fb = d["frequency_bands"]
+times = np.array(fb["times"], dtype=np.float64)
+dt = float(times[1] - times[0])
+bass = np.array(fb["bass_energy"], dtype=np.float64)
+p99 = float(np.percentile(bass, 99))
+bass_n = (np.clip(bass / p99, 0, 1) if p99 > 0 else np.zeros_like(bass)).astype(np.float32)
+N = len(bass_n)
+sr = d["sample_rate"]
+print(f"SPIKE2: sr={sr} dt={dt:.6f} N={N} fps={fps}")
+
+# --- clean scene ---
+bpy.ops.wm.read_factory_settings(use_empty=True)
+scene = bpy.context.scene
+scene.render.fps = fps
+
+# --- 1) data object: mesh N verts, X=arange*dt, float attr bass_n ---
+mesh = bpy.data.meshes.new("audio_data")
+mesh.vertices.add(N)
+co = np.zeros(N * 3, dtype=np.float32)
+co[0::3] = np.arange(N, dtype=np.float32) * dt
+mesh.vertices.foreach_set("co", co)
+attr = mesh.attributes.new(name="bass_n", type='FLOAT', domain='POINT')
+attr.data.foreach_set("value", bass_n)
+mesh.update()
+data_obj = bpy.data.objects.new("audio_data", mesh)
+scene.collection.objects.link(data_obj)
+
+# --- 2) probe: single vertex, GN sets its Z = sampled bass at scene time ---
+pmesh = bpy.data.meshes.new("probe")
+pmesh.vertices.add(1)
+pmesh.vertices.foreach_set("co", [0.0, 0.0, 0.0])
+pmesh.update()
+probe = bpy.data.objects.new("probe", pmesh)
+scene.collection.objects.link(probe)
+
+# --- 3) GN node group (4.0+ interface API) ---
+ng = bpy.data.node_groups.new("sampler", 'GeometryNodeTree')
+ng.interface.new_socket("Geometry", in_out='INPUT', socket_type='NodeSocketGeometry')
+ng.interface.new_socket("Geometry", in_out='OUTPUT', socket_type='NodeSocketGeometry')
+nodes, links = ng.nodes, ng.links
+n_in = nodes.new('NodeGroupInput')
+n_out = nodes.new('NodeGroupOutput')
+
+st = nodes.new('GeometryNodeInputSceneTime')            # Seconds
+div = nodes.new('ShaderNodeMath'); div.operation = 'DIVIDE'
+links.new(st.outputs['Seconds'], div.inputs[0])
+div.inputs[1].default_value = dt                         # index_f = Seconds / dt
+
+floor = nodes.new('ShaderNodeMath'); floor.operation = 'FLOOR'
+links.new(div.outputs[0], floor.inputs[0])
+fr = nodes.new('ShaderNodeMath'); fr.operation = 'SUBTRACT'
+links.new(div.outputs[0], fr.inputs[0]); links.new(floor.outputs[0], fr.inputs[1])
+i1 = nodes.new('ShaderNodeMath'); i1.operation = 'ADD'; i1.inputs[1].default_value = 1.0
+links.new(floor.outputs[0], i1.inputs[0])
+
+obj_info = nodes.new('GeometryNodeObjectInfo')
+obj_info.inputs['Object'].default_value = data_obj
+obj_info.transform_space = 'ORIGINAL'
+
+na = nodes.new('GeometryNodeInputNamedAttribute'); na.data_type = 'FLOAT'
+na.inputs['Name'].default_value = "bass_n"
+
+si0 = nodes.new('GeometryNodeSampleIndex'); si0.data_type = 'FLOAT'; si0.domain = 'POINT'; si0.clamp = True
+si1 = nodes.new('GeometryNodeSampleIndex'); si1.data_type = 'FLOAT'; si1.domain = 'POINT'; si1.clamp = True
+for si, idx in ((si0, floor), (si1, i1)):
+    links.new(obj_info.outputs['Geometry'], si.inputs['Geometry'])
+    links.new(na.outputs['Attribute'], si.inputs['Value'])
+    links.new(idx.outputs[0], si.inputs['Index'])
+
+# mix: v = v0*(1-frac) + v1*frac
+mix = nodes.new('ShaderNodeMix'); mix.data_type = 'FLOAT'
+links.new(fr.outputs[0], mix.inputs['Factor'])
+links.new(si0.outputs[0], mix.inputs[2])   # A
+links.new(si1.outputs[0], mix.inputs[3])   # B
+
+# set position offset Z = mixed value
+setpos = nodes.new('GeometryNodeSetPosition')
+combine = nodes.new('ShaderNodeCombineXYZ')
+links.new(mix.outputs[0], combine.inputs['Z'])
+links.new(n_in.outputs[0], setpos.inputs['Geometry'])
+links.new(combine.outputs[0], setpos.inputs['Offset'])
+links.new(setpos.outputs[0], n_out.inputs[0])
+
+modgn = probe.modifiers.new("gn", 'NODES'); modgn.node_group = ng
+
+# --- 4) verify: for sampled frames, read probe evaluated Z vs expected ---
+depsgraph = bpy.context.evaluated_depsgraph_get()
+def sampled_z(frame):
+    scene.frame_set(frame)
+    dg = bpy.context.evaluated_depsgraph_get()
+    ev = probe.evaluated_get(dg)
+    return float(ev.data.vertices[0].co.z)
+
+def expected(frame):
+    sec = frame / fps
+    idx_f = sec / dt
+    i0 = int(np.floor(idx_f)); i1 = i0 + 1; f = idx_f - i0
+    i0c = min(max(i0, 0), N - 1); i1c = min(max(i1, 0), N - 1)
+    return bass_n[i0c] * (1 - f) + bass_n[i1c] * f
+
+print(f"{'frame':>6} {'sec':>7} {'GN_z':>10} {'expected':>10} {'abs_err':>10}")
+max_err = 0.0
+test_frames = [1, 30, 90, 150, 300, 600, 1200, 2000, int(d['duration']*fps)-1]
+for fr_n in test_frames:
+    gz = sampled_z(fr_n); ex = expected(fr_n); err = abs(gz - ex)
+    max_err = max(max_err, err)
+    print(f"{fr_n:>6} {fr_n/fps:>7.2f} {gz:>10.5f} {ex:>10.5f} {err:>10.2e}")
+print(f"SPIKE2_RESULT sr={sr} max_abs_err={max_err:.3e} verdict={'PASS' if max_err < 1e-4 else 'FAIL'}")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -11,6 +11,7 @@ resolution-markers = [
 members = [
     "beatrix",
     "cinemon",
+    "cymatic",
     "medusa",
     "obsession",
     "setka-common",
@@ -524,6 +525,35 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cymatic"
+version = "0.1.0"
+source = { editable = "packages/cymatic" }
+dependencies = [
+    { name = "beatrix" },
+    { name = "setka-common" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "beatrix", editable = "packages/beatrix" },
+    { name = "setka-common", editable = "packages/common" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Co to jest

Nowy pakiet workspace **`cymatic`** — proceduralny wizualizer audio 3D (Blender Geometry Nodes) sterowany analizą `beatrix`, autorowany przez oficjalny Blender MCP, renderowany do mp4. Powstał metodą compound-engineering: brainstorm → plan (recenzowany) → de-ryzykujące spike'y → implementacja → render end-to-end.

## Workflow (potwierdzony empirycznie)

`audio → beatrix (--beat-division 1) → analysis.json → cymatic: normalizacja p99 + obwiednie + dt → Claude przez MCP buduje scenę GN w żywym Blenderze (most B) → akceptacja looku → render headless → mp4`

## De-ryzykowanie — 4 spike'y PASS (na żywej maszynie, Blender 5.1.2, realne CC0 audio, 2× sample rate)

- **Spike 0 (pożądalność):** działający wizualizer zbudowany na żywo; sync potwierdzony.
- **Spike 1 (normalizacja):** per-track p99, CV 0.4–0.7, clamp 1%.
- **Spike 2 (most B — GN time-sampling):** `Seconds/dt → Sample Index×2 + Mix`, err **6e-08** na 48k i 44k (R3).
- **Spike 3a (MCP):** oficjalny Blender Lab MCP, `execute_blender_code` + screenshot zweryfikowane; podpięty do Claude Code.

## Implementacja (Unity 4–10)

**Host-side** (`src/cymatic/`): `config`, `normalization`, `analysis_loader` (dt/sr per-track, R3), `runner` (subprocess + frames→ffmpeg mux), `sync_verification` (±N klatek, **0** odchyłki), `cli`.
**In-Blender** (`blender_script/`, bpy-guarded): `data_object`, `gn_sampler` (most B), `presets/hybrid_v1`, `build_scene` (headless render). Leniwe importy (PEP 562 + lazy beatrix) → działa w bundled-python Blendera bez PyYAML.

## Render end-to-end

`cymatic.render()` → headless Blender (scena GN + 360 klatek PNG) → mux `ffmpeg` 8.1.1 → `beat_120bpm_12s_analysis.mp4` (H.264 960×540 + AAC, 12.0s). Blender 5.1.2 bez wewnętrznego enkodera FFMPEG → ścieżka frames→mux.

## Testy

**95 testów zielonych** (`uv run --package cymatic pytest`). `beatrix`/`setka-common` nietknięte (INV1). Klony prior-art (GPL) i audio testowe — gitignored.

## Poza zakresem (MVP gate)

- Unit 11 / Faza C: autonomiczna pętla autoringu MCP (R5).
- Fine-tuning codec/preset, render pełnej długości.

Plan + wymagania: `docs/plans/2026-05-30-001-feat-gn-audio-visualizer-plan.md`, `docs/brainstorms/2026-05-30-gn-audio-visualizer-requirements.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)