### PR TITLE
fix(fermata): wywołanie beatrix analyze + naprawa testu render

### DIFF
--- a/packages/fermata/src-tauri/src/services/process_runner.rs
+++ b/packages/fermata/src-tauri/src/services/process_runner.rs
@@ -31,7 +31,7 @@ impl ProcessRunner {
         log::info!("🎵 Running beatrix analyze: audio={}, output={}", audio_path.display(), analysis_dir.display());
 
         let mut cmd = AsyncCommand::new(&self.uv_path);
-        cmd.args(&["run", "--package", "beatrix", "beatrix"])
+        cmd.args(&["run", "--package", "beatrix", "beatrix", "analyze"])
             .arg(&audio_path)
             .arg(&analysis_dir)
             .current_dir(&self.workspace_root);
@@ -254,7 +254,7 @@ mod tests {
         let recording_path = temp_dir.path().join("test_recording");
         fs::create_dir_all(&recording_path).unwrap();
 
-        let result = runner.run_cinemon_render(&recording_path, "beat-switch").await;
+        let result = runner.run_cinemon_render(&recording_path, "beat-switch", None).await;
 
         // Should not panic and should return some result
         assert!(result.is_ok());


### PR DESCRIPTION
## Summary
Dwie naprawy w `packages/fermata/src-tauri/src/services/process_runner.rs`:

- **Bug runtime**: po modernizacji beatrix do `@click.group()` (merge `modernize-beatrix-cli-issue-2`, już w master) gołe wywołanie `beatrix <audio> <output>` tylko drukuje help zamiast analizować. Dodano podkomendę `analyze`, więc analiza audio z poziomu fermaty znów działa.
- **Błąd kompilacji testów**: `test_cinemon_render_command_structure` wołał `run_cinemon_render` bez argumentu `main_audio`, przez co cały moduł testowy fermaty się nie kompilował. Dodano `None`.

## Testing
- `cargo check` — czysto (tylko istniejące ostrzeżenia dead-code, niezwiązane).
- `cargo test --lib process_runner` — 6/6 zielonych (wcześniej moduł testowy w ogóle się nie kompilował).

## Post-Deploy Monitoring & Validation
- **Co obserwować**: logi fermaty przy uruchomieniu analizy — `🎵 Running beatrix analyze: audio=..., output=...`.
- **Sygnał zdrowy**: powstaje katalog `analysis/` z plikiem `*_analysis.json` po zakończeniu operacji.
- **Sygnał awarii / trigger rollbacku**: proces beatrix kończy się kodem ≠ 0 lub drukuje help zamiast analizować → rollback commita.
- **Walidacja**: jednorazowo uruchomić analizę na realnym nagraniu z GUI fermaty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)