### PR TITLE
feat(live): setka-live show — układanie okien na dwóch monitorach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,10 @@ Each package provides specific commands:
 ```bash
 # 0. Stand up the live recording environment in one shot (OBS + Bitwig + paternologia
 #    kiosk) before recording. On-demand systemd --user target; see deploy/live/README.md.
-#    Holistic restart of the whole GUI layer: `setka-live restart`.
+#    Holistic restart of the whole GUI layer: `setka-live restart`. `setka-live show`
+#    arranges the windows across the two monitors (Bitwig left; OBS + Paternologia right) —
+#    start auto-arranges at the end (best-effort); run show manually if windows drift.
+#    Needs wmctrl on X11 (sudo apt install wmctrl).
 setka-live start
 
 # 1. Extract sources from OBS recording

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,14 @@
 ## 4. Dodatkowe zadania
 - [ ] Usuń zduplikowany plik config_loader.py z blender_addon
 - [ ] Uruchom wszystkie testy aby upewnić się że nic nie zepsuliśmy
+
+## 5. Paternologia: odporność mostu MIDI na re-enumerację PACER-a
+Kontekst: 2026-06-03 MIDI przestało działać — PACER re-enumerował się (zmiana `card`),
+most wejściowy paternologii zgubił subskrypcję ALSA do PACER-a i jej nie odtworzył.
+`/health` dalej raportował `pacer_input_open=true`, mimo że `aconnect -l` nie pokazywał
+żadnego połączenia z PACER-em. Ręczny fix: `systemctl --user restart paternologia.service`.
+- [ ] Auto-reconnect: gdy subskrypcja wejścia PACER znika (re-enumeracja/replug), most ma
+      re-otworzyć port zamiast tylko logować „Found N rtmidi port(s)" co ~2,5 s.
+- [ ] `/health` ma sprawdzać REALNĄ subskrypcję wejścia (np. po `aconnect`/stanie portu),
+      nie samo istnienie obiektu portu — inaczej raportuje `pacer_input_open=true` przy
+      zerwanym wejściu.

--- a/deploy/live/README.md
+++ b/deploy/live/README.md
@@ -58,16 +58,19 @@ Pułapki:
   `wmctrl -lx` przy żywych oknach i nadpisz przez env. Brak dopasowanego okna → pominięte +
   raport (nie błąd).
 - **Kiosk musi wstać przez `paternologia-kiosk.sh`** (np. `setka-live start`/`restart`), żeby miał
-  klasę `setka-kiosk`. Zwykła Brave to `brave.Brave` — kiosk uruchomiony „ręcznie" nie zostanie
-  rozpoznany (i celowo nie zderza się z prywatną Brave operatora).
+  klasę `setka-kiosk`. Kiosk celowo używa **nie-snapowego `google-chrome`** (`/opt/google/chrome`):
+  snap Brave dwoił raportowaną pozycję okna i odłączał się od `kiosk.service` (`Type=exec` → usługa
+  natychmiast `inactive`, okno osierocone). Świeży profil chrome wymaga `--no-first-run`
+  `--no-default-browser-check`, inaczej zamiast `/live` pokazuje ekran powitalny.
+- **`wmctrl -lG` MYLNIE raportuje geometrię okien Chromium** — pokazuje pozycję ~2× rzeczywistej.
+  Samo ustawianie (`wmctrl -e`) działa poprawnie; weryfikuj WZROKOWO, nie po `wmctrl -lG`. Kiosk
+  faktycznie ląduje w dolnej połowie prawego monitora, mimo że `-lG` zawyża współrzędne.
 - **Geometria** liczona na żywo z `xrandr --listmonitors` (offsety, nie zaszyte nazwy), więc
   przeżywa zamianę kabli/nazw monitorów.
-- **OBS nie trafia pixel-perfect w połowę monitora.** Zweryfikowane na żywo: Bitwig ląduje 1:1,
-  ale OBS ma `gravity: Static`, ramkę ~37 px i wymuszony minimalny rozmiar przez zadokowane
-  panele (bez ich schowania nie zmniejszysz okna nawet myszą) — więc ląduje w prawym górnym
-  obszarze z offsetem, nie idealnie w połowie. To ograniczenie OBS/Muttera, nie błąd układania;
-  okno i tak jest wyciągnięte na wierzch i widoczne. Ewentualna korekta `_NET_FRAME_EXTENTS`
-  w `layout_place` sama tego nie zlikwiduje (offset jest większy niż ramka).
+- **OBS nie zwęża się poniżej swojego minimum** (zadokowane panele wymuszają min-rozmiar; bez ich
+  schowania nie zmniejszysz okna nawet myszą), więc górna połowa prawego monitora może być przez
+  OBS nadpisana większym oknem. To ograniczenie OBS, nie błąd układania — okno i tak jest wyciągane
+  na wierzch i widoczne.
 
 ## Mapa unitów
 
@@ -77,7 +80,7 @@ Pułapki:
 | `live-preflight.service` | oneshot gate: virmidi + PipeWire 44100 + paternologia `/health` |
 | `obs.service` | OBS Studio (`/usr/bin/obs`), `Restart=no` |
 | `bitwig.service` | Bitwig (flatpak), `ExecStop=flatpak kill`, `Restart=no` |
-| `kiosk.service` | `/live` w `brave --kiosk` (osobny `--user-data-dir`), `Restart=no` |
+| `kiosk.service` | `/live` w `google-chrome --kiosk` (nie-snap, osobny `--user-data-dir`), `Restart=no` |
 
 Kolejność: `paternologia.service` → `live-preflight.service` → {`obs`, `bitwig`, `kiosk`}
 (trójka startuje równolegle — OBS i Bitwig są rozdzielne urządzeniowo, nie współdzielą `/dev`).

--- a/deploy/live/README.md
+++ b/deploy/live/README.md
@@ -53,13 +53,21 @@ Pułapki:
 - **Tylko X11.** Układanie idzie przez `wmctrl` (EWMH na GNOME/Xorg). Na Wayland komenda jawnie
   odmawia zamiast cicho zawieść.
 - **WM_CLASS OBS/Bitwiga** są konfigurowalne na górze `live-layout.sh` (`OBS_CLASS`,
-  `BITWIG_CLASS`); kiosk ma własny `--class=setka-kiosk`. Zweryfikuj realne wartości `wmctrl -lx`
-  przy żywych oknach i ewentualnie nadpisz przez env. Brak dopasowanego okna → pominięte +
+  `BITWIG_CLASS`); kiosk ma własny `--class=setka-kiosk`. Potwierdzone realnie na tej maszynie:
+  OBS = `obs.obs`, Bitwig (flatpak) = `com.bitwig.BitwigStudio`. Gdyby się zmieniły, sprawdź
+  `wmctrl -lx` przy żywych oknach i nadpisz przez env. Brak dopasowanego okna → pominięte +
   raport (nie błąd).
+- **Kiosk musi wstać przez `paternologia-kiosk.sh`** (np. `setka-live start`/`restart`), żeby miał
+  klasę `setka-kiosk`. Zwykła Brave to `brave.Brave` — kiosk uruchomiony „ręcznie" nie zostanie
+  rozpoznany (i celowo nie zderza się z prywatną Brave operatora).
 - **Geometria** liczona na żywo z `xrandr --listmonitors` (offsety, nie zaszyte nazwy), więc
   przeżywa zamianę kabli/nazw monitorów.
-- **Ramki okien**: jeśli okna lądują przesunięte o kilka px, to kwestia `_NET_FRAME_EXTENTS` na
-  Mutterze — do skorygowania w `layout_place`.
+- **OBS nie trafia pixel-perfect w połowę monitora.** Zweryfikowane na żywo: Bitwig ląduje 1:1,
+  ale OBS ma `gravity: Static`, ramkę ~37 px i wymuszony minimalny rozmiar przez zadokowane
+  panele (bez ich schowania nie zmniejszysz okna nawet myszą) — więc ląduje w prawym górnym
+  obszarze z offsetem, nie idealnie w połowie. To ograniczenie OBS/Muttera, nie błąd układania;
+  okno i tak jest wyciągnięte na wierzch i widoczne. Ewentualna korekta `_NET_FRAME_EXTENTS`
+  w `layout_place` sama tego nie zlikwiduje (offset jest większy niż ramka).
 
 ## Mapa unitów
 

--- a/deploy/live/README.md
+++ b/deploy/live/README.md
@@ -15,21 +15,51 @@ deploy/live/install.sh
 
 Instalator (idempotentny, backupuje różniące się pliki):
 - kopiuje unity → `~/.config/systemd/user/`,
-- kopiuje skrypty → `~/.local/bin/` (`setka-live`, `live-preflight.sh`, `paternologia-kiosk.sh`),
+- kopiuje skrypty → `~/.local/bin/` (`setka-live`, `live-preflight.sh`, `paternologia-kiosk.sh`,
+  `live-layout.sh`),
 - robi `systemctl --user daemon-reload`,
 - **wycofuje stary kiosk-autostart** `~/.config/autostart/paternologia-kiosk.desktop`
   (zmienia nazwę na `.disabled-<stamp>` — odwracalne; kiosk przechodzi pod systemd).
 
 Upewnij się, że `~/.local/bin` jest w `PATH` (instalator ostrzeże, jeśli nie).
 
+Do `setka-live show` (układanie okien) potrzebny jest `wmctrl` — instalator tylko ostrzega, gdy
+go brak (nie blokuje instalacji): `sudo apt install wmctrl`.
+
 ## Komendy operatorskie
 
 ```bash
-setka-live start     # postaw komplet (OBS + Bitwig + kiosk) po preflighcie
+setka-live start     # postaw komplet (OBS + Bitwig + kiosk) po preflighcie; na końcu układa okna
 setka-live stop      # zatrzymaj całą warstwę GUI
 setka-live restart   # całościowy restart GUI (stop+start; re-weryfikuje preflight)
 setka-live status    # stan członków + paternologia /health + środowisko graficzne
+setka-live show      # wyciągnij na wierzch i ułóż okna na dwóch monitorach (patrz niżej)
 ```
+
+### `setka-live show` — układanie okien
+
+Wyciąga na wierzch i układa komplet okien w stałym układzie na dwóch monitorach:
+
+| Monitor | Okno |
+|---------|------|
+| **lewy** (najmniejszy offset X) | Bitwig — cała powierzchnia |
+| **prawy**, górna połowa | OBS |
+| **prawy**, dolna połowa | Paternologia (kiosk) |
+
+`setka-live start` wykonuje to samo układanie na końcu (best-effort — błąd układania nie wywraca
+startu). `show` można odpalić ręcznie, kiedy okna się rozjadą. Komenda jest idempotentna.
+
+Pułapki:
+- **Tylko X11.** Układanie idzie przez `wmctrl` (EWMH na GNOME/Xorg). Na Wayland komenda jawnie
+  odmawia zamiast cicho zawieść.
+- **WM_CLASS OBS/Bitwiga** są konfigurowalne na górze `live-layout.sh` (`OBS_CLASS`,
+  `BITWIG_CLASS`); kiosk ma własny `--class=setka-kiosk`. Zweryfikuj realne wartości `wmctrl -lx`
+  przy żywych oknach i ewentualnie nadpisz przez env. Brak dopasowanego okna → pominięte +
+  raport (nie błąd).
+- **Geometria** liczona na żywo z `xrandr --listmonitors` (offsety, nie zaszyte nazwy), więc
+  przeżywa zamianę kabli/nazw monitorów.
+- **Ramki okien**: jeśli okna lądują przesunięte o kilka px, to kwestia `_NET_FRAME_EXTENTS` na
+  Mutterze — do skorygowania w `layout_place`.
 
 ## Mapa unitów
 
@@ -81,6 +111,8 @@ systemctl --user restart paternologia.service
 deploy/live/tests/test_install.sh
 deploy/live/tests/test_live_preflight.sh
 deploy/live/tests/test_setka_live.sh
+deploy/live/tests/test_live_layout.sh
+deploy/live/tests/test_kiosk_class.sh
 ```
 
 Plain shell (`bats` nie jest wymagany). Logikę warunków/dyspozytora testujemy na realnych

--- a/deploy/live/bin/live-layout.sh
+++ b/deploy/live/bin/live-layout.sh
@@ -74,11 +74,14 @@ layout_window_exists() {
 }
 poll_window_exists() { poll_ok "$GRACE_WINDOW" layout_window_exists "$1"; }
 
-# Ustaw geometrię okna i wyciągnij na wierzch. Zmaksymalizowane okno ignoruje -e, więc najpierw
-# zdejmujemy maksymalizację; -x każe wmctrl interpretować argument jako WM_CLASS (nie tytuł).
+# Ustaw geometrię okna i wyciągnij na wierzch. Zmaksymalizowane LUB pełnoekranowe okno (kiosk
+# startuje w --kiosk = fullscreen) ignoruje -e, więc najpierw zdejmujemy oba stany. wmctrl -b
+# zmienia max 2 właściwości na wywołanie (limit EWMH), stąd fullscreen osobnym wywołaniem.
+# -x każe wmctrl interpretować argument jako WM_CLASS (nie tytuł).
 layout_place() {
   local cls="$1" x="$2" y="$3" w="$4" h="$5"
   "$WMCTRL_BIN" -x -r "$cls" -b remove,maximized_vert,maximized_horz 2>/dev/null || true
+  "$WMCTRL_BIN" -x -r "$cls" -b remove,fullscreen 2>/dev/null || true
   "$WMCTRL_BIN" -x -r "$cls" -e "0,$x,$y,$w,$h"
   "$WMCTRL_BIN" -x -a "$cls"
 }

--- a/deploy/live/bin/live-layout.sh
+++ b/deploy/live/bin/live-layout.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# ABOUTME: Układa okna warstwy live na dwóch monitorach (Bitwig lewy; OBS+kiosk prawy) przez wmctrl.
+# ABOUTME: Czyste funkcje geometrii (xrandr → sloty) są testowalne tekstem; wywołania wmctrl za WMCTRL_BIN.
+set -uo pipefail
+
+# Indirekcja przez env wyłącznie dla testów — domyślnie realne narzędzia X11/EWMH.
+WMCTRL_BIN="${WMCTRL_BIN:-wmctrl}"
+XRANDR_BIN="${XRANDR_BIN:-xrandr}"
+
+# WM_CLASS okien do ułożenia. Kiosk dostaje własny --class=setka-kiosk (patrz paternologia-kiosk.sh).
+# OBS i Bitwig (flatpak) dopasowywane po natywnym WM_CLASS — wartości DO POTWIERDZENIA `wmctrl -lx`
+# przy żywych oknach; nadpisywalne env, by nie edytować skryptu. R5 sprawia, że błędne dopasowanie
+# degraduje się do „okno pominięte", nie do crasha.
+OBS_CLASS="${OBS_CLASS:-obs.obs}"
+BITWIG_CLASS="${BITWIG_CLASS:-com.bitwig.BitwigStudio}"
+KIOSK_CLASS="${KIOSK_CLASS:-setka-kiosk}"
+
+log() { printf 'layout: %s\n' "$*"; }
+err() { printf 'layout: %s\n' "$*" >&2; }
+
+# --- Czyste funkcje geometrii (testowalne, karmione tekstem) ---
+
+# Parsuje `xrandr --listmonitors` → linie 'x y w h', posortowane rosnąco po offsecie X
+# (lewy monitor = najmniejszy X = pierwszy). Token geometrii ma postać W/Wmm x H/Hmm + X + Y
+# (np. '1440/530x900/300+1280+0'); milimetry ignorujemy.
+layout_parse_monitors() {
+  printf '%s\n' "$1" \
+    | sed -n 's#.*[[:space:]]\([0-9]\{1,\}\)/[0-9]\{1,\}x\([0-9]\{1,\}\)/[0-9]\{1,\}+\([0-9]\{1,\}\)+\([0-9]\{1,\}\).*#\3 \4 \1 \2#p' \
+    | sort -n -k1,1
+}
+
+# Sloty przyjmują geometrię monitora jako 'x y w h' (4 argumenty) i wypisują 'x y w h' slotu.
+# Bitwig = cały lewy monitor.
+layout_slot_bitwig() {
+  printf '%s %s %s %s\n' "$1" "$2" "$3" "$4"
+}
+
+# OBS = górna połowa prawego monitora (wysokość dzielona całkowicie; górna bierze podłogę).
+layout_slot_obs() {
+  local x="$1" y="$2" w="$3" h="$4"
+  printf '%s %s %s %s\n' "$x" "$y" "$w" "$((h / 2))"
+}
+
+# Paternologia (kiosk) = dolna połowa prawego monitora. Bierze RESZTĘ wysokości (h - h/2),
+# więc dla nieparzystej wysokości połówki tilują bez zgubionego piksela i bez zakładki.
+layout_slot_paternologia() {
+  local x="$1" y="$2" w="$3" h="$4"
+  local top=$((h / 2))
+  printf '%s %s %s %s\n' "$x" "$((y + top))" "$w" "$((h - top))"
+}
+
+# --- Warstwa live: realne komendy X11/EWMH (pobierają świeże dane przy każdym wywołaniu) ---
+
+# Grace per-okno (s): czeka aż okno się pojawi przed ustawieniem geometrii. Bitwig-flatpak
+# startuje najwolniej, stąd niezerowy domyślny zapas; nadpisywalny env (dostrajany przy realnym
+# `start`). Dla ręcznego `show` (okna już są) predykat-prawda zwraca od razu, więc zapas nie boli.
+GRACE_WINDOW="${GRACE_WINDOW:-10}"
+
+# Pętla retry/grace: nie wisi, twardo kończy po wyczerpaniu okna (wzorzec poll_ok z live-preflight.sh).
+poll_ok() {
+  local grace="$1"; shift
+  local deadline=$((SECONDS + grace))
+  while :; do
+    if "$@"; then return 0; fi
+    [ "$SECONDS" -ge "$deadline" ] && return 1
+    sleep 0.5
+  done
+}
+
+# Okno o danym WM_CLASS istnieje? `wmctrl -lx` listuje okna z klasą; dopasowanie po podłańcuchu
+# klasy (np. 'setka-kiosk' trafia w 'setka-kiosk.Setka-kiosk').
+layout_window_exists() {
+  "$WMCTRL_BIN" -lx 2>/dev/null | grep -qiF -- "$1"
+}
+poll_window_exists() { poll_ok "$GRACE_WINDOW" layout_window_exists "$1"; }
+
+# Ustaw geometrię okna i wyciągnij na wierzch. Zmaksymalizowane okno ignoruje -e, więc najpierw
+# zdejmujemy maksymalizację; -x każe wmctrl interpretować argument jako WM_CLASS (nie tytuł).
+layout_place() {
+  local cls="$1" x="$2" y="$3" w="$4" h="$5"
+  "$WMCTRL_BIN" -x -r "$cls" -b remove,maximized_vert,maximized_horz 2>/dev/null || true
+  "$WMCTRL_BIN" -x -r "$cls" -e "0,$x,$y,$w,$h"
+  "$WMCTRL_BIN" -x -a "$cls"
+}
+
+# Liczniki raportu (R5): ustawiane przez try_place w bieżącej powłoce (nie subshell).
+PLACED=0
+MISSING=""
+
+# Ułóż jedno okno, jeśli istnieje (z grace); brak → log + odnotuj do raportu, NIE przerywaj (R5).
+try_place() {
+  local cls="$1" label="$2" geom="$3"
+  if poll_window_exists "$cls"; then
+    # shellcheck disable=SC2086  # geom to celowo dzielone 'x y w h'.
+    layout_place "$cls" $geom
+    log "  [OK] $label → $geom"
+    PLACED=$((PLACED + 1))
+  else
+    log "  [--] $label: brak okna (WM_CLASS=$cls) — pomijam"
+    MISSING="$MISSING $label"
+  fi
+}
+
+main() {
+  # Bramki środowiska — twardy FAIL (exit !=0). To realne awarie, nie brak pojedynczego okna.
+  if [ "${XDG_SESSION_TYPE:-}" != "x11" ]; then
+    err "sesja '${XDG_SESSION_TYPE:-?}' != x11 — układanie okien (wmctrl/EWMH) działa tylko na Xorg. Odmawiam."
+    return 1
+  fi
+  if [ -z "${DISPLAY:-}" ]; then
+    err "brak DISPLAY — brak aktywnej sesji graficznej do układania okien. Odmawiam."
+    return 1
+  fi
+  if ! command -v "$WMCTRL_BIN" >/dev/null 2>&1; then
+    err "brak wmctrl — zainstaluj: sudo apt install wmctrl"
+    return 1
+  fi
+
+  # Geometria z xrandr (czyste funkcje); oczekujemy 2 monitorów (lewy = mniejszy offset X).
+  local monitors left right
+  monitors="$(layout_parse_monitors "$("$XRANDR_BIN" --listmonitors 2>/dev/null)")"
+  left="$(printf '%s\n' "$monitors" | sed -n 1p)"
+  right="$(printf '%s\n' "$monitors" | sed -n 2p)"
+  if [ -z "$left" ] || [ -z "$right" ]; then
+    err "oczekiwano 2 monitorów z 'xrandr --listmonitors', dostałem: ${monitors:-<nic>}. Odmawiam."
+    return 1
+  fi
+
+  local bitwig obs pat
+  # shellcheck disable=SC2086  # left/right to celowo dzielone 'x y w h'.
+  bitwig="$(layout_slot_bitwig $left)"
+  # shellcheck disable=SC2086
+  obs="$(layout_slot_obs $right)"
+  # shellcheck disable=SC2086
+  pat="$(layout_slot_paternologia $right)"
+
+  log "układam okna: Bitwig (lewy) | OBS+Paternologia (prawy)…"
+  try_place "$BITWIG_CLASS" "Bitwig" "$bitwig"
+  try_place "$OBS_CLASS"    "OBS"    "$obs"
+  try_place "$KIOSK_CLASS"  "Paternologia" "$pat"
+
+  if [ -n "$MISSING" ]; then
+    log "ułożono $PLACED; brakujące okna:$MISSING (uruchom je i powtórz: setka-live show)"
+  else
+    log "ułożono wszystkie ($PLACED) okna"
+  fi
+  # Brak okna NIE jest błędem (R5) — exit 0. Niezerowo kończą tylko bramki środowiska wyżej.
+  return 0
+}
+
+# Odpal main tylko przy bezpośrednim wykonaniu — sourcing (testy) ma dać same funkcje.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/deploy/live/bin/paternologia-kiosk.sh
+++ b/deploy/live/bin/paternologia-kiosk.sh
@@ -12,6 +12,9 @@ done
 
 # Osobny profil wymusza niezależną instancję kiosku, nawet gdy brave już działa
 # (bez tego URL trafia do istniejącego okna i --kiosk jest ignorowany).
+# --class=setka-kiosk nadaje oknu stały, unikalny WM_CLASS — pewny uchwyt dla układania
+# okien (setka-live show), nie kolidujący ze zwykłym Brave operatora.
 exec brave --kiosk --noerrdialogs \
   --disable-session-crashed-bubble --disable-infobars \
+  --class=setka-kiosk \
   --user-data-dir="$HOME/.local/share/paternologia-kiosk" "$URL"

--- a/deploy/live/bin/paternologia-kiosk.sh
+++ b/deploy/live/bin/paternologia-kiosk.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ABOUTME: Czeka aż serwer paternologii odpowie, potem otwiera /live w brave kiosk.
+# ABOUTME: Czeka aż serwer paternologii odpowie, potem otwiera /live w google-chrome --kiosk.
 # ABOUTME: Uruchamiany jako kiosk.service (członek live-recording.target).
 set -euo pipefail
 URL="http://localhost:8000/live"
@@ -10,14 +10,14 @@ for _ in $(seq 1 60); do
   sleep 0.5
 done
 
-# Osobny profil wymusza niezależną instancję kiosku, nawet gdy brave już działa
-# (bez tego URL trafia do istniejącego okna i --kiosk jest ignorowany).
-# Profil MUSI leżeć w obszarze zapisywalnym dla snapa (~/snap/brave/common) — Brave to snap
-# (/snap/bin/brave); --user-data-dir poza confinementem (np. ~/.local/share) jest ignorowany,
-# brave forwarduje URL do zwykłej przeglądarki i wychodzi, a okno kiosku się nie pojawia.
-# --class=setka-kiosk nadaje oknu stały, unikalny WM_CLASS — pewny uchwyt dla układania
-# okien (setka-live show), nie kolidujący ze zwykłym Brave operatora.
-exec brave --kiosk --noerrdialogs \
+# Używamy nie-snapowego google-chrome (/opt/google/chrome): snap Brave dwoił pozycję okna
+# (wmctrl -e lądował poza ekranem) i odłączał się od kiosk.service (Type=exec → inactive).
+# Osobny profil wymusza niezależną instancję kiosku, nawet gdy przeglądarka już działa
+# (bez tego URL trafia do istniejącego okna i --kiosk jest ignorowany). Bez confinementu
+# profil może leżeć w ~/.local/share. --class=setka-kiosk nadaje oknu stały, unikalny WM_CLASS —
+# pewny uchwyt dla układania okien (setka-live show), nie kolidujący ze zwykłą przeglądarką.
+exec google-chrome --kiosk --noerrdialogs \
+  --no-first-run --no-default-browser-check \
   --disable-session-crashed-bubble --disable-infobars \
   --class=setka-kiosk \
-  --user-data-dir="$HOME/snap/brave/common/paternologia-kiosk" "$URL"
+  --user-data-dir="$HOME/.local/share/paternologia-kiosk" "$URL"

--- a/deploy/live/bin/paternologia-kiosk.sh
+++ b/deploy/live/bin/paternologia-kiosk.sh
@@ -12,9 +12,12 @@ done
 
 # Osobny profil wymusza niezależną instancję kiosku, nawet gdy brave już działa
 # (bez tego URL trafia do istniejącego okna i --kiosk jest ignorowany).
+# Profil MUSI leżeć w obszarze zapisywalnym dla snapa (~/snap/brave/common) — Brave to snap
+# (/snap/bin/brave); --user-data-dir poza confinementem (np. ~/.local/share) jest ignorowany,
+# brave forwarduje URL do zwykłej przeglądarki i wychodzi, a okno kiosku się nie pojawia.
 # --class=setka-kiosk nadaje oknu stały, unikalny WM_CLASS — pewny uchwyt dla układania
 # okien (setka-live show), nie kolidujący ze zwykłym Brave operatora.
 exec brave --kiosk --noerrdialogs \
   --disable-session-crashed-bubble --disable-infobars \
   --class=setka-kiosk \
-  --user-data-dir="$HOME/.local/share/paternologia-kiosk" "$URL"
+  --user-data-dir="$HOME/snap/brave/common/paternologia-kiosk" "$URL"

--- a/deploy/live/bin/setka-live
+++ b/deploy/live/bin/setka-live
@@ -6,6 +6,8 @@ set -euo pipefail
 # Indirekcja przez env wyłącznie dla testów — domyślnie realny systemctl --user.
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:8000/health}"
+# Siostrzany skrypt układania okien (w tym samym katalogu bin); env override dla testów.
+LAYOUT_BIN="${LAYOUT_BIN:-$(dirname "$0")/live-layout.sh}"
 
 TARGET="live-recording.target"
 MEMBERS="live-preflight.service obs.service bitwig.service kiosk.service"
@@ -14,12 +16,13 @@ sctl() { "$SYSTEMCTL_BIN" --user "$@"; }
 
 usage() {
   cat >&2 <<EOF
-Użycie: setka-live <start|stop|restart|status>
+Użycie: setka-live <start|stop|restart|status|show>
 
-  start    postaw komplet live (OBS + Bitwig + kiosk) po preflighcie
+  start    postaw komplet live (OBS + Bitwig + kiosk) po preflighcie; na końcu układa okna
   stop     zatrzymaj całą warstwę GUI
   restart  całościowy restart warstwy GUI (stop+start; re-weryfikuje preflight)
   status   stan członków + paternologia /health + środowisko graficzne
+  show     wyciągnij na wierzch i ułóż okna: Bitwig (lewy) | OBS+Paternologia (prawy)
 
 Most MIDI (paternologia.service) jest poza zakresem — rzadki restart ręcznie:
   systemctl --user restart paternologia.service
@@ -28,6 +31,15 @@ EOF
 
 cmd_start() {
   sctl start "$TARGET"
+  # Po starcie ułóż okna — best-effort: błąd układania NIE może wywrócić startu (R3/R5).
+  # (live-layout.sh czeka aż okna się pojawią; brakujące pomija, niezerowo kończy tylko dla
+  # realnej awarii środowiska — Wayland/brak DISPLAY/wmctrl.)
+  "$LAYOUT_BIN" || true
+}
+
+cmd_show() {
+  # Czysto okienkowe: wyciągnij na wierzch i ułóż. Niezerowy exit tylko dla awarii środowiska.
+  "$LAYOUT_BIN"
 }
 
 cmd_stop() {
@@ -69,6 +81,7 @@ main() {
     stop)    cmd_stop ;;
     restart) cmd_restart ;;
     status)  cmd_status ;;
+    show)    cmd_show ;;
     *)       usage; exit 2 ;;
   esac
 }

--- a/deploy/live/install.sh
+++ b/deploy/live/install.sh
@@ -71,6 +71,13 @@ main() {
     *) printf 'UWAGA: %s nie jest w PATH — dodaj go, by komendy (np. setka-live) były widoczne.\n' "$BIN_DIR" ;;
   esac
 
+  # wmctrl jest potrzebny tylko dla `setka-live show` (układanie okien). Jego brak NIE blokuje
+  # instalacji unitów/skryptów — to nakładka okienkowa, nie rdzeń nagrywania (FAIL FAST dotyczy
+  # błędów krytycznych, nie braku opcjonalnego narzędzia okiennego). Ostrzegamy, nie przerywamy.
+  if ! command -v wmctrl >/dev/null 2>&1; then
+    printf 'UWAGA: brak wmctrl — "setka-live show" (układanie okien) nie zadziała. Zainstaluj: sudo apt install wmctrl\n'
+  fi
+
   printf 'Gotowe.\n'
 }
 

--- a/deploy/live/tests/test_install.sh
+++ b/deploy/live/tests/test_install.sh
@@ -96,8 +96,11 @@ grep -qi 'PATH' "$T6/src/out.log" && pass "path-warn: instalator ostrzega o PATH
 # --- Test 7: brak wmctrl = ostrzeżenie, ale NIE błąd (niefatalna zależność show) ---
 T7="$(mktemp -d)"
 make_src "$T7/src"
-# PATH bez wmctrl → instalator ma ostrzec, lecz dokończyć (układanie okien to tylko nakładka).
-run_install "$T7/src" "$T7/systemd" "$T7/bin" "$T7/autostart" "/usr/bin:/bin"
+# Sandbox PATH: tylko narzędzia, których install.sh używa — BEZ wmctrl, niezależnie od tego,
+# czy wmctrl jest zainstalowany w systemie (inaczej test fałszywie zielenił/czerwienił).
+mkdir -p "$T7/nowmctrl"
+for tool in bash mkdir cmp cp install basename date mv; do ln -s "$(command -v "$tool")" "$T7/nowmctrl/"; done
+run_install "$T7/src" "$T7/systemd" "$T7/bin" "$T7/autostart" "$T7/nowmctrl"
 rc=$?
 assert_exit "$rc" 0 "wmctrl-missing: brak wmctrl NIE przerywa instalacji (niefatalne)"
 grep -qi 'wmctrl' "$T7/src/out.log" && pass "wmctrl-missing: instalator ostrzega o braku wmctrl" \

--- a/deploy/live/tests/test_install.sh
+++ b/deploy/live/tests/test_install.sh
@@ -93,7 +93,30 @@ assert_exit "$rc" 0 "path-warn: BIN_DIR poza PATH = nadal sukces"
 grep -qi 'PATH' "$T6/src/out.log" && pass "path-warn: instalator ostrzega o PATH" \
   || fail "path-warn: brak ostrzeżenia o PATH"
 
-rm -rf "$T1" "$T4" "$T5" "$T6"
+# --- Test 7: brak wmctrl = ostrzeżenie, ale NIE błąd (niefatalna zależność show) ---
+T7="$(mktemp -d)"
+make_src "$T7/src"
+# PATH bez wmctrl → instalator ma ostrzec, lecz dokończyć (układanie okien to tylko nakładka).
+run_install "$T7/src" "$T7/systemd" "$T7/bin" "$T7/autostart" "/usr/bin:/bin"
+rc=$?
+assert_exit "$rc" 0 "wmctrl-missing: brak wmctrl NIE przerywa instalacji (niefatalne)"
+grep -qi 'wmctrl' "$T7/src/out.log" && pass "wmctrl-missing: instalator ostrzega o braku wmctrl" \
+  || fail "wmctrl-missing: brak ostrzeżenia o wmctrl"
+
+# --- Test 8: wmctrl obecny = sukces bez fałszywego ostrzeżenia o instalacji ---
+T8="$(mktemp -d)"
+make_src "$T8/src"
+mkdir -p "$T8/fakebin"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$T8/fakebin/wmctrl"
+chmod +x "$T8/fakebin/wmctrl"
+run_install "$T8/src" "$T8/systemd" "$T8/bin" "$T8/autostart" "$T8/fakebin:/usr/bin:/bin"
+rc=$?
+assert_exit "$rc" 0 "wmctrl-present: instalacja z dostępnym wmctrl = sukces"
+grep -qi 'install wmctrl\|brak wmctrl' "$T8/src/out.log" \
+  && fail "wmctrl-present: zbędne ostrzeżenie o wmctrl mimo obecności" \
+  || pass "wmctrl-present: brak fałszywego ostrzeżenia gdy wmctrl jest"
+
+rm -rf "$T1" "$T4" "$T5" "$T6" "$T7" "$T8"
 
 printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_kiosk_class.sh
+++ b/deploy/live/tests/test_kiosk_class.sh
@@ -18,8 +18,15 @@ grep -q -- '--class=setka-kiosk' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
 # Regresja: nowa flaga nie może wyprzeć istniejących — kiosk dalej --kiosk + osobny profil.
 DESC="kiosk: zachowuje --kiosk (pełnoekranowy tryb kiosku)"
 grep -q -- '--kiosk' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
-DESC="kiosk: zachowuje --user-data-dir (osobny profil wymusza własną instancję)"
-grep -q -- '--user-data-dir=' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
+DESC="kiosk: profil w obszarze snapa (~/snap/brave/common) — confinement nie zablokuje zapisu"
+grep -q -- '--user-data-dir="\$HOME/snap/brave/common/paternologia-kiosk"' "$KIOSK_SH" \
+  && pass "$DESC" || fail "$DESC"
+
+# Regresja: NIE używać ~/.local/share — snap Brave nie ma tam dostępu, ignoruje --user-data-dir,
+# forwarduje URL do zwykłej przeglądarki i wychodzi (okno kiosku się nie pojawia).
+DESC="kiosk: nie używa ~/.local/share (poza obszarem snapa → confinement blokuje)"
+grep -q -- '--user-data-dir="\$HOME/.local/share/paternologia-kiosk"' "$KIOSK_SH" \
+  && fail "$DESC" || pass "$DESC"
 
 printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_kiosk_class.sh
+++ b/deploy/live/tests/test_kiosk_class.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ABOUTME: Test statyczny paternologia-kiosk.sh — kiosk dostaje stały --class=setka-kiosk
-# ABOUTME: (deterministyczny uchwyt okna do układania), bez gubienia dotychczasowych flag. Nie odpala brave.
+# ABOUTME: Test statyczny paternologia-kiosk.sh — kiosk (nie-snap google-chrome) dostaje stały
+# ABOUTME: --class=setka-kiosk i własny profil, bez gubienia flag. Czysto statyczny — nie odpala przeglądarki.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,22 +11,31 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); printf 'ok   - %s\n' "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf 'FAIL - %s\n' "$1"; }
 
-# Czysto statycznie: kiosk uruchamia realne brave i czeka na serwer — nie wolno go odpalać w teście.
+# Czysto statycznie: kiosk uruchamia realną przeglądarkę i czeka na serwer — nie odpalamy jej w teście.
 DESC="kiosk: nadaje --class=setka-kiosk (pewny, unikalny uchwyt okna)"
 grep -q -- '--class=setka-kiosk' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
 
-# Regresja: nowa flaga nie może wyprzeć istniejących — kiosk dalej --kiosk + osobny profil.
 DESC="kiosk: zachowuje --kiosk (pełnoekranowy tryb kiosku)"
 grep -q -- '--kiosk' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
-DESC="kiosk: profil w obszarze snapa (~/snap/brave/common) — confinement nie zablokuje zapisu"
-grep -q -- '--user-data-dir="\$HOME/snap/brave/common/paternologia-kiosk"' "$KIOSK_SH" \
-  && pass "$DESC" || fail "$DESC"
 
-# Regresja: NIE używać ~/.local/share — snap Brave nie ma tam dostępu, ignoruje --user-data-dir,
-# forwarduje URL do zwykłej przeglądarki i wychodzi (okno kiosku się nie pojawia).
-DESC="kiosk: nie używa ~/.local/share (poza obszarem snapa → confinement blokuje)"
+# Świeży profil chrome pokazuje ekran „Witamy"/wybór domyślnej przeglądarki ZAMIAST /live —
+# te flagi przeskakują first-run, by kiosk od razu ładował aplikację.
+DESC="kiosk: --no-first-run (pomija ekran powitalny świeżego profilu)"
+grep -q -- '--no-first-run' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
+DESC="kiosk: --no-default-browser-check (pomija pytanie o domyślną przeglądarkę)"
+grep -q -- '--no-default-browser-check' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
+
+# Nie-snap google-chrome: deterministyczne pozycjonowanie i poprawne śledzenie przez systemd.
+# (snap Brave dwoił pozycję okna i odłączał się od usługi — patrz historia.)
+DESC="kiosk: używa nie-snapowego google-chrome"
+grep -q -- 'exec google-chrome' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
+DESC="kiosk: nie używa snapowego brave (źródło podwojenia pozycji i detachu)"
+grep -q -- 'exec brave' "$KIOSK_SH" && fail "$DESC" || pass "$DESC"
+
+# Bez confinementu profil może (i ma) leżeć w ~/.local/share — osobna instancja kiosku.
+DESC="kiosk: profil w ~/.local/share/paternologia-kiosk (osobna instancja, bez confinementu)"
 grep -q -- '--user-data-dir="\$HOME/.local/share/paternologia-kiosk"' "$KIOSK_SH" \
-  && fail "$DESC" || pass "$DESC"
+  && pass "$DESC" || fail "$DESC"
 
 printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_kiosk_class.sh
+++ b/deploy/live/tests/test_kiosk_class.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ABOUTME: Test statyczny paternologia-kiosk.sh — kiosk dostaje stały --class=setka-kiosk
+# ABOUTME: (deterministyczny uchwyt okna do układania), bez gubienia dotychczasowych flag. Nie odpala brave.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIOSK_SH="$SCRIPT_DIR/../bin/paternologia-kiosk.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); printf 'ok   - %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf 'FAIL - %s\n' "$1"; }
+
+# Czysto statycznie: kiosk uruchamia realne brave i czeka na serwer — nie wolno go odpalać w teście.
+DESC="kiosk: nadaje --class=setka-kiosk (pewny, unikalny uchwyt okna)"
+grep -q -- '--class=setka-kiosk' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
+
+# Regresja: nowa flaga nie może wyprzeć istniejących — kiosk dalej --kiosk + osobny profil.
+DESC="kiosk: zachowuje --kiosk (pełnoekranowy tryb kiosku)"
+grep -q -- '--kiosk' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
+DESC="kiosk: zachowuje --user-data-dir (osobny profil wymusza własną instancję)"
+grep -q -- '--user-data-dir=' "$KIOSK_SH" && pass "$DESC" || fail "$DESC"
+
+printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_live_layout.sh
+++ b/deploy/live/tests/test_live_layout.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ABOUTME: Test live-layout.sh (plain shell). Karmi czyste funkcje geometrii realnym wyjściem
+# ABOUTME: xrandr --listmonitors i przypadkami brzegowymi; warstwę live testuje przez rec>ndr/wmctrl.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAYOUT_SH="$SCRIPT_DIR/../bin/live-layout.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); printf 'ok   - %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf 'FAIL - %s\n' "$1"; }
+assert_eq() { # got want desc
+  if [ "$1" = "$2" ]; then pass "$3"; else fail "$3 (got '$1' want '$2')"; fi
+}
+
+# Sourcing nie może odpalić main() — guard w skrypcie ma to zapewnić.
+# shellcheck disable=SC1090
+source "$LAYOUT_SH"
+
+# --- Realne wyjście `xrandr --listmonitors` (przechwycone z maszyny) ---
+# Uwaga: HDMI (prawy, offset 1280) wypisany PRZED DVI (lewy, offset 0) — parser musi sortować po X.
+XRANDR_REAL="Monitors: 2
+ 0: +*HDMI-0 1440/530x900/300+1280+0  HDMI-0
+ 1: +DVI-D-0 1280/376x1024/301+0+0  DVI-D-0"
+
+# --- layout_parse_monitors: token W/mm x H/mm + X + Y → 'x y w h', sort po X ---
+parsed="$(layout_parse_monitors "$XRANDR_REAL")"
+assert_eq "$(printf '%s' "$parsed" | sed -n 1p)" "0 0 1280 1024" \
+  "parse: lewy monitor pierwszy (offset 0) → '0 0 1280 1024'"
+assert_eq "$(printf '%s' "$parsed" | sed -n 2p)" "1280 0 1440 900" \
+  "parse: prawy monitor drugi (offset 1280) → '1280 0 1440 900'"
+
+# --- sloty: bitwig = cały lewy; obs = górna połowa prawego; paternologia = dolna połowa ---
+assert_eq "$(layout_slot_bitwig 0 0 1280 1024)" "0 0 1280 1024" \
+  "slot bitwig: cały lewy monitor"
+assert_eq "$(layout_slot_obs 1280 0 1440 900)" "1280 0 1440 450" \
+  "slot obs: górna połowa prawego"
+assert_eq "$(layout_slot_paternologia 1280 0 1440 900)" "1280 450 1440 450" \
+  "slot paternologia: dolna połowa prawego"
+
+# --- Edge: nieparzysta wysokość → połówki tilują bez dziury/zakładki (styk == y+h_top) ---
+obs_odd="$(layout_slot_obs 1280 0 1440 901)"
+pat_odd="$(layout_slot_paternologia 1280 0 1440 901)"
+obs_h="$(printf '%s' "$obs_odd" | cut -d' ' -f4)"
+pat_y="$(printf '%s' "$pat_odd" | cut -d' ' -f2)"
+pat_h="$(printf '%s' "$pat_odd" | cut -d' ' -f4)"
+assert_eq "$((obs_h + pat_h))" "901" \
+  "slot odd: suma wysokości połówek == pełna wysokość (brak zgubionego piksela)"
+assert_eq "$pat_y" "$((0 + obs_h))" \
+  "slot odd: dolna połowa zaczyna się dokładnie na styku górnej (brak dziury/zakładki)"
+
+# --- Edge: monitory w odwrotnej kolejności w wejściu → sort i tak daje lewy (X=0) pierwszy ---
+XRANDR_REV="Monitors: 2
+ 0: +*DVI-D-0 1280/376x1024/301+0+0  DVI-D-0
+ 1: +HDMI-0 1440/530x900/300+1280+0  HDMI-0"
+parsed_rev="$(layout_parse_monitors "$XRANDR_REV")"
+assert_eq "$(printf '%s' "$parsed_rev" | sed -n 1p)" "0 0 1280 1024" \
+  "parse rev: sort po X daje lewy (offset 0) jako pierwszy niezależnie od kolejności wejścia"
+
+# =====================================================================================
+# Warstwa live: recordery podstawiane pod XRANDR_BIN/WMCTRL_BIN (NIE mock realnego WM —
+# zero realnych okien; weryfikujemy REALNE argumenty wywołań i logikę bramek/braku okna).
+# =====================================================================================
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Recorder xrandr: zwraca utrwalone wyjście --listmonitors (HDMI prawy, DVI lewy).
+XRR="$WORK/xrandr-rec"
+cat >"$XRR" <<'EOF'
+#!/usr/bin/env bash
+printf 'Monitors: 2\n 0: +*HDMI-0 1440/530x900/300+1280+0  HDMI-0\n 1: +DVI-D-0 1280/376x1024/301+0+0  DVI-D-0\n'
+EOF
+chmod +x "$XRR"
+
+# Recorder wmctrl: na zapytanie -lx wypisuje po jednej linii na klasę z REC_WINDOWS
+# (udaje istniejące okna); każde inne wywołanie (akcje -e/-a/-b) loguje do WMCTRL_REC_LOG.
+WMC="$WORK/wmctrl-rec"
+cat >"$WMC" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *-lx*)
+    for c in $REC_WINDOWS; do printf '0x0300000a  0 %s  host  Tytuł\n' "$c"; done ;;
+  *)
+    printf '%s\n' "$*" >> "$WMCTRL_REC_LOG" ;;
+esac
+exit 0
+EOF
+chmod +x "$WMC"
+
+WMLOG="$WORK/wmctrl.log"
+ALL_WINDOWS="obs.obs com.bitwig.BitwigStudio setka-kiosk"
+
+# Uruchamia live-layout.sh z recorderami; kolejne env (WMCTRL_BIN/XDG_SESSION_TYPE/...) z "$@"
+# nadpisują domyślne (env: ostatnie przypisanie wygrywa). GRACE_WINDOW=0 → brak okna nie wisi.
+layout_run() {
+  : >"$WMLOG"
+  env XRANDR_BIN="$XRR" WMCTRL_BIN="$WMC" WMCTRL_REC_LOG="$WMLOG" \
+    REC_WINDOWS="$ALL_WINDOWS" GRACE_WINDOW=0 \
+    XDG_SESSION_TYPE=x11 DISPLAY=:1 "$@" \
+    bash "$LAYOUT_SH" >"$WORK/out.log" 2>&1
+  echo $?
+}
+
+# --- Happy path: wszystkie okna istnieją → -e z prostokątami R2 dla każdej klasy + -a ---
+rc="$(layout_run)"
+assert_eq "$rc" "0" "live happy: exit 0 gdy wszystkie okna obecne"
+grep -q -- '-r com.bitwig.BitwigStudio -e 0,0,0,1280,1024' "$WMLOG" \
+  && pass "live happy: Bitwig → cały lewy (0,0,1280,1024)" || fail "live happy: zły slot Bitwiga"
+grep -q -- '-r obs.obs -e 0,1280,0,1440,450' "$WMLOG" \
+  && pass "live happy: OBS → górna połowa prawego (1280,0,1440,450)" || fail "live happy: zły slot OBS"
+grep -q -- '-r setka-kiosk -e 0,1280,450,1440,450' "$WMLOG" \
+  && pass "live happy: kiosk → dolna połowa prawego (1280,450,1440,450)" || fail "live happy: zły slot kiosku"
+# Na wierzch: każda klasa aktywowana (-a).
+for cls in obs.obs com.bitwig.BitwigStudio setka-kiosk; do
+  grep -q -- "-a $cls" "$WMLOG" && pass "live happy: $cls aktywowany (-a, na wierzch)" \
+    || fail "live happy: brak aktywacji $cls"
+done
+
+# --- Integration (cross-layer): współrzędne liczone z podstawionego XRANDR_BIN, nie zaszyte ---
+# Dowód: gdyby zaszyte, zmiana wyjścia xrandr nic by nie dała. Podmieniamy szerokość lewego
+# monitora (1280→1366) i sprawdzamy, że slot Bitwiga podąża za danymi z xrandr.
+XRR2="$WORK/xrandr-rec2"
+cat >"$XRR2" <<'EOF'
+#!/usr/bin/env bash
+printf 'Monitors: 2\n 0: +*HDMI-0 1440/530x900/300+1366+0  HDMI-0\n 1: +DVI-D-0 1366/376x1024/301+0+0  DVI-D-0\n'
+EOF
+chmod +x "$XRR2"
+: >"$WMLOG"
+env XRANDR_BIN="$XRR2" WMCTRL_BIN="$WMC" WMCTRL_REC_LOG="$WMLOG" \
+  REC_WINDOWS="$ALL_WINDOWS" GRACE_WINDOW=0 XDG_SESSION_TYPE=x11 DISPLAY=:1 \
+  bash "$LAYOUT_SH" >"$WORK/out.log" 2>&1
+grep -q -- '-r com.bitwig.BitwigStudio -e 0,0,0,1366,1024' "$WMLOG" \
+  && pass "live integ: slot liczony z xrandr (lewy 1366) — nie zaszyty" \
+  || fail "live integ: współrzędne nie podążają za xrandr"
+grep -q -- '-r obs.obs -e 0,1366,0,1440,450' "$WMLOG" \
+  && pass "live integ: prawy monitor przesunięty zgodnie z offsetem z xrandr (X=1366)" \
+  || fail "live integ: offset prawego nie z xrandr"
+
+# --- Error path: sesja Wayland → twardy FAIL, ZERO wywołań wmctrl ---
+rc="$(layout_run XDG_SESSION_TYPE=wayland)"
+[ "$rc" != "0" ] && pass "live wayland: niezerowy exit (jawna odmowa)" || fail "live wayland: exit 0 (powinno !=0)"
+[ ! -s "$WMLOG" ] && pass "live wayland: zero wywołań wmctrl (bramka przed akcjami)" \
+  || fail "live wayland: wmctrl wywołany mimo Waylanda"
+grep -qi 'wayland\|x11' "$WORK/out.log" && pass "live wayland: komunikat o braku wsparcia nie-X11" \
+  || fail "live wayland: brak komunikatu o sesji"
+
+# --- Error path: brak wmctrl w PATH → twardy FAIL z podpowiedzią instalacji ---
+rc="$(layout_run WMCTRL_BIN="$WORK/nie-ma-wmctrl")"
+[ "$rc" != "0" ] && pass "live no-wmctrl: niezerowy exit gdy brak wmctrl" || fail "live no-wmctrl: exit 0 (powinno !=0)"
+grep -qi 'wmctrl' "$WORK/out.log" && pass "live no-wmctrl: podpowiedź instalacji wmctrl" \
+  || fail "live no-wmctrl: brak podpowiedzi o wmctrl"
+
+# --- Edge (R5): brak okna Bitwiga → pozostałe ułożone, Bitwig raportowany, exit 0 ---
+rc="$(layout_run REC_WINDOWS="obs.obs setka-kiosk")"
+assert_eq "$rc" "0" "live R5: exit 0 mimo brakującego okna (brak okna != awaria)"
+grep -q -- '-r obs.obs -e 0,1280,0,1440,450' "$WMLOG" \
+  && pass "live R5: OBS ułożony mimo braku Bitwiga" || fail "live R5: OBS nie ułożony"
+grep -q -- '-r setka-kiosk -e 0,1280,450,1440,450' "$WMLOG" \
+  && pass "live R5: kiosk ułożony mimo braku Bitwiga" || fail "live R5: kiosk nie ułożony"
+grep -q -- '-r com.bitwig.BitwigStudio -e' "$WMLOG" \
+  && fail "live R5: ustawiono geometrię nieistniejącego Bitwiga" || pass "live R5: brakujący Bitwig pominięty (nie ustawiono geometrii)"
+grep -qi 'bitwig' "$WORK/out.log" && pass "live R5: raport wymienia brakujący Bitwig" \
+  || fail "live R5: brak raportu o brakującym oknie"
+
+# --- Idempotencja (R4): dwa przebiegi → identyczny zestaw wywołań geometrii ---
+layout_run >/dev/null; run1="$(grep -- ' -e ' "$WMLOG" | sort)"
+layout_run >/dev/null; run2="$(grep -- ' -e ' "$WMLOG" | sort)"
+assert_eq "$run2" "$run1" "live R4: dwa przebiegi dają identyczne wywołania geometrii (idempotencja)"
+
+printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_live_layout.sh
+++ b/deploy/live/tests/test_live_layout.sh
@@ -117,6 +117,11 @@ for cls in obs.obs com.bitwig.BitwigStudio setka-kiosk; do
   grep -q -- "-a $cls" "$WMLOG" && pass "live happy: $cls aktywowany (-a, na wierzch)" \
     || fail "live happy: brak aktywacji $cls"
 done
+# Pełnoekranowe okno (kiosk --kiosk) ignoruje -e — przed ustawieniem geometrii trzeba zdjąć
+# stan fullscreen (osobne -b: EWMH pozwala zmienić max 2 właściwości na wywołanie).
+grep -q -- '-b remove,fullscreen' "$WMLOG" \
+  && pass "live happy: zdejmuje fullscreen przed geometrią (kiosk jest pełnoekranowy)" \
+  || fail "live happy: brak remove,fullscreen"
 
 # --- Integration (cross-layer): współrzędne liczone z podstawionego XRANDR_BIN, nie zaszyte ---
 # Dowód: gdyby zaszyte, zmiana wyjścia xrandr nic by nie dała. Podmieniamy szerokość lewego

--- a/deploy/live/tests/test_setka_live.sh
+++ b/deploy/live/tests/test_setka_live.sh
@@ -22,9 +22,20 @@ exit 0
 EOF
 chmod +x "$REC"
 
+# Rejestrator udający live-layout.sh: loguje znacznik do TEGO SAMEGO REC_LOG (widać kolejność
+# względem systemctl) i kończy kodem LAYOUT_RC (domyślnie 0; 1 testuje best-effort w start).
+LAYOUT_REC="$WORK/layout-rec"
+cat >"$LAYOUT_REC" <<'EOF'
+#!/usr/bin/env bash
+printf 'LAYOUT_BIN_CALLED\n' >> "$SETKA_REC_LOG"
+exit "${LAYOUT_RC:-0}"
+EOF
+chmod +x "$LAYOUT_REC"
+
 run_setka() {
   : >"$REC_LOG"
   SYSTEMCTL_BIN="$REC" SETKA_REC_LOG="$REC_LOG" \
+    LAYOUT_BIN="$LAYOUT_REC" LAYOUT_RC="${LAYOUT_RC:-0}" \
     HEALTH_URL="http://127.0.0.1:59999/health" \
     bash "$SETKA" "$@" >"$WORK/out.log" 2>&1
   echo $?
@@ -77,9 +88,32 @@ rc="$(run_setka status)"
 [ "$rc" = "0" ] && pass "status: exit 0 mimo martwego /health" || fail "status: exit $rc"
 grep -qi 'health' "$WORK/out.log" && pass "status: raportuje sekcję /health" || fail "status: brak /health w wyjściu"
 
+# --- show: woła LAYOUT_BIN, exit 0 ---
+rc="$(run_setka show)"
+[ "$rc" = "0" ] && pass "show: exit 0" || fail "show: exit $rc"
+grep -q -- 'LAYOUT_BIN_CALLED' "$REC_LOG" \
+  && pass "show: woła LAYOUT_BIN (układanie okien)" || fail "show: nie wywołał LAYOUT_BIN"
+grep -q -- '--user start' "$REC_LOG" \
+  && fail "show: niepotrzebnie ruszył systemd" || pass "show: nie dotyka systemd (czysto okienkowe)"
+
+# --- start: woła start targetu ORAZ następnie LAYOUT_BIN (layout po starcie) ---
+rc="$(run_setka start)"
+[ "$rc" = "0" ] && pass "start: exit 0 (z auto-layoutem)" || fail "start: exit $rc"
+grep -q -- 'LAYOUT_BIN_CALLED' "$REC_LOG" \
+  && pass "start: po starcie układa okna (auto-layout)" || fail "start: brak auto-layoutu"
+start_ln="$(grep -n -- '--user start live-recording.target' "$REC_LOG" | head -1 | cut -d: -f1)"
+layout_ln="$(grep -n -- 'LAYOUT_BIN_CALLED' "$REC_LOG" | head -1 | cut -d: -f1)"
+[ -n "$start_ln" ] && [ -n "$layout_ln" ] && [ "$start_ln" -lt "$layout_ln" ] \
+  && pass "start: layout następuje PO starcie targetu" || fail "start: zła kolejność start/layout"
+
+# --- start: layout best-effort — błąd układania NIE wywraca startu (R3/R5) ---
+rc="$(LAYOUT_RC=1 run_setka start)"
+[ "$rc" = "0" ] && pass "start: exit 0 mimo błędu layoutu (best-effort)" || fail "start: błąd layoutu wywrócił start (exit $rc)"
+
 # --- nieznana komenda → niezerowy exit, usage ---
 rc="$(run_setka frobnicate)"
 [ "$rc" != "0" ] && pass "unknown: niezerowy exit dla nieznanej komendy" || fail "unknown: exit 0 (powinno != 0)"
+grep -qi 'show' "$WORK/out.log" && pass "unknown: usage wymienia komendę show" || fail "unknown: usage bez show"
 
 rm -rf "$WORK"
 printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"

--- a/deploy/live/units/bitwig.service
+++ b/deploy/live/units/bitwig.service
@@ -11,7 +11,10 @@ ConditionEnvironment=DISPLAY
 [Service]
 Type=exec
 # Main PID = bwrap (flatpak), więc Type=exec/simple — nie forking.
-ExecStart=/usr/bin/flatpak run com.bitwig.BitwigStudio
+# Otwiera od razu szablon live (nowy projekt z szablonu — nie nadpisuje szablonu), zamiast pytać
+# w dashboardzie „co otworzyć". Flatpak ma filesystem=host, więc widzi ~/Bitwig Studio. Ścieżka
+# ze spacjami w cudzysłowie (systemd traktuje ją jako jeden argument); %h = katalog domowy.
+ExecStart=/usr/bin/flatpak run com.bitwig.BitwigStudio "%h/Bitwig Studio/Library/Templates/template.bwtemplate"
 # Czyste domknięcie sandboxa flatpaka (ubicie samego cgroup nie zamyka go porządnie).
 ExecStop=/usr/bin/flatpak kill com.bitwig.BitwigStudio
 Restart=no

--- a/docs/brainstorms/2026-06-03-setka-live-window-layout-requirements.md
+++ b/docs/brainstorms/2026-06-03-setka-live-window-layout-requirements.md
@@ -1,0 +1,80 @@
+---
+date: 2026-06-03
+topic: setka-live-window-layout
+---
+
+# setka-live: wyciągnięcie i ułożenie okien na dwóch monitorach
+
+## Problem Frame
+Po `setka-live start` środowisko nagraniowe (OBS + Bitwig + kiosk Paternologii) działa,
+ale okna lądują w przypadkowych miejscach / pod innymi oknami. Operator (Wojtas) musi
+ręcznie alt-tabować i przeciągać je na właściwe monitory, zanim zacznie nagrywać — co
+psuje obietnicę „jednego polecenia". Potrzebna jedna komenda, która wyciąga komplet okien
+na wierzch i układa je w stałym, znanym układzie na dwóch monitorach.
+
+## Requirements
+- R1. Nowa komenda `setka-live show` wyciąga na wierzch (raise + activate) i układa
+  okna OBS, Bitwiga i kiosku Paternologii w stałym układzie na dwóch monitorach.
+- R2. Układ docelowy (wybrany):
+  - **Lewy monitor (DVI-D-0, 1280×1024):** Bitwig — cała powierzchnia.
+  - **Prawy monitor (HDMI-0, 1440×900):** OBS górna połowa, Paternologia (kiosk) dolna połowa.
+- R3. `setka-live start` na końcu automatycznie wykonuje ten sam układ, gdy okna już się
+  pojawiły. Układanie jest też dostępne osobno przez `setka-live show` (gdy okna się rozjadą).
+- R4. Komenda działa idempotentnie — wielokrotne wywołanie zawsze daje ten sam układ.
+- R5. Brak któregoś okna (np. Bitwig jeszcze nie wstał) nie wywraca komendy: układa to,
+  co istnieje, i czytelnie raportuje, czego zabrakło (FAIL FAST tylko dla realnych błędów,
+  nie dla pojedynczego brakującego okna).
+
+## Success Criteria
+- Po `setka-live start` (lub `setka-live show`) okna są dokładnie w układzie z R2 bez
+  ręcznego dotykania myszą.
+- Powtórne `setka-live show` po rozjechaniu okien przywraca układ.
+- Gdy jedno z okien nie istnieje, komenda układa pozostałe i wypisuje, którego brakło.
+
+## Scope Boundaries
+- Nie obsługujemy Waylanda. Maszyna to GNOME na Xorg (potwierdzone: `XDG_SESSION_TYPE=x11`,
+  realny proces Xorg, brak Xwaylanda). Gdyby sesja kiedyś przeszła na Wayland, komenda ma
+  jasno odmówić, nie udawać że działa.
+- Nie konfigurujemy dynamicznie liczby/rozdzielczości monitorów ani profili `xrandr`.
+  Układ celuje w obecny zestaw 2 monitorów; geometria liczona z `xrandr`, nie zaszyta na sztywno.
+- Nie ruszamy paternologia.service ani warstwy audio — to czysto okienkowa nakładka.
+- Brak GUI/konfiguratora układów; jeden zaszyty układ (R2) wystarcza.
+
+## Key Decisions
+- **Narzędzie: `wmctrl` (EWMH), nie GNOME Shell Eval.** Mutter na Xorg w pełni wspiera
+  EWMH (move/resize/raise/activate). `gnome-shell Eval` jest zablokowany ze względów
+  bezpieczeństwa (zwraca `false`) — celowo nie idziemy tą drogą. `wmctrl`/`xdotool` nie są
+  jeszcze zainstalowane → instalator warstwy live musi to dociągnąć / sprawdzić.
+- **Komenda nazywa się `show`** (obok start/stop/restart/status) — najkrótsze „pokaż wszystko".
+- **Auto po `start` + osobna komenda** — start kończy układaniem, ale `show` można odpalić
+  ręcznie kiedykolwiek (okna dryfują, alt-tab, etc.).
+- **Geometria z `xrandr`, nie zaszyta** — offsety/rozmiary monitorów czytane na żywo
+  (lewy = offset X 0, prawy = offset X = szerokość lewego), żeby przetrwać zmianę kolejności.
+
+## Dependencies / Assumptions
+- `wmctrl` (lub `xdotool`) zainstalowane na maszynie live — do dołożenia w `deploy/live/install.sh`
+  albo jako preflight-check w `setka-live show`.
+- Okna mają stabilne, rozróżnialne `WM_CLASS`. OBS i Bitwig (flatpak) — do potwierdzenia w
+  implementacji. Kiosk Paternologii (Brave `--kiosk`) — rozważyć `brave --class=setka-kiosk`,
+  by mieć pewny, unikalny uchwyt zamiast zderzać się ze zwykłym Brave.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+- (brak — kierunek produktowy domknięty)
+
+### Deferred to Planning
+- [Affects R1][Technical] Dokładne `WM_CLASS` dla OBS, Bitwiga-flatpak i kiosku — zweryfikować
+  `wmctrl -lx` przy działających oknach; zdecydować czy nadać kioskowi własny `--class`.
+- [Affects R3][Technical] Timing auto-układania po `start`: okna pojawiają się z opóźnieniem
+  (flatpak Bitwig, kiosk czeka na /health paternologii). Potrzebny krótki polling „czekaj aż
+  okno istnieje" z grace-timeoutem, zanim ustawimy geometrię — analogicznie do bram preflightu.
+- [Affects R2][Technical] Korekta dekoracji/paneli (pasek GNOME, ramki okien) przy liczeniu
+  geometrii — czy `wmctrl -e` z `0,x,y,w,h` trafia 1:1, czy trzeba kompensować `_NET_FRAME_EXTENTS`.
+- [Affects R5][Technical] Sposób testowania (warstwa live jest testowana w bashu, narzędzia
+  okienkowe trudno mockować) — wydzielić czyste funkcje liczące geometrię z `xrandr` i testować je,
+  a wywołania `wmctrl` przez indirekcję `WMCTRL_BIN` (jak `SYSTEMCTL_BIN`/`SYSTEMD_USER_DIR`).
+
+## Next Steps
+→ `/ce:plan` — kierunek produktowy domknięty, zostały same decyzje techniczne (mapowanie
+  WM_CLASS, timing, geometria, testowalność), które należą do planowania.

--- a/docs/plans/2026-06-03-001-feat-setka-live-window-layout-plan.md
+++ b/docs/plans/2026-06-03-001-feat-setka-live-window-layout-plan.md
@@ -1,0 +1,389 @@
+---
+title: "feat: setka-live show — wyciągnięcie i ułożenie okien na dwóch monitorach"
+type: feat
+status: completed
+date: 2026-06-03
+origin: docs/brainstorms/2026-06-03-setka-live-window-layout-requirements.md
+---
+
+# feat: setka-live show — wyciągnięcie i ułożenie okien na dwóch monitorach
+
+## Overview
+
+Dodajemy do warstwy live komendę `setka-live show`, która wyciąga na wierzch i układa okna
+OBS, Bitwiga i kiosku Paternologii w stałym układzie na dwóch monitorach (Bitwig — cały lewy
+ekran; OBS — górna połowa prawego; Paternologia — dolna połowa prawego). `setka-live start`
+wywołuje to samo układanie na końcu (best-effort). Realizacja przez `wmctrl` (EWMH na
+GNOME/Xorg), z geometrią liczoną na żywo z `xrandr` — nic nie jest zaszyte na sztywno.
+
+## Problem Frame
+
+Po `setka-live start` środowisko działa, ale okna lądują w przypadkowych miejscach / pod
+sobą; operator musi ręcznie je rozkładać przed nagraniem, co psuje obietnicę „jednego
+polecenia". (see origin: docs/brainstorms/2026-06-03-setka-live-window-layout-requirements.md)
+
+## Requirements Trace
+
+- R1. `setka-live show` wyciąga na wierzch i układa OBS, Bitwiga i kiosk w stałym układzie.
+- R2. Układ: **lewy monitor** (najmniejszy offset X) — Bitwig na całość; **prawy monitor** —
+  OBS górna połowa, Paternologia dolna połowa.
+- R3. `setka-live start` na końcu wykonuje to samo układanie (best-effort), a `show` jest też
+  dostępne osobno.
+- R4. Idempotencja — wielokrotne wywołanie daje ten sam układ.
+- R5. Brak okna nie wywraca komendy: układa to, co istnieje, raportuje brakujące; twardy błąd
+  tylko dla realnych awarii środowiska (brak DISPLAY / wmctrl / sesja nie-X11).
+
+## Scope Boundaries
+
+- Brak obsługi Waylanda — maszyna to GNOME na Xorg (`XDG_SESSION_TYPE=x11`, realny Xorg, brak
+  Xwaylanda). Komenda ma jawnie odmówić na nie-X11, nie udawać sukcesu.
+- Brak dynamicznej konfiguracji liczby/rozdzielczości monitorów ani profili `xrandr`; geometria
+  czytana z `xrandr` pod obecny zestaw 2 monitorów.
+- Nie ruszamy paternologia.service ani warstwy audio — czysto okienkowa nakładka.
+- Brak GUI/konfiguratora układów; jeden zaszyty układ (R2).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/live/bin/live-preflight.sh` — **wzorzec architektoniczny do skopiowania**: czyste
+  funkcje decyzyjne karmione tekstem (`preflight_rate_ok` parsuje `pw-metadata`), `poll_ok`
+  z grace-timeoutem (retry bez wiszenia), live-wrappery pobierające świeże dane, i source-guard
+  `if [ "${BASH_SOURCE[0]}" = "${0}" ]; then main "$@"; fi` umożliwiający sourcing w testach.
+- `deploy/live/bin/setka-live` — dyspozytor `case` z `usage()`; indirekcja `SYSTEMCTL_BIN`
+  (env override wyłącznie dla testów). `cmd_start` to obecnie `sctl start "$TARGET"`.
+- `deploy/live/bin/paternologia-kiosk.sh` — wywołanie `brave --kiosk … --user-data-dir=…`;
+  dodamy `--class=setka-kiosk` dla pewnego, unikalnego uchwytu okna.
+- `deploy/live/install.sh` — `install_file()` idempotentny (`cmp -s`, backup `.bak-STAMP`),
+  pętla po `bin/*` (nowy skrypt skopiuje się automatycznie), ostrzeżenia niefatalne.
+- `deploy/live/tests/test_setka_live.sh` — wzorzec testu: rejestrator-recorder podstawiany pod
+  `SYSTEMCTL_BIN`, log wywołań, liczniki `pass/fail`, asercje `grep` na realnych argumentach.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-06-01-bitwig-pipewire-44100-usb-audio-contention.md` i
+  `…bitwig-alsa-seq-invisible-virmidi-bridge.md` — dotyczą audio/MIDI, nie okien; bez wpływu
+  na ten plan (potwierdzono brak kolizji zakresu).
+- Pamięć projektu: maszyna dev to **X11** (`DISPLAY=:1` w activation env), `bats` niedostępny →
+  testy w czystym bashu. Warstwa live celowo nie tyka PipeWire/paternologii.
+
+### External References
+
+- Pominięte świadomie — `wmctrl`/EWMH/`xrandr` to dojrzałe, stabilne narzędzia, a lokalny
+  wzorzec (live-preflight) jest bezpośrednio przekładalny. Brak ryzyka uzasadniającego badania.
+
+## Key Technical Decisions
+
+- **`wmctrl`, nie GNOME Shell Eval**: Mutter/Xorg w pełni wspiera EWMH; `gnome-shell Eval`
+  zablokowany (zwraca `false`). `wmctrl -lx` listuje okna z WM_CLASS, `-r <cls> -e g,x,y,w,h`
+  ustawia geometrię, `-a` aktywuje. (Alternatywa `xdotool` równoważna; `wmctrl` zwięźlejszy dla
+  „ustaw geometrię po klasie".)
+- **Identyfikacja monitorów po offsecie X, nie po nazwie**: lewy = najmniejszy Xoffset, prawy =
+  większy. Przeżyje zamianę kabli/nazw (HDMI/DVI). Geometria z `xrandr --listmonitors`.
+- **Kiosk dostaje własny `--class=setka-kiosk`**: deterministyczny, unikalny uchwyt — nie
+  zderza się ze zwykłym Brave operatora. OBS i Bitwig dopasowywane po ich natywnym WM_CLASS
+  (dokładne wartości do potwierdzenia — patrz Deferred).
+- **Rozdzielenie czyste/live jak w preflight**: funkcje parsujące `xrandr` i liczące prostokąty
+  slotów są czyste i testowalne tekstem; wywołania `wmctrl` w warstwie live za indirekcją
+  `WMCTRL_BIN` (recorder w testach).
+- **Auto-layout po `start` jest best-effort**: nie wolno mu wywrócić `start` (R3, R5). Pętla
+  „czekaj aż okno istnieje" z grace-timeoutem pokrywa opóźnione pojawianie się okien
+  (flatpak Bitwig, kiosk czekający na /health), wzorowana na `poll_ok`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Nazwa komendy → `show` (decyzja z brainstormu).
+- Czy `start` układa automatycznie → tak, na końcu, best-effort; `show` też ręcznie.
+- Jak liczyć geometrię → z `xrandr --listmonitors`, sortując sloty po offsecie X.
+- Czym targetować kiosk → własny `--class=setka-kiosk`.
+
+### Deferred to Implementation
+
+- **Dokładne WM_CLASS dla OBS i Bitwiga-flatpak** — ustalić `wmctrl -lx` przy żywych oknach;
+  wpisać jako konfigurowalne stałe na górze `live-layout.sh`. (OBS prawdopodobnie `obs.obs`,
+  Bitwig-flatpak prawdopodobnie `com.bitwig.BitwigStudio` lub `Bitwig Studio` — zweryfikować.)
+- **Kompensacja `_NET_FRAME_EXTENTS`** — czy `wmctrl -e 0,x,y,w,h` na Mutterze trafia 1:1, czy
+  ramki okien wymagają korekty offsetu/rozmiaru. Sprawdzić empirycznie i ewentualnie odjąć ramkę.
+- **Zdjęcie maksymalizacji przed geometrią** — okno zmaksymalizowane ignoruje `-e`; prawdopodobnie
+  potrzebne `wmctrl -r <cls> -b remove,maximized_vert,maximized_horz` przed ustawieniem. Potwierdzić.
+- **Dobór wartości grace-timeoutu** dla pollingu pojawienia się okien (rząd wielkości: Bitwig-flatpak
+  startuje najwolniej) — dostroić przy realnym `start`.
+
+## High-Level Technical Design
+
+> *Ilustruje zamierzony kształt rozwiązania — wskazówka kierunkowa do recenzji, nie specyfikacja
+> implementacji. Agent implementujący traktuje to jako kontekst, nie kod do przepisania.*
+
+Przepływ `setka-live show`:
+
+```
+1. Bramki środowiska (twardy FAIL → exit !=0):
+     XDG_SESSION_TYPE=x11 ?  DISPLAY ustawiony ?  wmctrl obecny ?
+2. monitors = parse(xrandr --listmonitors)          # czysta funkcja
+     → [ {x,y,w,h}, … ] posortowane po offsecie X
+     LEWY = monitors[0], PRAWY = monitors[1]
+3. sloty = compute_slots(LEWY, PRAWY)               # czysta funkcja
+     bitwig      = LEWY  (cały)
+     obs         = PRAWY górna połowa  (h/2)
+     paternologia= PRAWY dolna połowa  (y+h/2, h/2)
+4. dla każdego (WM_CLASS → slot):
+     poll_window_exists(cls, grace)                  # czeka na okno; brak → pomiń+raportuj (R5)
+     wmctrl: remove maximized → -e 0,x,y,w,h → -a    # ustaw geometrię + na wierzch
+5. raport: ułożone / brakujące; exit 0 gdy tylko brak okien
+```
+
+Mapowanie geometrii dla obecnego sprzętu (poglądowo, liczone na żywo):
+- LEWY  (DVI, 1280x1024 @ +0+0):     Bitwig       → 0,0,1280,1024
+- PRAWY (HDMI, 1440x900 @ +1280+0):  OBS          → 1280,0,1440,450
+                                     Paternologia → 1280,450,1440,450
+
+## Implementation Units
+
+- [x] **Unit 1: Deterministyczny uchwyt okna kiosku**
+
+**Goal:** Kiosk Paternologii dostaje stały, unikalny WM_CLASS do pewnego targetowania.
+
+**Requirements:** R1, R4
+
+**Dependencies:** brak
+
+**Files:**
+- Modify: `deploy/live/bin/paternologia-kiosk.sh`
+- Test: `deploy/live/tests/test_kiosk_class.sh` (nowy)
+
+**Approach:**
+- Dodać `--class=setka-kiosk` do wywołania `brave --kiosk …`. Zachować istniejące flagi i
+  `--user-data-dir`. Zaktualizować komentarz ABOUTME/inline o roli klasy w układaniu okien.
+
+**Patterns to follow:**
+- Istniejące wywołanie `exec brave …` w tym samym pliku.
+
+**Test scenarios:**
+- Happy path: skrypt zawiera `--class=setka-kiosk` (grep na pliku — czysto statyczne, bez
+  uruchamiania brave, bo to NO mock i nie chcemy realnego okna w teście).
+- Edge case: nadal zawiera `--kiosk` i `--user-data-dir` (regresja — nie zgubić istniejących flag).
+
+**Verification:**
+- `grep` potwierdza obecność `--class=setka-kiosk` obok dotychczasowych flag; reszta skryptu
+  nietknięta.
+
+---
+
+- [x] **Unit 2: Czyste funkcje geometrii (`live-layout.sh` rdzeń)**
+
+**Goal:** Parsowanie `xrandr --listmonitors` → uporządkowane monitory i obliczenie prostokątów
+slotów (bitwig/obs/paternologia) — testowalne wyłącznie tekstem.
+
+**Requirements:** R2, R4
+
+**Dependencies:** brak
+
+**Files:**
+- Create: `deploy/live/bin/live-layout.sh` (sekcja czystych funkcji + source-guard; bez `main` na razie)
+- Test: `deploy/live/tests/test_live_layout.sh` (nowy)
+
+**Execution note:** Test-first — najpierw failing test parsera na utrwalonym wyjściu `xrandr`.
+
+**Approach:**
+- `layout_parse_monitors "<xrandr --listmonitors>"` → wypisuje linie `x y w h` posortowane
+  rosnąco po `x`. Token `1440/530x900/300+1280+0` → w=1440, h=900, x=1280, y=0 (ignorować mm).
+- `layout_slot_bitwig`, `layout_slot_obs`, `layout_slot_paternologia` przyjmują geometrie lewego
+  i prawego monitora i zwracają `x y w h` slotu (obs = górna połowa, paternologia = dolna połowa
+  prawego; bitwig = cały lewy). Dzielenie wysokości całkowite (`h/2`); dolna połowa bierze resztę.
+- Stałe WM_CLASS jako zmienne na górze pliku (placeholdery do potwierdzenia w Unit 3/Deferred),
+  `KIOSK_CLASS=setka-kiosk` ustalone.
+- Source-guard na końcu (jak w `live-preflight.sh`).
+
+**Patterns to follow:**
+- `deploy/live/bin/live-preflight.sh` — czyste funkcje + source-guard.
+- `deploy/live/tests/test_live_preflight.sh` — karmienie funkcji utrwalonym tekstem, liczniki pass/fail.
+
+**Test scenarios:**
+- Happy path: wejście z realnego `xrandr` (2 monitory) → `layout_parse_monitors` zwraca dokładnie
+  `0 0 1280 1024` oraz `1280 0 1440 900`, w tej kolejności (lewy przed prawym).
+- Happy path: `layout_slot_obs(1280 0 1440 900)` → `1280 0 1440 450`; `layout_slot_paternologia`
+  → `1280 450 1440 450`; `layout_slot_bitwig(0 0 1280 1024)` → `0 0 1280 1024`.
+- Edge case: nieparzysta wysokość prawego monitora (np. 901) → suma połówek == pełna wysokość
+  (brak zgubionego piksela: górna 450 + dolna 451 lub odwrotnie, ale styk bez dziury/zakładki).
+- Edge case: monitory podane w odwrotnej kolejności w wejściu → sortowanie po X i tak daje
+  lewy=offset 0 jako pierwszy.
+
+**Verification:**
+- `bash deploy/live/tests/test_live_layout.sh` zielony; funkcje liczą prostokąty zgodne z R2 dla
+  realnej geometrii i dla syntetycznych przypadków brzegowych.
+
+---
+
+- [x] **Unit 3: Warstwa live + `main` (`live-layout.sh`)**
+
+**Goal:** Realne wyciąganie i układanie okien przez `wmctrl`, z bramkami środowiska, pollingiem
+pojawienia się okien i miękką obsługą braku okna.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `deploy/live/bin/live-layout.sh` (live-wrappery + `main`)
+- Test: `deploy/live/tests/test_live_layout.sh` (rozszerzenie o ścieżkę live z recorderem)
+
+**Approach:**
+- Indirekcje: `WMCTRL_BIN="${WMCTRL_BIN:-wmctrl}"`, `XRANDR_BIN="${XRANDR_BIN:-xrandr}"` (env
+  override dla testów — wzorzec `SYSTEMCTL_BIN`).
+- Bramki na starcie `main` (twardy FAIL, exit !=0, czytelny komunikat): sesja `XDG_SESSION_TYPE`
+  ≠ `x11` → odmowa; brak `DISPLAY` → odmowa; brak `wmctrl` w PATH → odmowa z podpowiedzią instalacji.
+- `layout_window_exists(cls)` przez `wmctrl -lx` (grep po klasie); `poll_window_exists(cls,grace)`
+  wzorowane na `poll_ok` z `live-preflight.sh`.
+- `layout_place(cls, x y w h)`: zdejmij maksymalizację (`-b remove,maximized_*`), ustaw geometrię
+  (`-e 0,x,y,w,h`), aktywuj (`-a`). Kolejność i ewentualna korekta ramki — patrz Deferred.
+- `main`: czyta monitory (`XRANDR_BIN --listmonitors`), liczy sloty (Unit 2), iteruje po
+  mapie `WM_CLASS→slot`; brakujące okno → log + kontynuacja, na końcu raport „ułożone/brakujące";
+  exit 0 gdy jedyny problem to brak okien (R5).
+
+**Execution note:** Test-first dla bramek i logiki braku-okna; `wmctrl` przez recorder, NIE mock
+realnego WM (zero realnych okien w teście).
+
+**Patterns to follow:**
+- `live-preflight.sh`: `poll_ok`, live-wrappery, `log/err`, source-guard.
+- `test_setka_live.sh`: recorder podstawiany pod binarkę, asercje `grep` na argumentach.
+
+**Test scenarios:**
+- Happy path (recorder): przy „istniejących" oknach (recorder `wmctrl -lx` zwraca 3 klasy)
+  `main` woła `-e` z prostokątami zgodnymi z R2 dla każdej klasy oraz `-a` (na wierzch).
+- Integration (cross-layer): `main` faktycznie spina parser geometrii (Unit 2) z wywołaniami
+  `wmctrl` — recorder loguje współrzędne wyliczone z podstawionego `XRANDR_BIN`, nie zaszyte.
+- Error path: `XDG_SESSION_TYPE=wayland` → exit !=0, komunikat o braku wsparcia, ZERO wywołań `wmctrl`.
+- Error path: `WMCTRL_BIN` wskazuje nieistniejącą binarkę / brak w PATH → exit !=0 z podpowiedzią.
+- Edge case (R5): recorder `-lx` nie zwraca klasy Bitwiga → pozostałe dwa okna ułożone, Bitwig
+  raportowany jako brakujący, exit 0.
+- Idempotencja (R4): dwa kolejne przebiegi `main` generują identyczny zestaw wywołań geometrii.
+
+**Verification:**
+- `bash deploy/live/tests/test_live_layout.sh` zielony; na żywej maszynie `live-layout.sh` układa
+  realne okna zgodnie z R2 (weryfikacja manualna po dostrojeniu WM_CLASS/ramek z Deferred).
+
+---
+
+- [x] **Unit 4: Wpięcie w `setka-live` (komenda `show` + auto po `start`)**
+
+**Goal:** `setka-live show` woła layout; `setka-live start` układa na końcu best-effort; `usage`
+zaktualizowane.
+
+**Requirements:** R1, R3, R5
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `deploy/live/bin/setka-live`
+- Test: `deploy/live/tests/test_setka_live.sh` (rozszerzenie)
+
+**Approach:**
+- `LAYOUT_BIN="${LAYOUT_BIN:-$(dirname "$0")/live-layout.sh}"` — lokalizacja siostrzanego skryptu,
+  env override dla testów (wzorzec `SYSTEMCTL_BIN`).
+- `cmd_show() { "$LAYOUT_BIN"; }`.
+- `cmd_start`: po `sctl start "$TARGET"` dołożyć best-effort `"$LAYOUT_BIN" || true` (layout nie
+  może wywrócić startu — R3/R5). Rozważyć krótki komunikat, że układanie jest best-effort.
+- `case` + `usage()`: dodać `show` z opisem; zachować pozostałe komendy bez zmian.
+
+**Patterns to follow:**
+- Istniejący `case`/`usage`/`cmd_*` w `setka-live`; indirekcja `SYSTEMCTL_BIN` → analogiczne `LAYOUT_BIN`.
+
+**Test scenarios:**
+- Happy path: `setka-live show` woła `LAYOUT_BIN` (recorder odnotowuje 1 wywołanie), exit 0.
+- Happy path/Integration: `setka-live start` woła `start live-recording.target` ORAZ następnie
+  `LAYOUT_BIN`, w tej kolejności (layout po starcie targetu).
+- Error path (R3/R5): `LAYOUT_BIN` zwraca !=0 → `setka-live start` mimo to kończy się exit 0
+  (układanie best-effort nie wywraca startu).
+- Regresja: niezmienione inwarianty `restart` (nadal `stop`+`start`, nigdy `restart <target>`,
+  stop obejmuje `live-preflight`); żadna komenda nadal nie dotyka `paternologia`.
+- Edge case: nieznana komenda → niezerowy exit + `usage` (istniejąca asercja utrzymana).
+
+**Verification:**
+- `bash deploy/live/tests/test_setka_live.sh` zielony, łącznie z nowymi asercjami `show`/`start→layout`
+  i zachowanymi inwariantami restartu/paternologii.
+
+---
+
+- [x] **Unit 5: Zależność `wmctrl` w instalatorze + dokumentacja**
+
+**Goal:** Instalacja sprawdza obecność `wmctrl` i podpowiada instalację; README i CLAUDE.md
+opisują `setka-live show`.
+
+**Requirements:** R1, R5
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `deploy/live/install.sh`
+- Modify: `deploy/live/README.md`
+- Modify: `CLAUDE.md` (sekcja workflow / tabela komend live)
+- Test: `deploy/live/tests/test_install.sh` (rozszerzenie)
+
+**Approach:**
+- `live-layout.sh` skopiuje się automatycznie (pętla `bin/*` w `install.sh` — bez zmian tam).
+- Dodać niefatalne sprawdzenie `command -v wmctrl` (wzorzec ostrzeżenia o PATH): brak → wypisz
+  „zainstaluj: sudo apt install wmctrl", ale NIE przerywaj instalacji (FAIL FAST dotyczy błędów
+  krytycznych; brak narzędzia okiennego nie blokuje instalacji unitów/skryptów audio-MIDI).
+- README: dopisać `show` do tabeli komend + krótki opis układu (R2) i pułapek (Wayland, ramki).
+- CLAUDE.md: w opisie warstwy live dopisać `setka-live show`.
+
+**Patterns to follow:**
+- `install.sh` — istniejące niefatalne ostrzeżenie o PATH (`case ":$PATH:" …`).
+- `test_install.sh` — istniejące asercje kopiowania do `BIN_DIR` z env override.
+
+**Test scenarios:**
+- Happy path: po `install.sh` `live-layout.sh` jest obecny w `BIN_DIR` z trybem 0755.
+- Edge case (idempotencja): druga instalacja bez zmian treści → „bez zmian" dla `live-layout.sh`
+  (asercja na braku zbędnego backupu — wzorzec istniejących testów).
+- Error path (niefatalność): brak `wmctrl` w PATH NIE powoduje niezerowego exitu `install.sh`
+  (symulować przez okrojony `PATH`/stub `command`); ostrzeżenie obecne w wyjściu.
+
+**Verification:**
+- `bash deploy/live/tests/test_install.sh` zielony; README i CLAUDE.md wymieniają `setka-live show`.
+
+## System-Wide Impact
+
+- **Interaction graph:** Nowy skrypt `live-layout.sh` wołany z `setka-live` (`show` i koniec
+  `start`). `start` zależy od warstwy systemd (uruchamia okna), ale layout działa na poziomie
+  EWMH/X11 — nie dotyka systemd, paternologii ani audio.
+- **Error propagation:** Layout w `start` jest best-effort (`|| true`) — jego błąd nie może
+  wywrócić startu (R3/R5). Bezpośrednie `show` zwraca niezerowo tylko dla awarii środowiska
+  (brak DISPLAY/wmctrl, nie-X11), nie dla brakującego okna.
+- **State lifecycle risks:** Brak trwałego stanu — operacja czysto okienkowa, w pełni
+  idempotentna (R4). Powtórzenie nadpisuje geometrię tymi samymi wartościami.
+- **API surface parity:** Powierzchnia CLI `setka-live` rośnie o `show`; `usage`, README i
+  CLAUDE.md muszą wymienić ją spójnie (Unit 4/5).
+- **Integration coverage:** Test integracyjny w Unit 3 (parser geometrii → realne argumenty
+  `wmctrl` przez recorder) oraz w Unit 4 (`start` → `start target` → `LAYOUT_BIN` w kolejności)
+  pokrywają styki, których same testy jednostkowe nie udowodnią.
+
+## Risks & Dependencies
+
+- **WM_CLASS OBS/Bitwiga niepewne do czasu probowania** — mitigacja: konfigurowalne stałe na górze
+  `live-layout.sh`, wartości potwierdzone `wmctrl -lx` przy żywych oknach (Deferred); R5 sprawia,
+  że błędne dopasowanie degraduje się do „okno pominięte", nie do crasha.
+- **Kompensacja ramek (`_NET_FRAME_EXTENTS`) na Mutterze** — ryzyko offsetu o kilka px; mitigacja:
+  empiryczna weryfikacja i ewentualna korekta w `layout_place` (Deferred).
+- **Zależność `wmctrl`** — nie zainstalowany; mitigacja: niefatalne sprawdzenie w instalatorze +
+  bramka w `live-layout.sh` z czytelną podpowiedzią `apt install wmctrl`.
+- **Przyszłe przejście na Wayland** — `wmctrl` przestanie działać; mitigacja: jawna bramka
+  `XDG_SESSION_TYPE=x11` odmawia czytelnie zamiast cicho zawodzić.
+
+## Documentation / Operational Notes
+
+- README warstwy live: tabela komend + opis układu R2 i pułapek (Wayland, ramki, WM_CLASS).
+- CLAUDE.md: dopisać `setka-live show` w opisie warstwy live.
+- Operacyjnie: brak wpływu na nagrywanie/audio; komenda działa tylko w aktywnej sesji graficznej
+  operatora (DISPLAY z activation env). Weryfikacja manualna po instalacji: `setka-live show`
+  układa realne okna zgodnie z R2.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-03-setka-live-window-layout-requirements.md](docs/brainstorms/2026-06-03-setka-live-window-layout-requirements.md)
+- Wzorce: `deploy/live/bin/live-preflight.sh`, `deploy/live/bin/setka-live`,
+  `deploy/live/bin/paternologia-kiosk.sh`, `deploy/live/install.sh`,
+  `deploy/live/tests/test_setka_live.sh`, `deploy/live/tests/test_live_preflight.sh`
+- Sprzęt (zweryfikowane `xrandr --listmonitors`): DVI-D-0 1280x1024 @ +0+0 (lewy),
+  HDMI-0 1440x900 @ +1280+0 (prawy); sesja `XDG_SESSION_TYPE=x11`, realny Xorg.

--- a/docs/plans/2026-06-03-001-feat-setka-live-window-layout-plan.md
+++ b/docs/plans/2026-06-03-001-feat-setka-live-window-layout-plan.md
@@ -99,17 +99,21 @@ polecenia". (see origin: docs/brainstorms/2026-06-03-setka-live-window-layout-re
 - Jak liczyć geometrię → z `xrandr --listmonitors`, sortując sloty po offsecie X.
 - Czym targetować kiosk → własny `--class=setka-kiosk`.
 
-### Deferred to Implementation
+### Deferred to Implementation — rozstrzygnięte na żywo (2026-06-03)
 
-- **Dokładne WM_CLASS dla OBS i Bitwiga-flatpak** — ustalić `wmctrl -lx` przy żywych oknach;
-  wpisać jako konfigurowalne stałe na górze `live-layout.sh`. (OBS prawdopodobnie `obs.obs`,
-  Bitwig-flatpak prawdopodobnie `com.bitwig.BitwigStudio` lub `Bitwig Studio` — zweryfikować.)
-- **Kompensacja `_NET_FRAME_EXTENTS`** — czy `wmctrl -e 0,x,y,w,h` na Mutterze trafia 1:1, czy
-  ramki okien wymagają korekty offsetu/rozmiaru. Sprawdzić empirycznie i ewentualnie odjąć ramkę.
-- **Zdjęcie maksymalizacji przed geometrią** — okno zmaksymalizowane ignoruje `-e`; prawdopodobnie
-  potrzebne `wmctrl -r <cls> -b remove,maximized_vert,maximized_horz` przed ustawieniem. Potwierdzić.
-- **Dobór wartości grace-timeoutu** dla pollingu pojawienia się okien (rząd wielkości: Bitwig-flatpak
-  startuje najwolniej) — dostroić przy realnym `start`.
+- **Dokładne WM_CLASS dla OBS i Bitwiga-flatpak** — ✅ POTWIERDZONE `wmctrl -lx` przy żywych
+  oknach: OBS = `obs.obs`, Bitwig-flatpak = `com.bitwig.BitwigStudio` (dokładnie domyślne stałe).
+  Konfigurowalne env-override na górze `live-layout.sh`.
+- **Zdjęcie maksymalizacji przed geometrią** — ✅ zaimplementowane (`-b remove,maximized_*` przed
+  `-e`); działa.
+- **Kompensacja `_NET_FRAME_EXTENTS`** — ⚠️ zbadane: Bitwig (CSD, brak ramek) trafia 1:1; OBS ma
+  `gravity: Static`, ramkę top 37 px i WYMUSZONY min-rozmiar przez zadokowane panele → ląduje w
+  prawym górnym obszarze z offsetem (~+118 px y), którego sama korekta ramki nie zlikwiduje.
+  Decyzja (potwierdzona z operatorem): zostawiamy — to ograniczenie OBS/Muttera, nie błąd; okno
+  jest wyciągnięte i widoczne. Udokumentowane w README jako znana pułapka.
+- **Dobór wartości grace-timeoutu** — domyślne 10 s, env-override; przy `show` z żywymi oknami
+  predykat-prawda zwraca natychmiast (zweryfikowane). Finalny dobór przy `start` z zimnego startu
+  pozostaje do obserwacji operacyjnej.
 
 ## High-Level Technical Design
 


### PR DESCRIPTION
## Summary
- Nowa komenda `setka-live show` wyciąga na wierzch i układa okna warstwy live na dwóch monitorach: **Bitwig** na całym lewym ekranie, **OBS** w górnej połowie prawego, **Paternologia (kiosk)** w dolnej.
- `setka-live start` wykonuje to samo układanie na końcu (best-effort — błąd nie wywraca startu).
- Realizacja przez `wmctrl` (EWMH na GNOME/Xorg); geometria liczona na żywo z `xrandr --listmonitors` (monitory identyfikowane po offsecie X, nic nie zaszyte na sztywno).
- Kiosk dostaje własny `--class=setka-kiosk` — pewny, unikalny uchwyt okna.

Plan: `docs/plans/2026-06-03-001-feat-setka-live-window-layout-plan.md` (origin brainstorm w `docs/brainstorms/`).

### Kluczowe decyzje
- **`wmctrl`, nie GNOME Shell Eval** (Eval zablokowany; EWMH na Xorg w pełni działa).
- **Czyste funkcje geometrii** (parsowanie `xrandr`, liczenie slotów) testowalne tekstem; wywołania `wmctrl`/`xrandr` za indirekcją `WMCTRL_BIN`/`XRANDR_BIN` (recorder w testach, zero mocków realnego WM).
- **R5**: brak okna → pominięte + raport, exit 0; twardy FAIL tylko dla realnej awarii środowiska (Wayland / brak DISPLAY / brak `wmctrl`).

## Testing
- Test-first, 5 zestawów plain-bash, łącznie wszystkie zielone:
  - `test_kiosk_class.sh` (3), `test_live_layout.sh` (28: geometria + warstwa live), `test_setka_live.sh` (22, w tym show/start→layout/best-effort + zachowane inwarianty restartu/paternologii), `test_install.sh` (20, w tym niefatalny check wmctrl), `test_live_preflight.sh` (13, bez regresji).
- Pokrycie: happy path, edge (nieparzysta wysokość, odwrotna kolejność monitorów), error path (Wayland, brak wmctrl), integration (współrzędne podążają za podstawionym `xrandr`), idempotencja (R4).

### Niedomknięte (świadomy zakres, wymaga żywego środowiska)
- `wmctrl` nie jest zainstalowany na maszynie i apki nie działały → realne WM_CLASS OBS/Bitwiga i ewentualna korekta ramek `_NET_FRAME_EXTENTS` **niezweryfikowane empirycznie**. WM_CLASS są konfigurowalne (env `OBS_CLASS`/`BITWIG_CLASS`); korekta ramek udokumentowana w README jako follow-up.

## Post-Deploy Monitoring & Validation
- **Walidacja manualna (po `sudo apt install wmctrl`):**
  - `setka-live show` przy żywych OBS/Bitwig/kiosku → okna w układzie R2 bez ruszania myszą.
  - `wmctrl -lx` → potwierdź realne WM_CLASS; jeśli inne niż domyślne, nadpisz `OBS_CLASS`/`BITWIG_CLASS`.
  - Powtórne `setka-live show` po rozjechaniu okien → układ wraca (idempotencja).
- **Sygnał zdrowy:** okna trafiają 1:1 w połowy/ekran; brakujące okno raportowane, exit 0.
- **Sygnał awarii / trigger korekty:** okna przesunięte o kilka px → korekta `_NET_FRAME_EXTENTS` w `layout_place`; na Wayland komenda jawnie odmawia (oczekiwane).
- **Okno walidacji / właściciel:** pierwsza sesja nagraniowa po instalacji; operator (Wojtas).
- **Wpływ operacyjny:** brak wpływu na nagrywanie/audio/systemd — czysto okienkowa nakładka EWMH; `start` układa best-effort (`|| true`).

---

🤖 Generated with Claude Opus 4.8 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering