### PR TITLE
feat: Bitwig jako etap miksu w pipelinie teledysku (mixed/ + master-aware analiza)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,19 +259,30 @@ Each package provides specific commands:
 # 1. Extract sources from OBS recording
 obs-extract /path/to/recording.mkv
 
-# 2. Analyze audio for animation timing
+# 2. Mix/level audio manually in Bitwig, then export the master mix to mixed/
+#    (File -> Export Audio -> Project Master). The polished master from mixed/
+#    drives analysis AND becomes the final clip soundtrack; extracted/ stays as
+#    the video source. The mixed/ directory is managed by RecordingStructureManager.
+
+# 3. Analyze audio for animation timing (analyze the Bitwig master)
 uv run --package beatrix python -m beatrix.cli.analyze_audio \
-  "/path/to/recording/extracted/main_audio.m4a" \
+  "/path/to/recording/mixed/master.wav" \
   "/path/to/recording/analysis"
 
-# 3. Create Blender VSE project with preset-based animations
+# 4. Create Blender VSE project with preset-based animations
+#    Point --main-audio at the master using an ABSOLUTE path. Cinemon is
+#    master-aware: it picks analysis/master_analysis.json matching the master.
 cinemon-blend-setup /path/to/recording \
   --preset vintage \
-  --main-audio "main_audio.m4a"
+  --main-audio "/path/to/recording/mixed/master.wav"
 
-# 4. Upload and publish to social media
+# 5. Upload and publish to social media
 python -m medusa.cli upload /path/to/recording/blender/render/output.mp4
 ```
+
+> Audio/video drift is compensated manually in Blender (the pipeline does not
+> auto-sync). Per-instrument stems (`mixed/stems/`) and per-track animation
+> targeting are a future phase.
 
 ### Beatrix Audio Analysis Examples
 

--- a/docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md
+++ b/docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md
@@ -1,0 +1,97 @@
+---
+date: 2026-06-02
+topic: bitwig-mixed-audio-pipeline
+---
+
+# Bitwig jako etap miksu w pipelinie teledysku
+
+## Problem Frame
+
+Wojtas gra live, nagrywa w OBS (canvas → MKV) i — po pracach z
+[[2026-05-31-midi-recording-orchestration-requirements]] — równolegle łapie wielościeżkowy
+materiał w Bitwigu. Dziś pipeline teledysku (OBSession → Fermata → Beatrix → Cinemon → Blender)
+analizuje i wkleja do klipu **surowe audio z OBS** — bez szansy na poprawę jakości.
+
+Cel: wstawić **Bitwig jako ręczny etap post-produkcji audio** pomiędzy nagraniem a analizą.
+Po nagraniu Wojtas wyrównuje głośności / miksuje w Bitwigu i dopiero **ten dopracowany eksport**
+napędza analizę (Beatrix) oraz ścieżkę dźwiękową finalnego klipu. Głównym celem jest **jakość
+post-produkcji audio**; targetowanie animacji per-ścieżka to bonus na później.
+
+## Requirements
+
+- **R1.** Struktura nagrania zyskuje **ustaloną konwencję katalogu** na eksport audio z Bitwiga
+  (master mix; miejsce gotowe również na stemy per-instrument). Realizacja przez rozszerzenie
+  `RecordingStructureManager` w `setka-common`.
+- **R2.** **Beatrix analizuje master mix z Bitwiga** zamiast audio wyciągniętego z OBS —
+  wskazaniem istniejącego CLI na plik w katalogu miksu (bez zmiany ducha Beatrix).
+- **R3.** **Cinemon używa master miksu z Bitwiga jako finalnego audio klipu** (`--main-audio`
+  wskazuje plik w katalogu miksu). Wideo nadal pochodzi z OBSession.
+- **R4.** Różnica czasu audio↔wideo (dryf) jest kompensowana **ręcznie w montażu Blender**.
+  Brak automatycznej synchronizacji w pipelinie; na start kompensację można pominąć.
+- **R5.** Workflow jest **udokumentowany w wiki** (`Post-prod teledysk` + sekcja eksportu w
+  `Bitwig Studio`, już uzupełniona), tak by ręczny krok miksu i konwencja handoffu były jasne.
+- **R6. (bonus, odroczone)** Eksport stemów per-instrument umożliwia Beatrix per-stem i
+  targetowanie animacji per-kamera w Cinemon. Pełna funkcja odroczona do drugiej fazy; **layout
+  danych z R1 musi być gotowy na stemy bez przebudowy**.
+
+## Success Criteria
+
+- Ścieżka dźwiękowa finalnego klipu = **zmiksowany/wyrównany master z Bitwiga**, nie surowe
+  audio z OBS.
+- Beatrix uruchamia się na master miksie z Bitwiga, a jego zdarzenia napędzają Cinemon.
+- Istnieje **powtarzalny, udokumentowany handoff**: eksport z Bitwiga → ustalony folder →
+  istniejące CLI (Beatrix/Cinemon) → render.
+- Dołożenie stemów w drugiej fazie **nie wymaga przebudowy** layoutu danych.
+
+## Scope Boundaries
+
+- **Bez** automatycznej synchronizacji audio/wideo i **bez** wyrównywania OBS-audio vs
+  Bitwig-audio (dryf → ręcznie w Blenderze).
+- **Bez** automatyzacji eksportu w Bitwigu (ręczne `File → Export Audio`) i **bez** generowania
+  DAWproject.
+- **Bez** pełnego targetowania per-stem teraz (R6 odroczone do drugiej fazy).
+- **Bez** zmian w orkiestracji nagrywania — to domena
+  [[2026-05-31-midi-recording-orchestration-requirements]].
+- Sam miks pozostaje **ręczną pracą kreatywną**; automatyzujemy tylko handoff i przepięcie wejść.
+
+## Key Decisions
+
+- **Bitwig = ręczny etap miksu w pipelinie** (analogicznie do decyzji kreatywnych w Fermacie):
+  cel to jakość audio, nie ground-truth z MIDI.
+- **Master mix = kręgosłup** (finalne audio + Beatrix); **stemy = tani eksport** odblokowujący
+  bonus per-track, ale kosztowny downstream → osobna faza.
+- **Handoff = konwencja katalogu** w strukturze nagrania (minimum nowego kodu; Beatrix/Cinemon
+  już przyjmują jawną ścieżkę audio) — zamiast kroku w Fermacie czy nowej komendy-glue.
+- **Sync poza pipelinem** — dryf koryguje człowiek w Blenderze; ewentualny pojedynczy parametr
+  offsetu w Cinemon to przyszłość, nie MVP.
+
+## Dependencies / Assumptions
+
+- Bitwig produkuje **zmiksowany master** (i opcjonalnie stemy) — zależy od wielościeżkowego
+  capture z [[2026-05-31-midi-recording-orchestration-requirements]] (lub przynajmniej miksu
+  stereo nagranego w Bitwigu).
+- **Potwierdzone:** Bitwig eksportuje dowolny track osobno oraz `Project Master` przez
+  `File → Export Audio` (wiki `Bitwig Studio` zaktualizowane, źródło: Bitwig Userguide).
+- Beatrix (CLI: ścieżka audio + katalog wyjścia) i Cinemon (`--main-audio`) **już przyjmują
+  jawną ścieżkę** → do weryfikacji w planowaniu, że nie trzeba zmian w kodzie tych pakietów.
+- `RecordingStructureManager` (`setka-common`) to wspólne miejsce na nowy katalog.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1][Technical] Nazwa i kształt konwencji katalogu (`mixed/` vs `bitwig/`), nazewnictwo
+  pliku master vs stemów, akceptowane formaty (WAV/FLAC) i API w `RecordingStructureManager`.
+- [Affects R2][Technical] Czy Beatrix/Cinemon wymagają jakiejkolwiek zmiany kodu, czy wystarczy
+  wskazanie nowej ścieżki (zweryfikować na realnym CLI).
+- [Affects R3/R4][Technical] Rola audio z OBS po zmianie (przestajemy je ekstraktować czy
+  zostaje nieszkodliwym fallbackiem) oraz ewentualny pojedynczy parametr offsetu audio w Cinemon.
+- [Affects R6][Needs research] Projekt drugiej fazy: Beatrix per-stem (wiele wejść →
+  per-stem events) i mapowanie stem→kamera/strip w Cinemon.
+- [Drobne][Technical] Wiki: poprawić lokalizację paternologii (`~/dev/paternologia` →
+  `packages/paternologia` po PR #30) na stronie `Paternologia` i w workflowach.
+
+## Next Steps
+
+→ `/ce:plan` — wszystkie decyzje produktowe rozstrzygnięte; pozostałe pytania są techniczne
+i należą do planowania.

--- a/docs/plans/2026-06-02-001-feat-bitwig-mixed-audio-pipeline-plan.md
+++ b/docs/plans/2026-06-02-001-feat-bitwig-mixed-audio-pipeline-plan.md
@@ -1,0 +1,318 @@
+---
+title: "feat: Bitwig jako etap miksu w pipelinie teledysku"
+type: feat
+status: completed
+date: 2026-06-02
+origin: docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md
+deepened: 2026-06-02
+---
+
+# feat: Bitwig jako etap miksu w pipelinie teledysku
+
+## Overview
+
+Wstawiamy **Bitwig jako ręczny etap post-produkcji audio** pomiędzy nagraniem a analizą.
+Po nagraniu Wojtas miksuje/wyrównuje głośności w Bitwigu i eksportuje dopracowany **master mix**
+do ustalonego katalogu w strukturze nagrania (`mixed/`). Od tego momentu **Beatrix analizuje ten
+master, a Cinemon używa go jako finalnego audio klipu** — zamiast surowego audio wyciągniętego
+z OBS. Dryf audio↔wideo koryguje się ręcznie w Blenderze (poza pipelinem).
+
+Zmiana jest celowo mała (wariant **„chude MVP"** wybrany po przeglądzie planu): Beatrix nie wymaga
+zmian, a my **nie ruszamy współdzielonego resolvera ścieżek ani `MediaDiscovery`**. Realna praca to
+(1) kanoniczny katalog `mixed/` w `setka-common`, (2) jawne wskazanie Cinemonowi mastera przez
+`--main-audio` **ścieżką absolutną** (resolver bez zmian — działa dziś) oraz (3) drobna,
+**master-aware** poprawka wyboru pliku analizy w Cinemonie, by nie użyć nieaktualnej analizy.
+**Cymatic pozostaje poza zakresem.** Dryf audio↔wideo koryguje się ręcznie w Blenderze.
+
+## Problem Frame
+
+Dziś pipeline teledysku (OBSession → Fermata → Beatrix → Cinemon → Blender) analizuje i wkleja
+do klipu **surowe audio z OBS** — bez szansy na poprawę jakości. Cel: jakość post-produkcji
+audio przez ręczny miks w Bitwigu, którego eksport napędza dalszy pipeline. Pełny opis intencji
+i decyzji produktowych: origin doc
+(`docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md`).
+
+## Requirements Trace
+
+- **R1.** Struktura nagrania ma kanoniczny katalog `mixed/` na eksport audio z Bitwiga (master;
+  gotowy też na stemy) — przez `RecordingStructureManager` (see origin: R1).
+- **R2.** Beatrix analizuje master mix z Bitwiga (wskazanie istniejącego CLI na plik w `mixed/`)
+  (see origin: R2).
+- **R3.** Cinemon używa master miksu z Bitwiga jako finalnego audio klipu; wideo dalej z
+  OBSession (see origin: R3).
+- **R4.** Dryf audio↔wideo kompensowany ręcznie w Blenderze; brak auto-sync w pipelinie
+  (see origin: R4).
+- **R5.** Workflow udokumentowany w wiki (`Post-prod teledysk` + sekcja eksportu `Bitwig Studio`,
+  ta druga już zrobiona) (see origin: R5).
+- **R6. (odroczone)** Layout `mixed/` gotowy na stemy per-instrument bez przebudowy; pełne
+  targetowanie per-ścieżka = osobna faza (see origin: R6).
+
+## Scope Boundaries
+
+- **Bez** automatycznej synchronizacji audio/wideo i bez wyrównywania OBS-audio vs Bitwig-audio.
+- **Bez** automatyzacji eksportu w Bitwigu (ręczne `File → Export Audio`) i bez DAWproject.
+- **Bez** pełnego targetowania per-stem teraz (R6 odroczone).
+- **Bez** zmian w orkiestracji nagrywania (domena planu midi-recording-orchestration).
+- **Bez** zmian w Beatrix (CLI już przyjmuje dowolną ścieżkę — potwierdzone w researchu).
+- **Bez** zmian we współdzielonym resolverze ścieżek (`_resolve_relative_paths`) ani w
+  `MediaDiscovery` — mastera wskazujemy jawnie ścieżką absolutną (wariant A po przeglądzie planu).
+- **Cymatic poza zakresem** — dalej konsumuje audio/analizę z `extracted/` (ma własny resolver,
+  nie używa `MediaDiscovery`); użycie mastera z `mixed/` w cymatic to przyszła faza.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`packages/common/src/setka_common/file_structure/specialized/recording.py`** — klasa
+  `RecordingStructureManager` (od linii 54). Stałe `EXTRACTED_DIRNAME`/`BLENDER_DIRNAME`/
+  `ANALYSIS_DIRNAME` (l. 58–60), dataclass `RecordingStructure` (pole `extracted_dir`),
+  `get_structure()` (63–95), `create_structure()` (98–122), wzorzec `ensure_analysis_dir()`
+  (228–265) i `ensure_blender_dir()` (183–225). **Wzór dodania katalogu = mirror tych metod.**
+- **`packages/common/src/setka_common/utils/files.py`** — `MediaDiscovery` (30–178);
+  **niezmieniany w tym planie**. Uwaga: `__init__` twardo wymaga istnienia `extracted/`
+  (`FileNotFoundError`), a `validate_structure()` wymaga audio w `extracted/` → `extracted/`
+  pozostaje warunkiem wstępnym (OBSession zawsze je produkuje).
+- **`packages/common/src/setka_common/config/yaml_config.py`** — `_resolve_relative_paths()`
+  (440–504): **ścieżka absolutna `main_audio` zwracana bez zmian (l. 463–464)** → mastera z
+  `mixed/` wskazujemy absolutnie, **bez ruszania resolvera**. (Goła nazwa dalej → `extracted/`.)
+- **`packages/cinemon/src/cinemon/config/cinemon_config_generator.py`** —
+  `generate_config_from_preset()` (82–96) bierze `main_audio` z override lub
+  `discovery.detect_main_audio()`. **Wybór analizy (186–191) używa `analysis_files[0]` —
+  posortowane alfabetycznie → tu leży P0:** przy współistnieniu starej `*_analysis.json` z
+  `master_analysis.json` może trafić w nieaktualny plik. To miejsce poprawki w Unit 2.
+- **`packages/cinemon/src/cinemon/cli/blend_setup.py`** — opcja `--main-audio` (162–166),
+  przekazanie jako override (287–295).
+- **`packages/beatrix/src/beatrix/cli/click_cli.py`** — `analyze(audio_file, output_dir, …)`
+  (46–109): `audio_file` to dowolna istniejąca ścieżka, `output_dir` tworzony, wynik
+  `{stem}_analysis.json` (78–80). **Zero zmian.**
+- **`packages/common/src/setka_common/file_structure/types.py`** — `AUDIO` (l. 22) zawiera
+  `.wav`/`.flac` → eksport Bitwiga jest natywnie akceptowany.
+
+### Institutional Learnings
+
+- Workflow testów Setka: uruchamiać pytest **po ścieżce** i używać `uv sync --all-packages`;
+  pełne `uv run pytest` bywa zepsute (z pamięci projektu). Weryfikację jednostek wyrażono jako
+  uruchomienie testów konkretnego pakietu po ścieżce.
+
+### External References
+
+- Bitwig Userguide — Exporting Audio (`File → Export Audio`: per-track + Project Master) —
+  potwierdza wykonalność eksportu mastera i stemów; wiki `Bitwig Studio` zaktualizowane.
+
+## Key Technical Decisions
+
+- **Katalog `mixed/` jako kanoniczne miejsce eksportu** (a nie reużycie `extracted/`): oddziela
+  „surowe źródła z OBS" od „dopracowanego miksu z Bitwiga"; czytelne dla człowieka; naturalnie
+  pomieści przyszłe stemy (`mixed/stems/`).
+- **Master wskazywany jawnie, ścieżką absolutną** w `--main-audio` (wariant A): zero zmian we
+  współdzielonym resolverze (`yaml_config.py:463-464` już zwraca absolutną ścieżkę bez zmian).
+  Eliminuje ryzyko regresji `extracted/` i klasę bugów z auto-discovery (cymatic, separator w
+  zwracanej ścieżce, przypadkowy plik w `mixed/`). Koszt: trzeba podać ścieżkę absolutną.
+- **Master-aware wybór analizy w Cinemonie (P0 fix):** zamiast `analysis_files[0]` (sortowane)
+  Cinemon wyprowadza oczekiwaną nazwę analizy ze stemu `main_audio` (`master.wav` →
+  `master_analysis.json`) i preferuje ją; brak dopasowania → dotychczasowe zachowanie. Bez tego
+  nieaktualna `*_analysis.json` z poprzedniego runu cicho rozjeżdża animacje z dźwiękiem.
+- **Cymatic poza zakresem** — ma własny resolver (`AudioValidator().detect_main_audio(extracted_dir)`
+  + `{stem}_analysis.json`), nie korzysta z `MediaDiscovery`; douczenie go `mixed/` to przyszła faza.
+- **Beatrix bez zmian** — wskazujemy CLI na master, output do `analysis/`.
+- **Sync poza kodem** — dryf koryguje człowiek w Blenderze; **założenie do weryfikacji: relacja to
+  stały offset, nie narastający clock drift** (patrz Open Questions / Risks).
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Czy Beatrix/Cinemon wymagają zmian kodu?* — Beatrix: nie. Cinemon: jedyna zmiana to
+  master-aware wybór pliku analizy (P0 fix); **brak** zmian w `MediaDiscovery`/resolverze.
+- *Zakres handoffu (przegląd planu)* — wariant A „chude MVP": master wskazywany jawnie ścieżką
+  absolutną; auto-discovery i zmiana resolvera odrzucone jako nadmiarowe wobec celu i ryzykowne
+  dla shared code.
+- *Nazwa konwencji katalogu* — `mixed/` (master jako `mixed/master.wav`, stemy w przyszłości w
+  `mixed/stems/`).
+- *Rola audio z OBS* — `extracted/` pozostaje warunkiem wstępnym (OBSession je produkuje) i
+  źródłem wideo; finalne audio bierzemy z mastera wskazanego jawnie.
+- *Format pliku* — WAV (i FLAC) są już w dozwolonych rozszerzeniach `AUDIO`.
+- *Cymatic* — poza zakresem (własny resolver na `extracted/`); douczenie `mixed/` = przyszła faza.
+
+### Deferred to Implementation
+
+- Dokładne nazwy metod/pól (`ensure_mixed_dir`, `mixed_dir`) — do ustalenia przy mirrorze
+  istniejących metod.
+- Projekt drugiej fazy (R6): Beatrix per-stem (wiele wejść) i mapowanie stem→strip w Cinemon —
+  osobny plan; wtedy też ergonomia (auto-discovery `mixed/`) i objęcie cymatic.
+
+### Needs Validation (przed poleganiem na „no-sync")
+
+- [Affects R4][Needs research] Zmierzyć offset audio↔wideo na początku i końcu jednego pełnego,
+  długiego nagrania. Jeśli różnica head-vs-tail jest niezerowa (narastający drift), **pojedynczy
+  offset w Blenderze nie wystarczy** — wtedy ręczna korekta wymaga retime/stretch, co zmienia
+  trudność i sens odłożonego „parametru offsetu".
+
+## Implementation Units
+
+- [x] **Unit 1: Katalog `mixed/` w RecordingStructureManager**
+
+**Goal:** Dodać kanoniczny katalog `mixed/` do struktury nagrania (master teraz, miejsce na stemy).
+
+**Requirements:** R1, R6 (gotowość layoutu)
+
+**Dependencies:** brak
+
+**Files:**
+- Modify: `packages/common/src/setka_common/file_structure/specialized/recording.py`
+- Test: `packages/common/tests/test_recording_structure.py`
+
+**Approach:**
+- Dodać stałą `MIXED_DIRNAME = "mixed"` obok istniejących (l. ~58–60).
+- Rozszerzyć dataclass `RecordingStructure` o pole `mixed_dir: Path`.
+- Uzupełnić `get_structure()` (zbudowanie `mixed_dir`) i `create_structure()` (`mkdir`).
+- Dodać `ensure_mixed_dir(recording_dir)` w stylu `ensure_analysis_dir()` (walidacja pustej
+  ścieżki, `mkdir(parents=True, exist_ok=True)`, te same wyjątki `InvalidPathError`/
+  `DirectoryCreationError`).
+- Layout docelowy: `mixed/master.wav` (+ przyszłe `mixed/stems/`).
+
+**Patterns to follow:** `ensure_analysis_dir()` (recording.py:228–265), `ensure_blender_dir()`
+(183–225); stałe i pola dataclass jak `ANALYSIS_DIRNAME`/`analysis_dir`.
+
+**Test scenarios:**
+- Happy path: `get_structure(video)` zwraca `mixed_dir == recording_dir/"mixed"` bez tworzenia
+  katalogu.
+- Happy path: `create_structure(video)` tworzy `mixed/` obok `extracted/`, `analysis/`, `blender/`.
+- Happy path: `ensure_mixed_dir(recording_dir)` tworzy katalog i jest idempotentne (drugie
+  wywołanie nie rzuca).
+- Edge case: pusta/niepoprawna `recording_dir` → `InvalidPathError` (jak w istniejących testach).
+- Edge case: stała `MIXED_DIRNAME == "mixed"` (test wartości stałych, wzór l. 388–394).
+
+**Verification:** Testy `packages/common/tests/test_recording_structure.py` (uruchamiane po
+ścieżce dla pakietu `common`) przechodzą; `RecordingStructure` ma `mixed_dir`, a
+`create_structure` materializuje `mixed/`.
+
+---
+
+- [x] **Unit 2: Master-aware wybór pliku analizy w Cinemonie (P0 fix)**
+
+**Goal:** Gdy podano `main_audio` (np. absolutna ścieżka do `mixed/master.wav`), Cinemon ma
+wybrać **analizę pasującą do mastera** (`master_analysis.json`), a nie pierwszy alfabetycznie plik
+w `analysis/`. Bez tego nieaktualna analiza poprzedniego runu cicho rozjeżdża animacje z dźwiękiem.
+
+**Requirements:** R2, R3, R4
+
+**Dependencies:** Unit 1 (konwencja `mixed/`), ale technicznie niezależny od niej w kodzie
+
+**Files:**
+- Modify: `packages/cinemon/src/cinemon/config/cinemon_config_generator.py` (`_build_config_from_preset`,
+  blok auto-wykrycia analizy l. ~186–191)
+- Test: `packages/cinemon/tests/` (test generatora configu — dopasować do istniejącego pliku
+  testów `cinemon_config_generator`)
+
+**Approach:**
+- W bloku wyboru analizy: jeśli znane jest `main_audio`, wyprowadzić oczekiwaną nazwę
+  `f"{Path(main_audio).stem}_analysis.json"` i jeśli taki plik jest wśród
+  `discovery.discover_analysis_files()` — wybrać go (jako `analysis/<nazwa>`).
+- Fallback (brak dopasowania lub brak `main_audio`): **dotychczasowe** zachowanie
+  (`analysis_files[0]`), więc istniejące nagrania działają bez zmian.
+- **Brak** zmian w `MediaDiscovery` i `_resolve_relative_paths` (wariant A). Master wskazywany
+  przez `--main-audio` ścieżką absolutną → resolver zwraca ją bez zmian (`yaml_config.py:463-464`).
+- Beatrix bez zmian: `beatrix analyze /abs/…/mixed/master.wav /abs/…/analysis/` daje
+  `analysis/master_analysis.json`.
+
+**Patterns to follow:** istniejący blok `discover_analysis_files()` w
+`cinemon_config_generator.py` (186–191); `Path(...).stem` jak w Beatrix (`click_cli.py:78–80`).
+
+**Test scenarios:**
+- Happy path: `main_audio` stem = `master`, w `analysis/` są `master_analysis.json` **oraz**
+  stara `main_audio_analysis.json` → wybrana zostaje `analysis/master_analysis.json` (rdzeń P0).
+- Happy path: `main_audio` stem = `master`, w `analysis/` tylko `master_analysis.json` → wybrana.
+- Edge case: `main_audio` podane, ale brak `{stem}_analysis.json` → fallback do `analysis_files[0]`
+  (zachowanie jak dziś), bez wyjątku.
+- Edge case (regresja): `main_audio` nie podane (auto-detekcja) → wybór analizy identyczny jak
+  przed zmianą.
+- Edge case: `analysis/` puste → analiza `None`/pominięta jak dziś (bez wyjątku).
+
+**Verification:** Testy `cinemon` (po ścieżce) przechodzą; dla nagrania, gdzie współistnieją stara
+i master-analiza, generator wpina `analysis/master_analysis.json`; ścieżki bez `main_audio` lub
+bez dopasowania zachowują dotychczasowy wybór.
+
+---
+
+- [x] **Unit 3: Dokumentacja workflow post-prod z Bitwigiem**
+
+**Goal:** Opisać ręczny krok miksu + konwencję `mixed/` tak, by workflow był powtarzalny.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1, Unit 2 (opisujemy realne zachowanie: jawne `--main-audio` + master-aware analiza)
+
+**Files:**
+- Modify: `~/dev/music-box-wiki/wiki/workflows/Post-prod teledysk.md` (dodać etap „Miks w
+  Bitwigu → eksport do `mixed/`" przed Beatrix; zaznaczyć ręczną kompensację dryfu w Blenderze)
+- Modify: `~/dev/music-box-wiki/wiki/software/Paternologia.md` (poprawić lokalizację:
+  `~/dev/paternologia` → `packages/paternologia` po PR #30) oraz wzmianki w workflowach, jeśli są
+- Modify: `CLAUDE.md` (sekcja „Complete Pipeline Workflow" — dodać krok eksportu z Bitwiga do
+  `mixed/` i wskazania Beatrix/Cinemon na master)
+
+**Approach:**
+- Workflow: po ekstrakcji OBSession → **ręczny miks w Bitwigu** → `File → Export Audio` mastera
+  do `mixed/master.wav` → `beatrix analyze /abs/…/mixed/master.wav /abs/…/analysis/` →
+  `cinemon-blend-setup … --main-audio /abs/…/mixed/master.wav` (**ścieżka absolutna**) → render;
+  offset audio/wideo ustawiany ręcznie w Blenderze.
+- Zaznaczyć: stemy (`mixed/stems/`), auto-discovery i targetowanie per-ścieżka to przyszła faza (R6).
+- Sekcja eksportu w `Bitwig Studio.md` jest już dodana — tylko podlinkować z workflow.
+- **`~/dev/music-box-wiki` to osobne repo git** (poza monorepo i poza CI) — edycje commitować/PR-ować
+  niezależnie; tu tylko opisujemy, co zmienić.
+
+**Patterns to follow:** styl i schema wiki (frontmatter `last_updated`, linki `[[…]]`) wg
+`music-box-wiki/CLAUDE.md`; istniejący `Post-prod teledysk.md`.
+
+**Test scenarios:** brak (dokumentacja). Weryfikacja przez przegląd treści.
+
+**Verification:** `Post-prod teledysk` pokazuje etap Bitwig→`mixed/` i ręczną kompensację dryfu;
+lokalizacja paternologii poprawiona; przykład w `CLAUDE.md` używa `mixed/master.wav`.
+
+## System-Wide Impact
+
+- **Interaction graph:** Unit 1 (nowa stała/pole w `RecordingStructureManager`) jest czysto
+  addytywne. Unit 2 dotyka **tylko** `cinemon_config_generator` (wybór analizy) — z fallbackiem do
+  obecnego zachowania. **Shared resolver/`MediaDiscovery` nieruszane** → brak wpływu na innych
+  konsumentów.
+- **Cymatic:** świadomie nieobjęty — ma własny resolver na `extracted/` + `{stem}_analysis.json`;
+  nie korzysta z `MediaDiscovery`, więc ta zmiana go nie dotyka (ani nie psuje, ani nie pomaga).
+- **Error propagation:** brak `mixed/` / brak `--main-audio` → ścieżki fallback działają jak dziś,
+  nie błąd. Brak dopasowanej master-analizy → fallback `analysis_files[0]`.
+- **State lifecycle risks:** brak — katalog addytywny; `ensure_mixed_dir` idempotentne.
+- **API surface parity:** Unit 2 zachowuje wsteczną zgodność (brak `main_audio` lub brak
+  dopasowania → dotychczasowy wybór) — pokryte testem regresji.
+- **Integration coverage:** kluczowy test — generacja configu Cinemona, gdy w `analysis/`
+  współistnieją stara i master-analiza (Unit 2).
+
+## Risks & Dependencies
+
+- **Nieaktualna analiza (P0)** — przy współistnieniu starej `*_analysis.json` z master-analizą
+  Cinemon mógłby wpiąć złą; mitygacja: master-aware wybór analizy (Unit 2) + test współistnienia.
+- **Drift vs offset** — „no-sync" zakłada stały offset; jeśli to narastający clock drift,
+  pojedynczy ręczny offset w Blenderze nie wyrówna head i tail długiego nagrania; mitygacja:
+  zmierzyć head-vs-tail na jednym pełnym nagraniu **przed** poleganiem na tej decyzji
+  (Open Questions → Needs Validation).
+- **Higiena `analysis/`** — przy re-renderach w `analysis/` zbierają się stare pliki; master-aware
+  wybór to adresuje, ale warto w dokumentacji zalecić czyszczenie nieaktualnych analiz.
+- **Zależność od capture w Bitwigu** — istnienie mastera zakłada działający miks/capture
+  (plan midi-recording-orchestration); przy braku mastera pipeline działa jak dziś (graceful).
+- **Wiki poza repo monorepo** — edycje w `~/dev/music-box-wiki` to osobne repo git; commit/PR
+  tam niezależnie (poza CI monorepo).
+
+## Documentation / Operational Notes
+
+- Aktualizacja wiki (`Post-prod teledysk`, `Paternologia` lokalizacja) i `CLAUDE.md` „Complete
+  Pipeline Workflow" — w Unit 3.
+- Brak migracji danych, brak flag, brak rolloutu — zmiana addytywna i opt-in (działa tylko gdy
+  pojawi się `mixed/`).
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md](docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md)
+- Related code: `setka_common/file_structure/specialized/recording.py`,
+  `setka_common/utils/files.py`, `setka_common/config/yaml_config.py`,
+  `cinemon/config/cinemon_config_generator.py`, `beatrix/cli/click_cli.py`
+- Related plans: `docs/plans/2026-05-31-001-feat-midi-recording-orchestration-plan.md`,
+  `docs/plans/2026-05-31-002-feat-recording-song-timeline-plan.md`
+- External docs: Bitwig Userguide — Exporting Audio (https://www.bitwig.com/userguide/latest/exporting_audio/)

--- a/packages/cinemon/src/cinemon/config/cinemon_config_generator.py
+++ b/packages/cinemon/src/cinemon/config/cinemon_config_generator.py
@@ -183,12 +183,19 @@ class CinemonConfigGenerator:
         # Get video files from the discovery instance
         video_files = discovery.discover_video_files()
 
-        # Auto-detect audio analysis file
+        # Auto-detect audio analysis file. Master-aware: when main_audio is
+        # known, prefer the analysis matching it (master.wav ->
+        # master_analysis.json) so a stale analysis from a previous run is not
+        # silently used. Fall back to the first sorted file otherwise.
         analysis_files = discovery.discover_analysis_files()
         analysis_file = None
         if analysis_files:
-            # Use the first analysis file found
-            analysis_file = f"analysis/{analysis_files[0]}"
+            chosen = analysis_files[0]
+            if main_audio:
+                expected = f"{Path(main_audio).stem}_analysis.json"
+                if expected in analysis_files:
+                    chosen = expected
+            analysis_file = f"analysis/{chosen}"
 
         # Update project settings
         config.project.video_files = video_files

--- a/packages/cinemon/tests/test_cinemon_config_generator.py
+++ b/packages/cinemon/tests/test_cinemon_config_generator.py
@@ -374,4 +374,111 @@ class TestCinemonConfigGeneratorPreset:
                 assert "trigger" in animation
 
 
+class TestCinemonConfigGeneratorAnalysisSelection:
+    """Master-aware selection of the analysis file (P0 fix).
+
+    When main_audio is known, the generator must pick the analysis matching
+    that audio (master_analysis.json) instead of the first alphabetically
+    sorted file in analysis/ — otherwise a stale analysis from a previous run
+    silently desyncs animations from the soundtrack.
+    """
+
+    def _make_recording(self, tmp_path):
+        recording_dir = tmp_path / "recording_20250105_143022"
+        extracted_dir = recording_dir / "extracted"
+        extracted_dir.mkdir(parents=True)
+        (extracted_dir / "Camera1.mp4").touch()
+        (extracted_dir / "main_audio.m4a").touch()
+        analysis_dir = recording_dir / "analysis"
+        analysis_dir.mkdir(parents=True)
+        return recording_dir, analysis_dir
+
+    def test_prefers_master_analysis_over_stale_alphabetical_first(self, tmp_path):
+        """Stale main_audio_analysis.json sorts first, but master must win."""
+        recording_dir, analysis_dir = self._make_recording(tmp_path)
+        # "main_audio_analysis.json" < "master_analysis.json" alphabetically
+        (analysis_dir / "main_audio_analysis.json").write_text("{}")
+        (analysis_dir / "master_analysis.json").write_text("{}")
+
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        master = mixed_dir / "master.wav"
+        master.touch()
+
+        generator = CinemonConfigGenerator()
+        config_path = generator.generate_preset(
+            recording_dir, "minimal", main_audio=str(master)
+        )
+
+        with config_path.open("r") as f:
+            config_data = yaml.safe_load(f)
+
+        assert config_data["audio_analysis"]["file"] == "analysis/master_analysis.json"
+
+    def test_picks_master_analysis_when_only_one(self, tmp_path):
+        """main_audio stem=master, only master_analysis.json present → picked."""
+        recording_dir, analysis_dir = self._make_recording(tmp_path)
+        (analysis_dir / "master_analysis.json").write_text("{}")
+
+        generator = CinemonConfigGenerator()
+        config_path = generator.generate_preset(
+            recording_dir, "minimal", main_audio="master.wav"
+        )
+
+        with config_path.open("r") as f:
+            config_data = yaml.safe_load(f)
+
+        assert config_data["audio_analysis"]["file"] == "analysis/master_analysis.json"
+
+    def test_falls_back_when_no_matching_analysis(self, tmp_path):
+        """main_audio given but no {stem}_analysis.json → fallback to first."""
+        recording_dir, analysis_dir = self._make_recording(tmp_path)
+        (analysis_dir / "main_audio_analysis.json").write_text("{}")
+
+        generator = CinemonConfigGenerator()
+        config_path = generator.generate_preset(
+            recording_dir, "minimal", main_audio="master.wav"
+        )
+
+        with config_path.open("r") as f:
+            config_data = yaml.safe_load(f)
+
+        assert (
+            config_data["audio_analysis"]["file"] == "analysis/main_audio_analysis.json"
+        )
+
+    def test_autodetect_main_audio_keeps_legacy_selection(self, tmp_path):
+        """No explicit main_audio (auto-detect) → selection unchanged (first)."""
+        recording_dir, analysis_dir = self._make_recording(tmp_path)
+        (analysis_dir / "aaa_analysis.json").write_text("{}")
+        (analysis_dir / "zzz_analysis.json").write_text("{}")
+
+        generator = CinemonConfigGenerator()
+        # single .m4a → auto-detected as main_audio; analysis pick = first sorted
+        config_path = generator.generate_preset(recording_dir, "minimal")
+
+        with config_path.open("r") as f:
+            config_data = yaml.safe_load(f)
+
+        assert config_data["audio_analysis"]["file"] == "analysis/aaa_analysis.json"
+
+    def test_empty_analysis_dir_does_not_fabricate_master(self, tmp_path):
+        """Empty analysis/ → must not inject a non-existent master_analysis.json."""
+        recording_dir, _ = self._make_recording(tmp_path)
+
+        generator = CinemonConfigGenerator()
+        # No exception, and master-aware logic does not invent a missing file.
+        config_path = generator.generate_preset(
+            recording_dir, "minimal", main_audio="master.wav"
+        )
+
+        with config_path.open("r") as f:
+            config_data = yaml.safe_load(f)
+
+        assert (
+            config_data.get("audio_analysis", {}).get("file")
+            != "analysis/master_analysis.json"
+        )
+
+
 # TestCinemonConfigGeneratorCustom removed - generate_config method was removed from API

--- a/packages/common/src/setka_common/file_structure/specialized/recording.py
+++ b/packages/common/src/setka_common/file_structure/specialized/recording.py
@@ -24,6 +24,7 @@ class RecordingStructure(MediaStructure):
     """Structure for OBS recording projects."""
 
     extracted_dir: Path
+    mixed_dir: Path
 
     def exists(self) -> bool:
         """Check if recording structure exists."""
@@ -58,6 +59,7 @@ class RecordingStructureManager(StructureManager):
     EXTRACTED_DIRNAME = "extracted"
     BLENDER_DIRNAME = "blender"
     ANALYSIS_DIRNAME = "analysis"
+    MIXED_DIRNAME = "mixed"
 
     @staticmethod
     def get_structure(video_path: Path) -> RecordingStructure:
@@ -85,6 +87,7 @@ class RecordingStructureManager(StructureManager):
         metadata_file = project_dir / RecordingStructureManager.METADATA_FILENAME
         processed_dir = project_dir / RecordingStructureManager.PROCESSED_DIRNAME
         extracted_dir = project_dir / RecordingStructureManager.EXTRACTED_DIRNAME
+        mixed_dir = project_dir / RecordingStructureManager.MIXED_DIRNAME
 
         return RecordingStructure(
             project_dir=project_dir,
@@ -92,6 +95,7 @@ class RecordingStructureManager(StructureManager):
             metadata_file=metadata_file,
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
+            mixed_dir=mixed_dir,
         )
 
     @staticmethod
@@ -113,6 +117,7 @@ class RecordingStructureManager(StructureManager):
         try:
             # Create all directories
             structure.extracted_dir.mkdir(parents=True, exist_ok=True)
+            structure.mixed_dir.mkdir(parents=True, exist_ok=True)
             logger.info(f"Created recording structure: {structure.project_dir}")
         except (OSError, PermissionError) as e:
             raise DirectoryCreationError(
@@ -262,6 +267,50 @@ class RecordingStructureManager(StructureManager):
         except (OSError, PermissionError) as e:
             raise DirectoryCreationError(
                 f"Failed to create analysis directory at {analysis_dir}: {e}"
+            )
+
+    @staticmethod
+    def ensure_mixed_dir(recording_dir: Path) -> Path:
+        """Ensure mixed directory exists.
+
+        Holds the polished audio mix exported from Bitwig (master now,
+        per-instrument stems later). Distinct from extracted/ which holds
+        raw OBS sources.
+
+        Args:
+            recording_dir: Recording directory path
+
+        Returns:
+            Path to mixed directory
+
+        Raises:
+            InvalidPathError: When recording_dir is invalid
+            DirectoryCreationError: When directory creation fails
+        """
+        if not recording_dir:
+            raise InvalidPathError("Recording directory cannot be empty")
+
+        recording_dir = Path(recording_dir)
+
+        if not recording_dir.exists():
+            raise InvalidPathError(
+                f"Recording directory does not exist: {recording_dir}"
+            )
+
+        if not recording_dir.is_dir():
+            raise InvalidPathError(
+                f"Recording path is not a directory: {recording_dir}"
+            )
+
+        mixed_dir = recording_dir / RecordingStructureManager.MIXED_DIRNAME
+
+        try:
+            mixed_dir.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Created mixed directory: {mixed_dir}")
+            return mixed_dir
+        except (OSError, PermissionError) as e:
+            raise DirectoryCreationError(
+                f"Failed to create mixed directory at {mixed_dir}: {e}"
             )
 
     @staticmethod

--- a/packages/common/tests/test_recording_structure.py
+++ b/packages/common/tests/test_recording_structure.py
@@ -25,6 +25,7 @@ class TestRecordingStructure:
             metadata_file=metadata_file,
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
+            mixed_dir=project_dir / "mixed",
         )
 
         assert structure.project_dir == project_dir
@@ -32,6 +33,7 @@ class TestRecordingStructure:
         assert structure.metadata_file == metadata_file
         assert structure.processed_dir == processed_dir
         assert structure.extracted_dir == extracted_dir
+        assert structure.mixed_dir == project_dir / "mixed"
 
     def test_exists_all_present(self, tmp_path):
         """Test exists() gdy wszystkie pliki istnieją."""
@@ -56,6 +58,7 @@ class TestRecordingStructure:
             metadata_file=metadata_file,
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
+            mixed_dir=project_dir / "mixed",
         )
 
         assert structure.exists() is True
@@ -83,6 +86,7 @@ class TestRecordingStructure:
             metadata_file=metadata_file,
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
+            mixed_dir=project_dir / "mixed",
         )
 
         assert structure.exists() is False
@@ -110,6 +114,7 @@ class TestRecordingStructure:
             metadata_file=metadata_file,
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
+            mixed_dir=project_dir / "mixed",
         )
 
         assert structure.is_valid() is True
@@ -137,6 +142,7 @@ class TestRecordingStructure:
             metadata_file=metadata_file,
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
+            mixed_dir=project_dir / "mixed",
         )
 
         assert structure.is_valid() is False
@@ -164,6 +170,7 @@ class TestRecordingStructure:
             metadata_file=metadata_file,
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
+            mixed_dir=project_dir / "mixed",
         )
 
         assert structure.is_valid() is True  # metadata jest opcjonalna
@@ -185,6 +192,16 @@ class TestRecordingStructureManager:
         assert structure.processed_dir == project_dir / "processed"
         assert structure.extracted_dir == project_dir / "extracted"
 
+    def test_get_structure_mixed_dir(self, tmp_path):
+        """Test get_structure() zwraca mixed_dir bez tworzenia katalogu."""
+        project_dir = tmp_path / "test_recording"
+        video_file = project_dir / "recording.mkv"
+
+        structure = RecordingStructureManager.get_structure(video_file)
+
+        assert structure.mixed_dir == project_dir / "mixed"
+        assert not structure.mixed_dir.exists()
+
     def test_create_structure(self, tmp_path):
         """Test create_structure()."""
         project_dir = tmp_path / "test_recording"
@@ -195,6 +212,17 @@ class TestRecordingStructureManager:
 
         assert structure.extracted_dir.exists()
         assert structure.extracted_dir.is_dir()
+
+    def test_create_structure_creates_mixed_dir(self, tmp_path):
+        """Test create_structure() tworzy katalog mixed/ obok extracted/."""
+        project_dir = tmp_path / "test_recording"
+        project_dir.mkdir()
+        video_file = project_dir / "recording.mkv"
+
+        structure = RecordingStructureManager.create_structure(video_file)
+
+        assert structure.mixed_dir.exists()
+        assert structure.mixed_dir.is_dir()
 
     def test_get_extracted_dir(self, tmp_path):
         """Test get_extracted_dir()."""
@@ -335,6 +363,31 @@ class TestRecordingStructureManager:
         assert analysis_dir.exists()
         assert analysis_dir.is_dir()
 
+    def test_ensure_mixed_dir(self, tmp_path):
+        """Test ensure_mixed_dir()."""
+        recording_dir = tmp_path / "test_recording"
+        recording_dir.mkdir()
+
+        mixed_dir = RecordingStructureManager.ensure_mixed_dir(recording_dir)
+
+        assert mixed_dir == recording_dir / "mixed"
+        assert mixed_dir.exists()
+        assert mixed_dir.is_dir()
+
+    def test_ensure_mixed_dir_already_exists(self, tmp_path):
+        """Test ensure_mixed_dir() gdy katalog już istnieje (idempotentność)."""
+        recording_dir = tmp_path / "test_recording"
+        recording_dir.mkdir()
+
+        existing_mixed_dir = recording_dir / "mixed"
+        existing_mixed_dir.mkdir()
+
+        mixed_dir = RecordingStructureManager.ensure_mixed_dir(recording_dir)
+
+        assert mixed_dir == existing_mixed_dir
+        assert mixed_dir.exists()
+        assert mixed_dir.is_dir()
+
     def test_get_analysis_file_path(self, tmp_path):
         """Test get_analysis_file_path()."""
         project_dir = tmp_path / "test_recording"
@@ -390,5 +443,6 @@ class TestRecordingStructureManager:
         assert RecordingStructureManager.EXTRACTED_DIRNAME == "extracted"
         assert RecordingStructureManager.BLENDER_DIRNAME == "blender"
         assert RecordingStructureManager.ANALYSIS_DIRNAME == "analysis"
+        assert RecordingStructureManager.MIXED_DIRNAME == "mixed"
         assert RecordingStructureManager.METADATA_FILENAME == "metadata.json"
         assert RecordingStructureManager.PROCESSED_DIRNAME == "processed"


### PR DESCRIPTION
## Summary

Wstawia **Bitwig jako ręczny etap post-produkcji audio** pomiędzy nagraniem a analizą. Po nagraniu Wojtas miksuje/wyrównuje głośności w Bitwigu, eksportuje **master** do `mixed/master.wav`, i ten dopracowany master napędza analizę (Beatrix) oraz jest finalną ścieżką dźwiękową klipu — zamiast surowego audio z OBS.

Wariant **„chude MVP"** (po przeglądzie planu): minimalna zmiana, bez ruszania współdzielonego resolvera ścieżek ani `MediaDiscovery`.

- **Unit 1 (setka-common):** kanoniczny katalog `mixed/` w `RecordingStructureManager` — stała `MIXED_DIRNAME`, pole `mixed_dir`, `create_structure()` go materializuje, nowe `ensure_mixed_dir()` mirrorujące `ensure_analysis_dir()`. Gotowe na przyszłe stemy (`mixed/stems/`).
- **Unit 2 (cinemon, P0 fix):** master-aware wybór pliku analizy — generator preferuje `{main_audio.stem}_analysis.json` zamiast pierwszego alfabetycznie pliku w `analysis/`, z fallbackiem do dotychczasowego zachowania. Naprawia cichy bug, w którym nieaktualna analiza poprzedniego runu rozjeżdżała animacje z dźwiękiem.
- **Unit 3 (docs):** `CLAUDE.md` „Complete Pipeline Workflow" opisuje etap Bitwig→`mixed/`, master wskazywany ścieżką absolutną w `--main-audio`, ręczna kompensacja dryfu A/V.

Master wskazywany jest jawnie **ścieżką absolutną** (resolver `yaml_config.py` zwraca ją bez zmian) — zero ryzyka regresji `extracted/`. Cymatic celowo poza zakresem.

Decyzje produktowe i techniczne: `docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md`, `docs/plans/2026-06-02-001-feat-bitwig-mixed-audio-pipeline-plan.md`.

## Testing

- `packages/common` — 151 passed (w tym nowe testy `mixed/`: `get_structure`/`create_structure`/`ensure_mixed_dir`/stała).
- `packages/cinemon` — config generator + CLI + pipeline: 61 passed; 5 nowych testów master-aware (rdzeń P0: stara `main_audio_analysis.json` sortuje się przed `master_analysis.json`, ale wybrany zostaje master; fallback; regresja auto-detekcji; pusty `analysis/`).
- `ruff check` na zmienionych plikach — czysto. (3 wcześniejsze ostrzeżenia w `project_manager.py` są poza zakresem tego PR.)

## Post-Deploy Monitoring & Validation

- **Co monitorować:** poprawność wpiętej analizy w generowanym configu Cinemona (`audio_analysis.file`) dla nagrań z wieloma plikami w `analysis/`.
- **Walidacja (komendy):**
  - `uv run --package setka-common pytest packages/common/tests/test_recording_structure.py --no-cov`
  - `uv run --package cinemon pytest packages/cinemon/tests/test_cinemon_config_generator.py --no-cov`
  - Manualnie: na realnym nagraniu z `mixed/master.wav` + `analysis/master_analysis.json` obok starej analizy sprawdzić, że wygenerowany YAML wskazuje `analysis/master_analysis.json`.
- **Zdrowy sygnał:** generowany config wskazuje analizę pasującą do mastera; ścieżki bez `--main-audio` lub bez dopasowania zachowują dotychczasowy wybór.
- **Sygnał awarii / trigger rollbacku:** config wpina nieaktualną analizę mimo obecności master-analizy → regresja Unit 2.
- **Do walidacji (osobno, nie blokuje PR):** zmierzyć offset A/V head-vs-tail na jednym długim nagraniu — jeśli dryf narasta, pojedynczy ręczny offset w Blenderze nie wystarczy (założenie „stały offset").
- **Okno walidacji / właściciel:** pierwsze realne nagranie z miksem w Bitwigu; Wojtas.

## Uwaga: dokumentacja wiki (osobne repo)

`~/dev/music-box-wiki` to **osobne repozytorium poza CI**. Edycje dokumentacji workflow (`Post-prod teledysk`, sekcja eksportu w `Bitwig Studio`, poprawka lokalizacji paternologii po PR #30) są **zapisane na dysku**, ale **nie zacommitowane** — to repo ma sporo niezwiązanego WIP, więc commit/PR tam zostawiam do decyzji autora.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 (1M context) via [Claude Code](https://claude.com/claude-code)