### PR TITLE
feat: Bitwig master/stems → analiza beatrix jednym kliknięciem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,9 @@ recording_name/
 ├── recording_name.mkv       # OBS recording
 ├── metadata.json           # Scene metadata
 ├── extracted/              # Individual sources
-├── analysis/               # Audio analysis JSON
+├── mixed/                  # Bitwig master (master.wav) + optional stems/ for analysis
+├── bitwig/                 # Bitwig project home (Save As here)
+├── analysis/               # Audio analysis JSON ({stem}_analysis.json per source)
 └── blender/               # VSE projects
     └── render/            # Final outputs
 ```

--- a/docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md
+++ b/docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md
@@ -1,0 +1,99 @@
+---
+date: 2026-06-04
+topic: bitwig-master-to-beatrix
+---
+
+# Bitwig master → beatrix: handoff zmiksowanego audio do analizy
+
+## Problem Frame
+Po dostrojeniu utworu w Bitwig droga dźwięku do miejsca, w którym beatrix go analizuje
+(a analiza napędza animacje w cinemon), jest w pełni ręczna i podatna na błędy:
+folder docelowy eksportu trzeba za każdym razem wyklikać, a istniejący „Analizuj"
+(fermata → beatrix) patrzy dziś **tylko do `extracted/`**, nie do polerowanego
+`mixed/`, i przy pustym `extracted/` **cicho failuje**. Wojtas chce jak najmniej
+ręcznej roboty teraz, a jednocześnie otwartą drogę do analizy **poszczególnych
+ścieżek (stemów)** w przyszłości — pod per-strip targeting animacji w cinemon.
+
+Rurociąg jest już w dużej części gotowy: kanoniczny `mixed/` istnieje w
+`RecordingStructureManager`, a cinemon jest „master-aware" (preferuje
+`analysis/{stem}_analysis.json` pasujący do `--main-audio`). Brakuje ostatniej mili:
+konwencji zapisu i tego, by „Analizuj" widział `mixed/`.
+
+## Requirements
+- R1. `RecordingStructureManager` zyskuje kanoniczny katalog `bitwig/` (obok
+  `extracted/`, `mixed/`, `analysis/`, `blender/`) jako stały dom na projekt Bitwig
+  (Save As tutaj). Tworzony przez `create_structure`, wystawiony w
+  `RecordingStructure`. Wzorzec analogiczny do `blender/`.
+- R2. Master powstaje przez Bitwig **Export Audio (Project Master)** i ląduje w
+  `mixed/master.wav`. Stemy (opcjonalnie, przyszłość) lądują w `mixed/stems/*.wav`
+  (Export Audio potrafi eksportować pojedyncze ścieżki jednym ruchem). To konwencja
+  operatorska, nie kod — kod musi ją tylko respektować (R3).
+- R3. Akcja „Analizuj" (przycisk w fermacie + ścieżka beatrix) **iteruje po plikach
+  audio w `mixed/`** — `mixed/master.wav` oraz pliki w `mixed/stems/` — produkując
+  jedną `analysis/{stem}_analysis.json` per plik. Preferuje `mixed/` nad `extracted/`;
+  gdy `mixed/` puste, fallback do `extracted/` (zgodność wstecz). Logika iteruje po
+  zbiorze plików, więc n=1 (sam master) to dzisiejszy przypadek, a dorzucenie stemów
+  później nie wymaga zmian w kodzie.
+- R4. Akcja „Analizuj" **pokazuje błąd w UI zamiast cicho failować**, gdy nie ma nic
+  do analizy (naprawa znanego cichego faila fermaty przy pustym wejściu).
+
+## Success Criteria
+- Po Export Audio do `mixed/master.wav` jedno kliknięcie „Analizuj" w fermacie tworzy
+  `analysis/master_analysis.json`, a `cinemon-blend-setup` sam go podchwytuje
+  (selekcja master-aware już istnieje).
+- Wrzucenie stemów do `mixed/stems/` i kliknięcie „Analizuj" tworzy po jednej analizie
+  per stem — bez zmian w kodzie.
+- Gdy nie ma czego analizować, fermata pokazuje czytelny komunikat błędu (nie milczy).
+
+## Scope Boundaries
+- **Bez watchera / daemona** — świadomie odrzucone. Eksport zostaje ręcznym
+  kliknięciem w Bitwig; analiza odpalana przez istniejący przycisk/komendę.
+- **Bez skryptowania Bitwig / controller extension / automatycznego eksportu** —
+  potwierdzone jako niewykonalne: brak headless renderu, brak akcji „Export Audio"
+  w API, brak per-project ścieżki eksportu. Krok Export Audio pozostaje ręczny w GUI.
+- **Bez auto-kopiowania z podfolderów projektu Bitwig** (`master-recordings/`,
+  `bounce/`) — master przychodzi przez Export Audio do `mixed/`. Czytanie z
+  `bitwig/<proj>/master-recordings|bounce/` to ewentualne przyszłe ułatwienie.
+- **Per-strip *targeting* animacji w cinemon** (mapowanie stripów na analizy stemów)
+  to przyszła robota po stronie cinemon; ten brainstorm odblokowuje jedynie
+  *analizę* poszczególnych ścieżek.
+- Korekta dryfu audio/wideo zostaje ręczna w Blenderze.
+
+## Key Decisions
+- **Export Audio (offline) zamiast master-recording/bounce (realtime):** szybsze,
+  standardowe, już udokumentowane w `music-box-wiki`. Friction „gdzie zapisać"
+  rozwiązujemy po stronie setki, nie Bitwig (Bitwig i tak nie da się tu pomóc
+  skryptem — ścieżka eksportu „lepi się" w obrębie sesji, więc per-song wskazujesz raz).
+- **„Analizuj" iteruje po `mixed/` (master + stemy) już teraz:** kupuje przyszłą
+  analizę per-stem niemal darmo (pętla zamiast pojedynczego pliku).
+- **Formalizacja `bitwig/`:** tanie (kopia wzorca `blender/`), daje kanoniczny dom na
+  projekt i otwiera furtkę do czytania wyjść projektu w przyszłości.
+
+## Dependencies / Assumptions
+- cinemon już preferuje `analysis/{stem}_analysis.json` pasujący do `main_audio`
+  (potwierdzone w `cinemon_config_generator.py`).
+- Bitwig Export Audio pamięta ostatni folder w obrębie sesji (wskazujesz `mixed/`
+  raz na utwór).
+- Zakłada się: jedno nagranie = jeden utwór/projekt.
+- Infra plikowa (`mixed/`, `ensure_mixed_dir`) już istnieje w setka-common.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+- (brak — decyzje produktowe rozstrzygnięte)
+
+### Deferred to Planning
+- [Affects R3][Technical] Gdzie żyje iteracja: rozszerzyć CLI beatrix o przyjmowanie
+  katalogu, czy zostawić beatrix per-plik i zrobić pętlę w fermacie/helperze?
+- [Affects R3][Technical] Reguły nazewnictwa/kolizji `*_analysis.json` przy stemach
+  o podobnych nazwach; jak nazwy stemów mapują się na targety stripów w cinemon.
+- [Affects R4][Technical] Dokładna ścieżka propagacji błędu backend→frontend w
+  fermacie (naprawa cichego faila).
+- [Affects R1][Needs research] Czy któryś konsument zakłada, że istnieją tylko
+  `extracted/`/`mixed/`? Idempotencja `create_structure` dla istniejących nagrań
+  (dodanie `bitwig/` wstecz).
+- [Affects R2][Needs research] Opcjonalnie: czy `AudioValidator` ma też rozwiązywać
+  master z `bitwig/<proj>/master-recordings|bounce/` jako fallback? (odroczone ułatwienie)
+
+## Next Steps
+→ `/ce:plan` — strukturyzowane planowanie implementacji

--- a/docs/plans/2026-06-04-001-feat-bitwig-master-to-beatrix-plan.md
+++ b/docs/plans/2026-06-04-001-feat-bitwig-master-to-beatrix-plan.md
@@ -1,0 +1,470 @@
+---
+title: "feat: Bitwig master/stems → analiza beatrix jednym kliknięciem"
+type: feat
+status: active
+date: 2026-06-04
+origin: docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md
+deepened: 2026-06-04
+---
+
+# feat: Bitwig master/stems → analiza beatrix jednym kliknięciem
+
+## Overview
+
+Domykamy „ostatnią milę" pipeline'u audio: po wyeksportowaniu zmiksowanego mastera
+z Bitwig do `mixed/master.wav`, jedno kliknięcie „Analizuj" w fermacie ma uruchomić
+analizę beatrix na masterze (i ewentualnych stemach z `mixed/stems/`), produkując po
+jednej `analysis/{stem}_analysis.json` na plik. Dziś „Analizuj" patrzy tylko do
+`extracted/`, filtruje wyłącznie `.m4a`, bierze pierwszy plik i cicho failuje w UI.
+
+Zmiana ma trzy warstwy: (1) kanoniczny katalog `bitwig/` w strukturze nagrania jako
+dom na projekt Bitwig, (2) świadomy `mixed/` resolver źródeł + tryb katalogowy w
+beatrix iterujący po plikach, (3) fermata wołająca to jednym wywołaniem i pokazująca
+błąd w UI. cinemon jest już „master-aware" — strona konsumenta jest gotowa.
+
+## Problem Frame
+
+Po dostrojeniu utworu w Bitwig droga dźwięku do analizy beatrix jest ręczna i
+zawodna. Istniejący przycisk „Analizuj" (fermata → beatrix przez subprocess) jest
+zahardkodowany na `extracted/` + `.m4a` + pierwszy plik, więc polerowanego
+`mixed/master.wav` nie zobaczy, a gdy nie ma czego analizować — błąd ginie we
+frontendzie. Wojtas chce minimum roboty teraz, ale otwartą drogę do analizy
+poszczególnych ścieżek (stemów) pod przyszły per-strip targeting w cinemon.
+(see origin: docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md)
+
+## Requirements Trace
+
+- R1. `RecordingStructureManager` zyskuje kanoniczny `bitwig/` (obok
+  `extracted/`/`mixed/`/`analysis/`/`blender/`) jako dom na projekt Bitwig (Save As).
+- R2. Master powstaje przez Bitwig Export Audio → `mixed/master.wav`; stemy
+  (opcjonalnie) → `mixed/stems/*.wav`. Konwencja operatorska; kod ma ją respektować.
+- R3. „Analizuj" (beatrix + fermata) iteruje po audio w `mixed/` (master + `stems/`),
+  jedna `analysis/{stem}_analysis.json` per plik; preferuje `mixed/` nad `extracted/`
+  (fallback do `extracted/`, gdy `mixed/` **nie ma plików audio LUB nie istnieje**).
+  Logika iteruje, więc n=1 (master) działa dziś, a stemy później bez zmian w kodzie.
+- R4. „Analizuj" pokazuje błąd w UI zamiast cicho failować, gdy nie ma czego
+  analizować.
+- R5. Render w fermacie (SetupRender) celuje `--main-audio` w `mixed/master.wav`
+  (fallback `extracted/`), żeby cinemon faktycznie wybrał `master_analysis.json` bez
+  ręcznego podawania ścieżki. *(Rozszerzenie zakresu wynikłe z review — domyka
+  pipeline end-to-end; bez tego analiza mastera mogłaby zostać pominięta przy renderze.)*
+
+## Scope Boundaries
+
+- Bez watchera / daemona — świadomie odrzucone.
+- Bez skryptowania Bitwig / controller extension / automatycznego eksportu
+  (potwierdzone niewykonalne). Export Audio zostaje ręcznym krokiem w GUI.
+- Bez auto-kopiowania z podfolderów projektu Bitwig (`master-recordings/`, `bounce/`).
+- Bez zmian w **kodzie cinemon** — selekcja master-aware (`{stem}_analysis.json`) już
+  istnieje; **nie ruszamy** `MediaDiscovery` ani `_resolve_relative_paths`. Spięcie
+  realizujemy po stronie fermaty (SetupRender podaje `--main-audio` na master, R5/Unit 5).
+- Bez utwardzania fallbacku cinemon `analysis_files[0]` — świadomie poza zakresem; przy
+  wielu stemach domyślny wybór bez `--main-audio` pozostaje zależny od kolejności sortu
+  (patrz Risks). Spięcie przez R5 (jawny `--main-audio` na master) to omija.
+- Per-strip *targeting* animacji w cinemon to przyszła robota; tu odblokowujemy tylko
+  *analizę* poszczególnych ścieżek.
+- Korekta dryfu audio/wideo zostaje ręczna w Blenderze.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **setka-common** `packages/common/src/setka_common/file_structure/specialized/recording.py`
+  - Blok stałych (l. 58–62): `EXTRACTED_DIRNAME`, `BLENDER_DIRNAME`, `ANALYSIS_DIRNAME`,
+    `MIXED_DIRNAME` — tu dochodzi `BITWIG_DIRNAME = "bitwig"`.
+  - `@dataclass RecordingStructure(MediaStructure)` (l. 22–52), pola `extracted_dir`,
+    `mixed_dir` — dochodzi `bitwig_dir: Path`. `exists()` (l. 29) celowo ignoruje
+    katalogi opcjonalne — **nie dodawać tam bitwig**.
+  - `get_structure()` (l. 64–99) buduje ścieżki (nie tworzy); `create_structure()`
+    (l. 101–127) robi `mkdir(parents=True, exist_ok=True)` dla `extracted`/`mixed`.
+  - `ensure_mixed_dir()` (l. 272–314) — dokładny szablon do sklonowania na
+    `ensure_bitwig_dir()` (guard `InvalidPathError`, `mkdir(exist_ok=True)`, wrap
+    `DirectoryCreationError`). Siostry: `ensure_analysis_dir` (233–270),
+    `ensure_blender_dir` (187–230).
+  - Helpery analizy już są: `get_analysis_file_path` (316–341, `{stem}_analysis.json`),
+    `find_audio_analysis` (343–361). Prymityw skanu audio:
+    `setka_common.utils.files.find_files_by_type(dir, MediaType.AUDIO)` (zwraca
+    posortowaną, case-insensitive listę).
+- **beatrix** `packages/beatrix/src/beatrix/core/audio_validator.py`
+  - `AudioValidator.detect_main_audio(extracted_dir, specified_audio=None)` (l. 31–64);
+    `find_audio_files(extracted_dir)` (l. 66–82) — wrapper na
+    `find_files_by_type`; wyjątki `NoAudioFileError`/`MultipleAudioFilesError`
+    (`beatrix/exceptions.py`). Parametr nazywa się `extracted_dir`, ale to dowolny
+    katalog — można go wskazać na `mixed/` bez zmian sygnatury.
+  - CLI `packages/beatrix/src/beatrix/cli/click_cli.py` — `analyze(audio_file,
+    output_dir, beat_division, min_onset_interval)` (l. 46–108), **per plik**,
+    nazewnictwo `{audio_file.stem}_analysis.json` (l. 78–80), błędy przez
+    `click.ClickException`. Entry-point: `beatrix = "beatrix.cli.analyze_audio:main"`
+    w `pyproject.toml`, gdzie `analyze_audio.main()` deleguje do `click_cli.main()`
+    (grupa `click`). Dodanie subkomendy do tej grupy **nie wymaga** zmiany `pyproject.toml`.
+- **fermata** (subprocess seam, nie bridge):
+  - `packages/fermata/src-tauri/src/services/process_runner.rs` →
+    `run_beatrix_analyze(recording_path, audio_file)` (l. 27–40): hardkoduje
+    `extracted/`, woła `uv run --package beatrix beatrix analyze <audio_path>
+    <recording_path/analysis>`. Wzorce sióstr: `run_cinemon_render` itp. (43–89),
+    `execute_command` → `ProcessResult{success,stdout,stderr,exit_code}` (126–150).
+  - `packages/fermata/src-tauri/src/commands/operations.rs` → `NextStep::Analyze`
+    (l. 138–181): hardkoduje `extracted/` (140), filtruje `.m4a` (154), bierze
+    `audio_files[0]` (178), ale **zwraca** `Err(...)` przy braku plików (164–176).
+    Komendy zwracają `Result<String, String>` (konwencja całego repo).
+  - Rejestracja komend: `packages/fermata/src-tauri/src/lib.rs` (`generate_handler!`,
+    l. 17–32) — nowe komendy trzeba dopisać.
+  - Status po analizie: `services/status_detector.rs::has_analysis_files` (l. 89+) —
+    dowolny `.json` w `analysis/` → `RecordingStatus::Analyzed`; wiele JSON-ów per-plik
+    zadziała bez zmian.
+  - **Cichy fail jest we froncie:** `packages/fermata/src/components/RecordingList.tsx`
+    (l. 207–223) po `runSpecificStep` robi tylko `refreshRecordings()` na `setTimeout`
+    i nie czyta `operationState.error`. Hook
+    `packages/fermata/src/hooks/useRecordings.ts`: `runSpecificStep` (173–203) łapie
+    błąd do `operationState.error`, ale `refreshRecordings` (74–94) w `catch` podstawia
+    **mock data** i zeruje `error` — dodatkowe maskowanie. Wzorzec do naśladowania:
+    `runSetupRenderWithPreset` (205–237) zapisuje `output: \`Error: ${msg}\``.
+
+### Institutional Learnings
+
+- `docs/solutions/` nie ma wpisów dot. file-structure/beatrix/fermata (tylko audio
+  hardware). Najbliższy precedens: **`docs/plans/2026-06-02-001-feat-bitwig-mixed-audio-pipeline-plan.md`**
+  (completed) — dodanie `mixed/` przeszło dokładnie wg wzorca 4 punktów + matrycy 5
+  testów; `mkdir(parents=True, exist_ok=True)` → idempotentne, „purely additive".
+- Master-aware selekcja w cinemon już zaimplementowana
+  (`cinemon/config/cinemon_config_generator.py:186-201`) — po zapisaniu
+  `analysis/master_analysis.json` cinemon ją podchwyci bez zmian.
+- Gotcha higieny: nieaktualne `*_analysis.json` kumulują się w `analysis/` —
+  master-aware łagodzi zły wybór, ale warto rozważyć czyszczenie stale (odłożone).
+- **Test gotcha (MEMORY):** uruchamiać pytest **po ścieżce**, nie pełne
+  `uv run pytest` (zepsute); `uv sync --all-packages`.
+
+### External References
+
+- Brak nowego — research Bitwig (brak headless renderu, brak akcji Export w API, brak
+  per-project ścieżki eksportu) zrobiony w origin brainstorm.
+
+## Key Technical Decisions
+
+- **Logika „preferuj mixed/ + iteruj" po stronie Pythona, nie Rust.** Resolver źródeł
+  w setka-common (`RecordingStructureManager`), tryb katalogowy w beatrix CLI; fermata
+  woła jednym wywołaniem. Rationale: DRY (wiedza o strukturze już jest w
+  setka-common), testowalność (pytest/CliRunner zamiast testów Rust subprocessu),
+  prostszy Rust, bezpośrednio realizuje R3. Alternatywa „pętla w Rust" odrzucona —
+  dublowałaby zbiór rozszerzeń audio i preferencję katalogów w drugim języku.
+  Krawędź **beatrix → setka_common już istnieje** (`audio_validator.py` importuje
+  `setka_common.utils.files`; setka-common to twarda zależność beatrix), więc resolver
+  w setka-common nie tworzy nowej zależności międzypakietowej.
+- **Nowa subkomenda `analyze-recording <katalog>`; istniejące `analyze <plik> <out>`
+  pozostaje nietknięte.** Świadomie odrzucamy overload `analyze` rozpoznający
+  plik-vs-katalog (dwuznaczna semantyka, footgun przy katalogu z jednym plikiem). Daje
+  fermacie jednoznaczne wywołanie i utrzymuje zgodność wstecz dokumentowanego
+  `beatrix analyze` (CLAUDE.md/wiki). Dodanie subkomendy do istniejącej grupy `click`
+  **nie wymaga** zmiany `pyproject.toml`.
+- **`bitwig/` tworzony zachłannie w `create_structure` (jak `mixed/`)** + lazy
+  `ensure_bitwig_dir` dla istniejących nagrań. Rationale: spójność z `mixed/`, kanoniczny
+  dom na Save As gotowy od razu. Świadomie akceptujemy, że **żaden kod nie czyta**
+  `bitwig/` — to celowy „reserved location"/afordancja dla operatora, nie wejście dla
+  automatyki; brak katalogu w starych nagraniach jest nieszkodliwy (analiza czyta
+  `mixed/`/`extracted/`).
+- **Fallback `extracted/` zachowany** — stare nagrania bez `mixed/` analizują się jak
+  dotąd (zgodność wstecz, R3).
+- **Cichy fail naprawiamy dwustronnie**, ale ciężar na froncie: Rust już zwraca `Err`;
+  front musi go renderować i przestać maskować mockiem.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Gdzie żyje pętla (CLI-dir vs loop-w-fermacie)?** → Python: resolver w setka-common
+  + tryb katalogowy w beatrix CLI; fermata woła raz. (uzasadnienie wyżej)
+- **Czy `bitwig/` tworzyć zachłannie?** → Tak, jak `mixed/`; + lazy `ensure_bitwig_dir`.
+- **Czy stare nagrania wymagają migracji `bitwig/`?** → Nie; nic nie czyta `bitwig/`,
+  brak katalogu jest nieszkodliwy. Resolver analizy gating-uje na `.exists()` `mixed/`.
+- **Czy ruszać kod cinemon?** → Nie; master-aware selekcja już działa. Spięcie
+  end-to-end robimy w fermacie (R5/Unit 5: SetupRender `--main-audio` → master).
+- **Kształt trybu katalogowego beatrix?** → Nowa subkomenda `analyze-recording
+  <katalog>` (nie overload `analyze`). Brak zmian w `pyproject.toml`.
+- **Polityka kolizji `{stem}_analysis.json`?** → **Fail-fast**: gdy dwa źródła
+  (np. `mixed/master.wav` i `mixed/stems/master.wav`) dałyby ten sam plik wyjściowy,
+  przerwij z czytelnym błędem wskazującym kolidujące pliki — **bez cichego nadpisania**
+  (zgodnie z FAIL FAST). Zalecana konwencja: unikalne nazwy stemów.
+
+### Deferred to Implementation
+
+- **Mapowanie nazw stemów → targety stripów w cinemon** — osobna przyszła robota
+  (per-strip targeting), poza tym planem.
+- **Czyszczenie stale `*_analysis.json`** przed zapisem nowych — czy kasować osierocone
+  analizy nieodpowiadające źródłom z `mixed/`. Drobne; ocenić przy implementacji.
+- **Czy resolver ma też zaglądać do `bitwig/<proj>/master-recordings|bounce/`** jako
+  fallback — odłożone ułatwienie, poza MVP.
+
+## Implementation Units
+
+- [ ] **Unit 1: `bitwig/` w RecordingStructureManager**
+
+**Goal:** Kanoniczny katalog `bitwig/` jako dom na projekt Bitwig — mirror wzorca `mixed/`.
+
+**Requirements:** R1
+
+**Dependencies:** Brak.
+
+**Files:**
+- Modify: `packages/common/src/setka_common/file_structure/specialized/recording.py`
+- Test: `packages/common/tests/test_recording_structure.py`
+
+**Approach:**
+- Dodaj `BITWIG_DIRNAME = "bitwig"` do bloku stałych (l. 58–62).
+- Dodaj pole `bitwig_dir: Path` do `RecordingStructure` (wzór: `mixed_dir`, l. 27).
+  Nie dotykać `exists()`.
+- W `get_structure()` zbuduj `bitwig_dir = project_dir / ...BITWIG_DIRNAME` i przekaż do
+  konstruktora; w `create_structure()` dodaj `structure.bitwig_dir.mkdir(parents=True,
+  exist_ok=True)` obok `mixed`.
+- Sklonuj `ensure_mixed_dir` → `ensure_bitwig_dir` (ten sam guard + wrap wyjątków).
+
+**Patterns to follow:** `MIXED_DIRNAME`/`mixed_dir`/`ensure_mixed_dir` w tym samym pliku;
+matryca testów z planu 2026-06-02-001 (Unit 1).
+
+**Test scenarios:**
+- Happy path: `get_structure()` zwraca `bitwig_dir` jako ścieżkę, **nie tworząc** katalogu.
+- Happy path: `create_structure()` materializuje `bitwig/` obok `extracted`/`mixed`.
+- Happy path: `ensure_bitwig_dir(recording_dir)` tworzy `bitwig/` i zwraca Path.
+- Edge case: `ensure_bitwig_dir` na istniejącym katalogu — idempotentne (drugie wywołanie OK).
+- Error path: pusty/nieistniejący/`not is_dir` `recording_dir` → `InvalidPathError`.
+- Happy path: `BITWIG_DIRNAME == "bitwig"` (test wartości stałej).
+
+**Verification:** Testy `test_recording_structure.py` przechodzą (uruchom po ścieżce);
+`create_structure` na świeżym `tmp_path` daje katalog `bitwig/`.
+
+---
+
+- [ ] **Unit 2: Resolver źródeł `mixed/`→`extracted/` w setka-common**
+
+**Goal:** Jedno źródło prawdy o tym, które pliki audio analizować dla danego nagrania:
+preferuj `mixed/` (master + `mixed/stems/`), fallback `extracted/`.
+
+**Requirements:** R3
+
+**Dependencies:** Brak (może powstać równolegle z Unit 1).
+
+**Files:**
+- Modify: `packages/common/src/setka_common/file_structure/specialized/recording.py`
+- Test: `packages/common/tests/test_recording_structure.py`
+
+**Approach:**
+- Dodaj static helper, np. `find_analysis_audio_sources(recording_dir) -> list[Path]`:
+  zbierz audio z `mixed/` **i osobno** z `mixed/stems/`. **Uwaga:** `find_files_by_type`
+  jest **nierekurencyjne** (`iterdir`), więc trzeba **dwóch wywołań** (`mixed/` oraz
+  `mixed/stems/`) i scalić wyniki — jedno wywołanie pominęłoby stemy.
+- Fallback: jeśli `mixed/` **nie ma plików audio LUB nie istnieje** → skanuj `extracted/`.
+  Gating na `.exists()` dla `mixed/`/`stems/`. Zwróć posortowaną, deterministyczną listę.
+- **Polityka kolizji:** jeśli dwa źródła dałyby ten sam `{stem}_analysis.json`
+  (np. `mixed/master.wav` + `mixed/stems/master.wav`), przerwij fail-fast z błędem
+  wskazującym kolidujące pliki — bez cichego nadpisania.
+- Stałe `MIXED_DIRNAME`/`EXTRACTED_DIRNAME` brane z managera, nie hardkodowane.
+- **Nie** kierować `mixed/` przez `AudioValidator.detect_main_audio` — przy >1 pliku
+  rzuca `MultipleAudioFilesError`; resolver to osobna ścieżka.
+
+**Patterns to follow:** istniejące `find_audio_analysis`/`get_analysis_file_path`;
+prymityw `find_files_by_type` z `setka_common.utils.files`.
+
+**Test scenarios:**
+- Happy path: tylko `mixed/master.wav` → zwraca `[master.wav]`.
+- Happy path: `mixed/master.wav` + `mixed/stems/{a,b}.wav` → zwraca wszystkie trzy.
+- Edge case: `mixed/` istnieje, ale **bez plików audio** (np. tylko `stems/` puste),
+  `extracted/` ma pliki → fallback do `extracted/`.
+- Edge case: `mixed/` nieobecne, `extracted/` ma pliki → fallback do `extracted/`.
+- Edge case: oba puste/nieobecne → zwraca `[]` (bez wyjątku; decyzja „brak audio" wyżej).
+- Edge case: mieszane rozszerzenia (`.wav`/`.flac`/`.m4a`) — wszystkie audio złapane,
+  nie-audio pominięte; stemy z `mixed/stems/` dołączone (test nierekurencyjności).
+- Error path: kolizja nazwy (`mixed/master.wav` + `mixed/stems/master.wav`) → fail-fast
+  z błędem wskazującym oba pliki, bez nadpisania.
+- Edge case: kolejność wyników deterministyczna (sort, case-insensitive).
+
+**Verification:** Testy resolvera przechodzą; resolver zwraca master gdy obecny, a
+stemy dokłada bez zmian w innym kodzie.
+
+---
+
+- [ ] **Unit 3: Tryb katalogowy/recording w beatrix CLI (iteracja per plik)**
+
+**Goal:** beatrix analizuje wszystkie źródła nagrania jednym wywołaniem, pisząc
+`analysis/{stem}_analysis.json` per plik; istniejący per-plikowy `analyze` bez zmian.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 2 (resolver źródeł).
+
+**Files:**
+- Modify: `packages/beatrix/src/beatrix/cli/click_cli.py`
+- Test: `packages/beatrix/tests/test_cli_click.py`
+- (Bez zmian w `pyproject.toml` — subkomenda dochodzi do istniejącej grupy `click`.)
+
+**Approach:**
+- Dodaj **nową subkomendę `analyze-recording <recording_dir> [--beat-division ...]
+  [--min-onset-interval ...]`** do grupy `cli` (nie overload `analyze`). Użyj
+  `find_analysis_audio_sources(recording_dir)` z Unit 2, iteruj, dla każdego pliku
+  zapisz `{stem}_analysis.json` do `analysis/` (reużyj nazewnictwa, l. 78–80). Gdy lista
+  pusta → `ClickException` z czytelnym komunikatem (zasila R4 przez stderr subprocessu).
+  Kolizja nazw → fail-fast (polityka z Unit 2/Open Questions).
+- Przekaż `beat_division`/`min_onset_interval` do każdej analizy.
+- Zachowaj single-file `analyze(<plik> <out>)` **bez zmian sygnatury**.
+
+**Patterns to follow:** obecny `analyze()` (nazewnictwo outputu, obsługa błędów przez
+`ClickException`); testy `TestClickCLI` z `CliRunner`.
+
+**Test scenarios:** (przez `CliRunner` na `analyze-recording`)
+- Happy path: katalog z `mixed/master.wav` → powstaje `analysis/master_analysis.json`.
+- Happy path: `mixed/` z masterem + 2 stemami → 3 pliki `*_analysis.json`, po jednym na źródło.
+- Edge case: `mixed/` puste, `extracted/` ma 1 plik → analiza z `extracted/` (fallback).
+- Error path: brak audio w `mixed/` i `extracted/` → niezerowy exit + komunikat na stderr.
+- Error path: kolizja nazw stemów → niezerowy exit + komunikat o kolizji, żaden plik nie nadpisany.
+- Edge case: parametry `--beat-division`/`--min-onset-interval` propagują do każdej analizy.
+- Regression: dotychczasowy `analyze <plik> <out>` działa jak wcześniej (sygnatura nietknięta).
+
+**Execution note:** Zacznij od failującego testu CLI na trybie katalogowym (kontrakt
+„N plików → N analiz").
+
+**Verification:** `test_cli_click.py` zielone (po ścieżce); jedno wywołanie na katalogu
+generuje komplet analiz; single-file ścieżka bez regresji.
+
+---
+
+- [ ] **Unit 4: fermata — jedno wywołanie beatrix na nagraniu + błąd w UI**
+
+**Goal:** „Analizuj" woła beatrix raz na całym nagraniu (drop hardkodu `extracted/`/`.m4a`/
+`[0]`), a błąd jest widoczny w UI zamiast cicho ginąć.
+
+**Requirements:** R3, R4
+
+**Dependencies:** Unit 3 (tryb katalogowy beatrix).
+
+**Files:**
+- Modify: `packages/fermata/src-tauri/src/services/process_runner.rs`
+- Modify: `packages/fermata/src-tauri/src/commands/operations.rs`
+- Modify: `packages/fermata/src/components/RecordingList.tsx`
+- Test: inline `#[cfg(test)]` w `operations.rs`/`process_runner.rs`;
+  `packages/fermata/src/components/RecordingList.test.tsx`
+
+**Approach (Rust):**
+- `run_beatrix_analyze`: zmień na wywołanie `beatrix analyze-recording <recording_path>`
+  (bez parametru `audio_file`, bez budowania `extracted/<plik>`). Propaguj
+  `ProcessResult.stderr` jako `Err` przy `!success` (wzór `run_next_step`).
+- `NextStep::Analyze` w `operations.rs`: usuń listowanie `extracted/`/filtr `.m4a`/`[0]`;
+  wywołaj raz `run_beatrix_analyze(recording.path)`; brak audio/kolizję sygnalizuje
+  beatrix (stderr → `Err(String)`). Zachowaj konwencję `Result<String, String>`.
+
+**Approach (frontend) — zawężony (finding #2):**
+- **Cichy fail żyje w `RecordingList.tsx`, nie w hooku.** `runSpecificStep` już zapisuje
+  realny błąd do `operationState.error`; wystarczy go **przeczytać i wyrenderować** po
+  operacji (wzór `runSetupRenderWithPreset` → `Error: ${msg}`).
+- **NIE ruszamy `refreshRecordings`/mock-fallbacku** w `useRecordings.ts` — to celowy
+  tryb dev (brak Tauri), osobna ścieżka niezwiązana z błędem analyze. Modyfikacja byłaby
+  scope creepem ryzykującym regresję offline-dev.
+
+**Patterns to follow:** `Result<String,String>` + `map_err(format!)` (recordings.rs);
+test `test_missing_dependencies` (operations.rs 386–495) jako wzór asercji `Err`;
+`uv_path: "echo"` do stubowania subprocessu; Vitest + `@testing-library` w istniejących
+`*.test.tsx`.
+
+**Test scenarios:**
+- Happy path (Rust): nagranie z `mixed/master.wav`, stub `uv`=`echo` → komenda zwraca
+  `Ok`, woła `beatrix analyze-recording <recording_path>` (nie `extracted/<plik>`).
+- Error path (Rust): brak audio (beatrix zwraca niezerowy exit/stderr) → komenda zwraca
+  `Err` z komunikatem ze stderr.
+- Integration (Rust): wywołanie nie zawiera już filtra `.m4a` ani `audio_files[0]` —
+  cała robota selekcji jest po stronie beatrix.
+- Happy path (front): udana analiza → brak błędu, lista odświeżona.
+- Error path (front): `runSpecificStep` ustawia `operationState.error` → komunikat
+  błędu **widoczny** w `RecordingList` (test renderu błędu).
+
+**Verification:** `cargo test` w `src-tauri` zielone; Vitest zielony; ręcznie: klik
+„Analizuj" na nagraniu z `mixed/master.wav` tworzy `analysis/master_analysis.json`, a
+na nagraniu bez audio pokazuje czytelny błąd.
+
+---
+
+- [ ] **Unit 5: SetupRender celuje `--main-audio` w master (spięcie do cinemon)**
+
+**Goal:** Render w fermacie podaje cinemon master z `mixed/`, żeby został wybrany
+`master_analysis.json` bez ręcznego `--main-audio`. Domyka pipeline end-to-end.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1–4 logicznie po (master już analizowany), ale zmiana w
+SetupRender jest niezależna technicznie.
+
+**Files:**
+- Modify: `packages/fermata/src-tauri/src/commands/operations.rs` (gałąź
+  `NextStep::SetupRender`)
+- Modify (jeśli rozdzielanie ścieżki): `packages/fermata/src-tauri/src/services/process_runner.rs`
+  (`run_cinemon_generate_config`/`run_cinemon_render`)
+- Test: inline `#[cfg(test)]` w `operations.rs`
+
+**Approach:**
+- W `NextStep::SetupRender` rozwiąż `main_audio`: jeśli istnieje `mixed/master.wav` →
+  podaj go jako `--main-audio` (ścieżka **absolutna**, bo cinemon master-aware oczekuje
+  absolutnej); w przeciwnym razie zachowaj dotychczasowe zachowanie (`extracted/` /
+  `AppConfig.main_audio_file`). To jedyna potrzebna zmiana — kod cinemon zostaje.
+- Świadomie **nie** utwardzamy fallbacku `analysis_files[0]` w cinemon (poza zakresem);
+  jawny `--main-audio` na master omija problem kolejności sortu przy stemach.
+
+**Patterns to follow:** istniejąca gałąź `NextStep::Analyze`/`SetupRender` w
+`operations.rs`; `run_cinemon_*` w `process_runner.rs`; `AppConfig.main_audio_file`
+(recordings.rs) jako dotychczasowe źródło domyślne.
+
+**Test scenarios:**
+- Happy path: istnieje `mixed/master.wav` → SetupRender przekazuje `--main-audio` ze
+  ścieżką absolutną do `mixed/master.wav`.
+- Edge case: brak `mixed/master.wav` → zachowane dotychczasowe rozwiązanie audio
+  (`extracted/`/config) — brak regresji.
+- Integration: przy obecnym `analysis/master_analysis.json` przekazany master prowadzi
+  cinemon do wyboru `master_analysis.json` (weryfikacja przez argument `--main-audio`,
+  bez uruchamiania Blendera).
+
+**Verification:** `cargo test` zielone; ręcznie: po „Analizuj" + render na nagraniu z
+`mixed/master.wav` cinemon użył `master_analysis.json` (nie pierwszego z brzegu).
+
+## System-Wide Impact
+
+- **Interaction graph:** `RecordingStructureManager` używany przez wszystkie pakiety —
+  zmiana czysto addytywna (nowy katalog/helper), istniejące pola/metody nietknięte.
+  fermata `NextStep::Analyze` → `process_runner` → `beatrix analyze-recording` →
+  `analysis/*.json` → `status_detector.has_analysis_files` → `RecordingStatus::Analyzed`
+  (działa z wieloma JSON-ami). Następnie `NextStep::SetupRender` → `--main-audio` na
+  `mixed/master.wav` (Unit 5) → cinemon wybiera `master_analysis.json` (już master-aware).
+- **Error propagation:** beatrix (ClickException/exit≠0) → `ProcessResult.stderr` →
+  `Err(String)` w komendzie Tauri → `operationState.error` (hook już to ustawia) →
+  **render w `RecordingList`** (jedyne brakujące ogniwo, które naprawiamy; hook/mock
+  nietknięte).
+- **State lifecycle risks:** nieaktualne `*_analysis.json` w `analysis/` (stale) — łagodzi
+  master-aware selekcja cinemon + jawny `--main-audio` (Unit 5); czyszczenie odłożone.
+  Domyślny fallback cinemon `analysis_files[0]` przy wielu stemach bez `--main-audio`
+  pozostaje zależny od sortu — świadomie poza zakresem, omijany przez Unit 5.
+- **API surface parity:** single-file `beatrix analyze <plik> <out>` zachowany; nowa
+  subkomenda `analyze-recording <katalog>` dodatkowa. Brak zmian w kodzie cinemon/medusy.
+- **Integration coverage:** testy Rust ze stubem `uv=echo` weryfikują wywołanie i
+  propagację błędu; testy Python (CliRunner + tmp_path) weryfikują „N plików → N analiz".
+
+## Risks & Dependencies
+
+- **Stare nagrania bez `mixed/`** — fallback `extracted/` utrzymuje zgodność wstecz.
+- **`bitwig/` nieobecny w starych nagraniach** — nieszkodliwe; nic go nie czyta.
+- **Sekwencja:** Unit 4 zależy od Unit 3 (`analyze-recording`), Unit 3 od Unit 2
+  (resolver). Unit 1 i Unit 5 niezależne technicznie (Unit 5 logicznie po analizie).
+- **Stemy „za darmo" są warunkowe:** kolizja nazw rozwiązana fail-fast (bez utraty
+  danych), ale domyślny wybór cinemon przy wielu stemach bez `--main-audio` zależy od
+  sortu — pełne per-stem targeting to przyszła robota poza tym planem.
+- **Test gotcha:** pytest po ścieżce (`uv run --package <pkg> pytest <path>`), nie pełne
+  `uv run pytest`; `uv sync --all-packages`.
+
+## Documentation / Operational Notes
+
+- Po wdrożeniu zaktualizować CLAUDE.md (sekcja file-structure: dodać `bitwig/`) i
+  `~/dev/music-box-wiki` (workflow „Post-prod teledysk": Export Audio → `mixed/`, klik
+  „Analizuj" analizuje master + stemy).
+- Kandydat na wpis `docs/solutions/`: gotcha „fermata Analizuj — extracted-only + `.m4a`
+  + cichy fail we froncie".
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md](docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md)
+- Precedens: `docs/plans/2026-06-02-001-feat-bitwig-mixed-audio-pipeline-plan.md` (completed)
+- Kod: `recording.py` (`ensure_mixed_dir`), `audio_validator.py`, `click_cli.py`,
+  `operations.rs::NextStep::Analyze`, `process_runner.rs::run_beatrix_analyze`,
+  `useRecordings.ts`, `RecordingList.tsx`, `cinemon_config_generator.py:186-201`

--- a/docs/plans/2026-06-04-001-feat-bitwig-master-to-beatrix-plan.md
+++ b/docs/plans/2026-06-04-001-feat-bitwig-master-to-beatrix-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Bitwig master/stems → analiza beatrix jednym kliknięciem"
 type: feat
-status: active
+status: completed
 date: 2026-06-04
 origin: docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md
 deepened: 2026-06-04
@@ -196,7 +196,7 @@ poszczególnych ścieżek (stemów) pod przyszły per-strip targeting w cinemon.
 
 ## Implementation Units
 
-- [ ] **Unit 1: `bitwig/` w RecordingStructureManager**
+- [x] **Unit 1: `bitwig/` w RecordingStructureManager**
 
 **Goal:** Kanoniczny katalog `bitwig/` jako dom na projekt Bitwig — mirror wzorca `mixed/`.
 
@@ -233,7 +233,7 @@ matryca testów z planu 2026-06-02-001 (Unit 1).
 
 ---
 
-- [ ] **Unit 2: Resolver źródeł `mixed/`→`extracted/` w setka-common**
+- [x] **Unit 2: Resolver źródeł `mixed/`→`extracted/` w setka-common**
 
 **Goal:** Jedno źródło prawdy o tym, które pliki audio analizować dla danego nagrania:
 preferuj `mixed/` (master + `mixed/stems/`), fallback `extracted/`.
@@ -281,7 +281,7 @@ stemy dokłada bez zmian w innym kodzie.
 
 ---
 
-- [ ] **Unit 3: Tryb katalogowy/recording w beatrix CLI (iteracja per plik)**
+- [x] **Unit 3: Tryb katalogowy/recording w beatrix CLI (iteracja per plik)**
 
 **Goal:** beatrix analizuje wszystkie źródła nagrania jednym wywołaniem, pisząc
 `analysis/{stem}_analysis.json` per plik; istniejący per-plikowy `analyze` bez zmian.
@@ -325,7 +325,7 @@ generuje komplet analiz; single-file ścieżka bez regresji.
 
 ---
 
-- [ ] **Unit 4: fermata — jedno wywołanie beatrix na nagraniu + błąd w UI**
+- [x] **Unit 4: fermata — jedno wywołanie beatrix na nagraniu + błąd w UI**
 
 **Goal:** „Analizuj" woła beatrix raz na całym nagraniu (drop hardkodu `extracted/`/`.m4a`/
 `[0]`), a błąd jest widoczny w UI zamiast cicho ginąć.
@@ -379,7 +379,7 @@ na nagraniu bez audio pokazuje czytelny błąd.
 
 ---
 
-- [ ] **Unit 5: SetupRender celuje `--main-audio` w master (spięcie do cinemon)**
+- [x] **Unit 5: SetupRender celuje `--main-audio` w master (spięcie do cinemon)**
 
 **Goal:** Render w fermacie podaje cinemon master z `mixed/`, żeby został wybrany
 `master_analysis.json` bez ręcznego `--main-audio`. Domyka pipeline end-to-end.

--- a/packages/beatrix/src/beatrix/cli/click_cli.py
+++ b/packages/beatrix/src/beatrix/cli/click_cli.py
@@ -15,6 +15,7 @@ import click
 
 from ..core.audio_analyzer import AudioAnalyzer
 from .. import __version__
+from setka_common.file_structure.specialized.recording import RecordingStructureManager
 
 
 @click.group(
@@ -41,6 +42,41 @@ def cli(ctx, verbose):
     # Show help if no command provided
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
+
+
+def _analyze_single_file(
+    audio_file: Path,
+    output_dir: Path,
+    beat_division: int,
+    min_onset_interval: float,
+) -> Path:
+    """Analyze a single audio file and save results to output_dir.
+
+    Returns the path to the written analysis file.
+    Raises click.ClickException on any failure.
+    """
+    logger = logging.getLogger(__name__)
+
+    output_filename = f"{audio_file.stem}_analysis.json"
+    output_path = output_dir / output_filename
+
+    logger.info(f"Analyzing audio file: {audio_file}")
+    logger.info(f"Output will be saved to: {output_path}")
+    logger.debug(
+        f"Parameters: beat_division={beat_division}, min_onset_interval={min_onset_interval}"
+    )
+
+    analyzer = AudioAnalyzer()
+    analysis_result = analyzer.analyze_for_animation(
+        audio_file,
+        beat_division=beat_division,
+        min_onset_interval=min_onset_interval,
+    )
+    analyzer.save_analysis(analysis_result, output_path)
+
+    click.echo(f"Analysis complete: {output_path}")
+    logger.info(f"Analysis completed successfully: {output_path}")
+    return output_path
 
 
 @cli.command()
@@ -74,30 +110,7 @@ def analyze(audio_file, output_dir, beat_division, min_onset_interval):
         # Ensure output directory exists
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate output filename
-        base_name = audio_file.stem
-        output_filename = f"{base_name}_analysis.json"
-        output_path = output_dir / output_filename
-
-        logger.info(f"Analyzing audio file: {audio_file}")
-        logger.info(f"Output will be saved to: {output_path}")
-        logger.debug(
-            f"Parameters: beat_division={beat_division}, min_onset_interval={min_onset_interval}"
-        )
-
-        # Create analyzer and analyze
-        analyzer = AudioAnalyzer()
-        analysis_result = analyzer.analyze_for_animation(
-            audio_file,
-            beat_division=beat_division,
-            min_onset_interval=min_onset_interval,
-        )
-
-        # Save results
-        analyzer.save_analysis(analysis_result, output_path)
-
-        click.echo(f"Analysis complete: {output_path}")
-        logger.info(f"Analysis completed successfully: {output_path}")
+        _analyze_single_file(audio_file, output_dir, beat_division, min_onset_interval)
 
     except FileNotFoundError as e:
         click.echo(f"Error: Audio file not found: {audio_file}", err=True)
@@ -106,6 +119,56 @@ def analyze(audio_file, output_dir, beat_division, min_onset_interval):
         logger.error(f"Analysis failed: {e}")
         click.echo(f"Error: Audio analysis failed: {e}", err=True)
         raise click.ClickException(f"Audio analysis failed: {e}")
+
+
+@cli.command("analyze-recording")
+@click.argument("recording_dir", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--beat-division",
+    type=click.IntRange(min=1),
+    default=8,
+    help="Beat division for animation events (default: 8)",
+)
+@click.option(
+    "--min-onset-interval",
+    type=click.FloatRange(min=0.1),
+    default=2.0,
+    help="Minimum interval between onset events in seconds (default: 2.0)",
+)
+def analyze_recording(recording_dir, beat_division, min_onset_interval):
+    """
+    Analyze all audio sources in a recording directory.
+
+    RECORDING_DIR: Path to the recording directory
+
+    Prefers mixed/ (master + stems) over extracted/ as audio source.
+    Writes one {stem}_analysis.json per audio file into analysis/.
+    """
+    logger = logging.getLogger(__name__)
+
+    try:
+        audio_sources = RecordingStructureManager.find_analysis_audio_sources(
+            recording_dir
+        )
+    except ValueError as e:
+        raise click.ClickException(f"Stem name collision: {e}")
+
+    if not audio_sources:
+        raise click.ClickException(
+            f"No audio files found in '{recording_dir}'. "
+            "Add audio to mixed/ or extracted/ before analyzing."
+        )
+
+    analysis_dir = RecordingStructureManager.ensure_analysis_dir(recording_dir)
+
+    for audio_file in audio_sources:
+        try:
+            _analyze_single_file(
+                audio_file, analysis_dir, beat_division, min_onset_interval
+            )
+        except Exception as e:
+            logger.error(f"Analysis failed for {audio_file}: {e}")
+            raise click.ClickException(f"Audio analysis failed for '{audio_file}': {e}")
 
 
 def main():

--- a/packages/beatrix/tests/test_cli_click.py
+++ b/packages/beatrix/tests/test_cli_click.py
@@ -3,10 +3,28 @@
 
 """Tests for modernized CLI using click."""
 
+import struct
+import wave
 from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
 from click.testing import CliRunner
 
 from beatrix.cli.click_cli import cli
+
+
+def _write_wav(path, duration_s=1.0, sample_rate=22050):
+    """Write a minimal valid WAV file with a sine wave to *path*."""
+    n_samples = int(sample_rate * duration_s)
+    t = np.linspace(0, duration_s, n_samples, endpoint=False)
+    audio = np.int16(np.sin(2 * np.pi * 440 * t) * 16000)
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(struct.pack(f"{n_samples}h", *audio))
+    return path
 
 
 class TestClickCLI:
@@ -199,3 +217,140 @@ class TestClickCLI:
             assert result.exit_code == 0
             # Should show completion message
             assert "Analysis complete" in result.output
+
+
+@pytest.mark.audio
+@pytest.mark.integration
+class TestAnalyzeRecordingCommand:
+    """Tests for the analyze-recording subcommand (directory mode)."""
+
+    def test_master_only_produces_one_analysis_file(self, tmp_path):
+        """Happy path: mixed/master.wav → analysis/master_analysis.json."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        _write_wav(mixed_dir / "master.wav")
+
+        result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        analysis_file = tmp_path / "analysis" / "master_analysis.json"
+        assert analysis_file.exists(), (
+            f"Expected {analysis_file}, output: {result.output}"
+        )
+
+    def test_master_and_stems_produce_three_analysis_files(self, tmp_path):
+        """Happy path: master + 2 stems → 3 *_analysis.json files."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+        _write_wav(mixed_dir / "master.wav")
+        _write_wav(stems_dir / "drums.wav")
+        _write_wav(stems_dir / "bass.wav")
+
+        result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        analysis_dir = tmp_path / "analysis"
+        for stem in ("master", "drums", "bass"):
+            assert (analysis_dir / f"{stem}_analysis.json").exists(), (
+                f"Missing {stem}_analysis.json; output: {result.output}"
+            )
+
+    def test_empty_mixed_falls_back_to_extracted(self, tmp_path):
+        """Edge case: mixed/ exists but empty, extracted/ has 1 file → fallback."""
+        runner = CliRunner()
+        (tmp_path / "mixed").mkdir()
+        extracted_dir = tmp_path / "extracted"
+        extracted_dir.mkdir()
+        _write_wav(extracted_dir / "source.wav")
+
+        result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "analysis" / "source_analysis.json").exists()
+
+    def test_no_audio_exits_nonzero_with_message(self, tmp_path):
+        """Error path: no audio anywhere → nonzero exit + message on stderr."""
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+        assert result.exit_code != 0
+        # CliRunner by default mixes stderr into output
+        assert "no audio" in result.output.lower() or "audio" in result.output.lower()
+
+    def test_stem_collision_exits_nonzero_no_file_written(self, tmp_path):
+        """Error path: collision in stem names → nonzero exit, no file written."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+        _write_wav(mixed_dir / "master.wav")
+        _write_wav(stems_dir / "master.wav")  # collision: both → master_analysis.json
+
+        result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert "collision" in result.output.lower() or "master" in result.output.lower()
+        analysis_dir = tmp_path / "analysis"
+        # No file should have been written during failed run
+        if analysis_dir.exists():
+            assert not any(analysis_dir.iterdir()), (
+                "No analysis files should be written on collision"
+            )
+
+    def test_beat_division_and_onset_interval_propagate(self, tmp_path):
+        """Edge case: custom options are forwarded to every analysis call."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        _write_wav(mixed_dir / "master.wav")
+
+        with patch("beatrix.cli.click_cli.AudioAnalyzer") as mock_analyzer_class:
+            mock_analyzer = Mock()
+            mock_analyzer_class.return_value = mock_analyzer
+            mock_analyzer.analyze_for_animation.return_value = {
+                "duration": 1.0,
+                "tempo": {"bpm": 120.0},
+                "animation_events": {"beats": []},
+            }
+
+            result = runner.invoke(
+                cli,
+                [
+                    "analyze-recording",
+                    str(tmp_path),
+                    "--beat-division",
+                    "4",
+                    "--min-onset-interval",
+                    "1.5",
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            mock_analyzer.analyze_for_animation.assert_called_once_with(
+                mixed_dir / "master.wav",
+                beat_division=4,
+                min_onset_interval=1.5,
+            )
+
+    def test_existing_analyze_command_still_works(self, tmp_path):
+        """Regression: single-file analyze command is unaffected."""
+        runner = CliRunner()
+        audio_file = tmp_path / "test.wav"
+        audio_file.touch()
+        output_dir = tmp_path / "output"
+
+        with patch("beatrix.cli.click_cli.AudioAnalyzer") as mock_analyzer_class:
+            mock_analyzer = Mock()
+            mock_analyzer_class.return_value = mock_analyzer
+            mock_analyzer.analyze_for_animation.return_value = {}
+
+            result = runner.invoke(cli, ["analyze", str(audio_file), str(output_dir)])
+
+            assert result.exit_code == 0
+            mock_analyzer.analyze_for_animation.assert_called_once()

--- a/packages/common/src/setka_common/file_structure/specialized/recording.py
+++ b/packages/common/src/setka_common/file_structure/specialized/recording.py
@@ -25,6 +25,7 @@ class RecordingStructure(MediaStructure):
 
     extracted_dir: Path
     mixed_dir: Path
+    bitwig_dir: Path
 
     def exists(self) -> bool:
         """Check if recording structure exists."""
@@ -60,6 +61,7 @@ class RecordingStructureManager(StructureManager):
     BLENDER_DIRNAME = "blender"
     ANALYSIS_DIRNAME = "analysis"
     MIXED_DIRNAME = "mixed"
+    BITWIG_DIRNAME = "bitwig"
 
     @staticmethod
     def get_structure(video_path: Path) -> RecordingStructure:
@@ -88,6 +90,7 @@ class RecordingStructureManager(StructureManager):
         processed_dir = project_dir / RecordingStructureManager.PROCESSED_DIRNAME
         extracted_dir = project_dir / RecordingStructureManager.EXTRACTED_DIRNAME
         mixed_dir = project_dir / RecordingStructureManager.MIXED_DIRNAME
+        bitwig_dir = project_dir / RecordingStructureManager.BITWIG_DIRNAME
 
         return RecordingStructure(
             project_dir=project_dir,
@@ -96,6 +99,7 @@ class RecordingStructureManager(StructureManager):
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
             mixed_dir=mixed_dir,
+            bitwig_dir=bitwig_dir,
         )
 
     @staticmethod
@@ -118,6 +122,7 @@ class RecordingStructureManager(StructureManager):
             # Create all directories
             structure.extracted_dir.mkdir(parents=True, exist_ok=True)
             structure.mixed_dir.mkdir(parents=True, exist_ok=True)
+            structure.bitwig_dir.mkdir(parents=True, exist_ok=True)
             logger.info(f"Created recording structure: {structure.project_dir}")
         except (OSError, PermissionError) as e:
             raise DirectoryCreationError(
@@ -312,6 +317,100 @@ class RecordingStructureManager(StructureManager):
             raise DirectoryCreationError(
                 f"Failed to create mixed directory at {mixed_dir}: {e}"
             )
+
+    @staticmethod
+    def ensure_bitwig_dir(recording_dir: Path) -> Path:
+        """Ensure bitwig directory exists.
+
+        Holds the Bitwig Studio project file (Save As target).
+        Distinct from mixed/ (audio exports) and extracted/ (raw OBS sources).
+
+        Args:
+            recording_dir: Recording directory path
+
+        Returns:
+            Path to bitwig directory
+
+        Raises:
+            InvalidPathError: When recording_dir is invalid
+            DirectoryCreationError: When directory creation fails
+        """
+        if not recording_dir:
+            raise InvalidPathError("Recording directory cannot be empty")
+
+        recording_dir = Path(recording_dir)
+
+        if not recording_dir.exists():
+            raise InvalidPathError(
+                f"Recording directory does not exist: {recording_dir}"
+            )
+
+        if not recording_dir.is_dir():
+            raise InvalidPathError(
+                f"Recording path is not a directory: {recording_dir}"
+            )
+
+        bitwig_dir = recording_dir / RecordingStructureManager.BITWIG_DIRNAME
+
+        try:
+            bitwig_dir.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Created bitwig directory: {bitwig_dir}")
+            return bitwig_dir
+        except (OSError, PermissionError) as e:
+            raise DirectoryCreationError(
+                f"Failed to create bitwig directory at {bitwig_dir}: {e}"
+            )
+
+    @staticmethod
+    def find_analysis_audio_sources(recording_dir: Path) -> list[Path]:
+        """Resolve audio sources for analysis: prefer mixed/ (master + stems), fallback extracted/.
+
+        Scans mixed/ and mixed/stems/ separately (find_files_by_type is non-recursive),
+        merges results. Falls back to extracted/ when mixed/ has no audio files or does
+        not exist.
+
+        Raises ValueError on stem name collision (two sources would produce the same
+        {stem}_analysis.json output file), enforcing fail-fast policy.
+
+        Args:
+            recording_dir: Recording directory path
+
+        Returns:
+            Sorted (case-insensitive) list of audio file paths to analyze
+
+        Raises:
+            ValueError: When two source files share the same stem (collision)
+        """
+        recording_dir = Path(recording_dir)
+
+        mixed_dir = recording_dir / RecordingStructureManager.MIXED_DIRNAME
+        stems_dir = mixed_dir / "stems"
+
+        mixed_files: list[Path] = []
+        if mixed_dir.exists():
+            mixed_files.extend(find_files_by_type(mixed_dir, MediaType.AUDIO))
+            if stems_dir.exists():
+                mixed_files.extend(find_files_by_type(stems_dir, MediaType.AUDIO))
+
+        if mixed_files:
+            # Detect stem name collisions before returning
+            seen_stems: dict[str, Path] = {}
+            for audio_file in mixed_files:
+                stem_key = audio_file.stem.lower()
+                if stem_key in seen_stems:
+                    raise ValueError(
+                        f"Stem name collision: '{audio_file}' and '{seen_stems[stem_key]}' "
+                        f"would both produce '{audio_file.stem}_analysis.json'. "
+                        "Use unique stem names in mixed/ and mixed/stems/."
+                    )
+                seen_stems[stem_key] = audio_file
+
+            return sorted(mixed_files, key=lambda p: p.name.lower())
+
+        # Fallback: no audio in mixed/ (or mixed/ absent) — use extracted/
+        extracted_dir = recording_dir / RecordingStructureManager.EXTRACTED_DIRNAME
+        extracted_files = find_files_by_type(extracted_dir, MediaType.AUDIO)
+        return sorted(extracted_files, key=lambda p: p.name.lower())
 
     @staticmethod
     def get_analysis_file_path(video_path: Path) -> Path:

--- a/packages/common/tests/test_recording_structure.py
+++ b/packages/common/tests/test_recording_structure.py
@@ -26,6 +26,7 @@ class TestRecordingStructure:
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
             mixed_dir=project_dir / "mixed",
+            bitwig_dir=project_dir / "bitwig",
         )
 
         assert structure.project_dir == project_dir
@@ -59,6 +60,7 @@ class TestRecordingStructure:
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
             mixed_dir=project_dir / "mixed",
+            bitwig_dir=project_dir / "bitwig",
         )
 
         assert structure.exists() is True
@@ -87,6 +89,7 @@ class TestRecordingStructure:
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
             mixed_dir=project_dir / "mixed",
+            bitwig_dir=project_dir / "bitwig",
         )
 
         assert structure.exists() is False
@@ -115,6 +118,7 @@ class TestRecordingStructure:
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
             mixed_dir=project_dir / "mixed",
+            bitwig_dir=project_dir / "bitwig",
         )
 
         assert structure.is_valid() is True
@@ -143,6 +147,7 @@ class TestRecordingStructure:
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
             mixed_dir=project_dir / "mixed",
+            bitwig_dir=project_dir / "bitwig",
         )
 
         assert structure.is_valid() is False
@@ -171,6 +176,7 @@ class TestRecordingStructure:
             processed_dir=processed_dir,
             extracted_dir=extracted_dir,
             mixed_dir=project_dir / "mixed",
+            bitwig_dir=project_dir / "bitwig",
         )
 
         assert structure.is_valid() is True  # metadata jest opcjonalna
@@ -446,3 +452,234 @@ class TestRecordingStructureManager:
         assert RecordingStructureManager.MIXED_DIRNAME == "mixed"
         assert RecordingStructureManager.METADATA_FILENAME == "metadata.json"
         assert RecordingStructureManager.PROCESSED_DIRNAME == "processed"
+
+
+class TestBitwigDir:
+    """Testy dla obsługi katalogu bitwig/ (Unit 1)."""
+
+    def test_bitwig_dirname_constant(self):
+        """Test wartości stałej BITWIG_DIRNAME."""
+        assert RecordingStructureManager.BITWIG_DIRNAME == "bitwig"
+
+    def test_get_structure_returns_bitwig_dir_path(self, tmp_path):
+        """Test get_structure() zwraca bitwig_dir jako ścieżkę bez tworzenia katalogu."""
+        project_dir = tmp_path / "test_recording"
+        video_file = project_dir / "recording.mkv"
+
+        structure = RecordingStructureManager.get_structure(video_file)
+
+        assert structure.bitwig_dir == project_dir / "bitwig"
+        assert not structure.bitwig_dir.exists()
+
+    def test_create_structure_creates_bitwig_dir(self, tmp_path):
+        """Test create_structure() materializuje bitwig/ obok extracted/ i mixed/."""
+        project_dir = tmp_path / "test_recording"
+        project_dir.mkdir()
+        video_file = project_dir / "recording.mkv"
+
+        structure = RecordingStructureManager.create_structure(video_file)
+
+        assert structure.bitwig_dir.exists()
+        assert structure.bitwig_dir.is_dir()
+        assert structure.bitwig_dir == project_dir / "bitwig"
+
+    def test_ensure_bitwig_dir_creates_and_returns_path(self, tmp_path):
+        """Test ensure_bitwig_dir() tworzy katalog bitwig/ i zwraca Path."""
+        recording_dir = tmp_path / "test_recording"
+        recording_dir.mkdir()
+
+        bitwig_dir = RecordingStructureManager.ensure_bitwig_dir(recording_dir)
+
+        assert bitwig_dir == recording_dir / "bitwig"
+        assert bitwig_dir.exists()
+        assert bitwig_dir.is_dir()
+
+    def test_ensure_bitwig_dir_is_idempotent(self, tmp_path):
+        """Test ensure_bitwig_dir() jest idempotentne — drugie wywołanie działa poprawnie."""
+        recording_dir = tmp_path / "test_recording"
+        recording_dir.mkdir()
+
+        bitwig_dir_first = RecordingStructureManager.ensure_bitwig_dir(recording_dir)
+        bitwig_dir_second = RecordingStructureManager.ensure_bitwig_dir(recording_dir)
+
+        assert bitwig_dir_first == bitwig_dir_second
+        assert bitwig_dir_second.exists()
+
+    def test_ensure_bitwig_dir_empty_path_raises(self, tmp_path):
+        """Test ensure_bitwig_dir() dla pustej ścieżki → InvalidPathError."""
+        from setka_common.exceptions import InvalidPathError
+
+        import pytest
+
+        with pytest.raises(InvalidPathError):
+            RecordingStructureManager.ensure_bitwig_dir("")
+
+    def test_ensure_bitwig_dir_nonexistent_raises(self, tmp_path):
+        """Test ensure_bitwig_dir() dla nieistniejącego katalogu → InvalidPathError."""
+        from setka_common.exceptions import InvalidPathError
+
+        import pytest
+
+        nonexistent = tmp_path / "nonexistent"
+
+        with pytest.raises(InvalidPathError):
+            RecordingStructureManager.ensure_bitwig_dir(nonexistent)
+
+    def test_ensure_bitwig_dir_not_a_dir_raises(self, tmp_path):
+        """Test ensure_bitwig_dir() gdy ścieżka wskazuje plik → InvalidPathError."""
+        from setka_common.exceptions import InvalidPathError
+
+        import pytest
+
+        file_path = tmp_path / "not_a_dir.mkv"
+        file_path.touch()
+
+        with pytest.raises(InvalidPathError):
+            RecordingStructureManager.ensure_bitwig_dir(file_path)
+
+
+class TestFindAnalysisAudioSources:
+    """Testy dla resolvera źródeł audio do analizy (Unit 2)."""
+
+    def test_only_mixed_master(self, tmp_path):
+        """Tylko mixed/master.wav → zwraca [master.wav]."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        master = mixed_dir / "master.wav"
+        master.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert result == [master]
+
+    def test_mixed_master_plus_stems(self, tmp_path):
+        """mixed/master.wav + mixed/stems/{a,b}.wav → zwraca wszystkie trzy."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+
+        master = mixed_dir / "master.wav"
+        master.touch()
+        stem_a = stems_dir / "bass.wav"
+        stem_a.touch()
+        stem_b = stems_dir / "guitar.wav"
+        stem_b.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert master in result
+        assert stem_a in result
+        assert stem_b in result
+        assert len(result) == 3
+
+    def test_mixed_no_audio_falls_back_to_extracted(self, tmp_path):
+        """mixed/ istnieje ale bez plików audio → fallback do extracted/."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        # Tworzymy tylko podkatalog stems/ bez plików audio
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+
+        extracted_dir = recording_dir / "extracted"
+        extracted_dir.mkdir()
+        ext_audio = extracted_dir / "source.m4a"
+        ext_audio.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert result == [ext_audio]
+
+    def test_no_mixed_falls_back_to_extracted(self, tmp_path):
+        """mixed/ nieobecne, extracted/ ma pliki → fallback do extracted/."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        extracted_dir = recording_dir / "extracted"
+        extracted_dir.mkdir()
+        ext_audio = extracted_dir / "source.m4a"
+        ext_audio.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert result == [ext_audio]
+
+    def test_both_empty_returns_empty_list(self, tmp_path):
+        """Oba katalogi puste/nieobecne → zwraca [] bez wyjątku."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert result == []
+
+    def test_mixed_extensions_all_audio_caught(self, tmp_path):
+        """Mieszane rozszerzenia — wszystkie audio złapane, nie-audio pominięte."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+
+        wav_file = mixed_dir / "master.wav"
+        wav_file.touch()
+        flac_file = mixed_dir / "master2.flac"
+        flac_file.touch()
+        m4a_file = stems_dir / "stem.m4a"
+        m4a_file.touch()
+        txt_file = mixed_dir / "readme.txt"
+        txt_file.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert wav_file in result
+        assert flac_file in result
+        assert m4a_file in result
+        assert txt_file not in result
+
+    def test_collision_raises_error(self, tmp_path):
+        """Kolizja nazwy (mixed/master.wav + mixed/stems/master.wav) → wyjątek z opisem."""
+        import pytest
+
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+
+        master_mixed = mixed_dir / "master.wav"
+        master_mixed.touch()
+        master_stem = stems_dir / "master.wav"
+        master_stem.touch()
+
+        with pytest.raises(ValueError, match="master"):
+            RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+    def test_deterministic_ordering(self, tmp_path):
+        """Kolejność wyników jest deterministyczna (sort case-insensitive)."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+
+        # Nazwy ze zróżnicowaną wielkością liter
+        file_z = mixed_dir / "Zebra.wav"
+        file_z.touch()
+        file_a = stems_dir / "apple.wav"
+        file_a.touch()
+        file_m = mixed_dir / "Master.wav"
+        file_m.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+        result_names = [f.name.lower() for f in result]
+
+        assert result_names == sorted(result_names)

--- a/packages/fermata/src-tauri/src/commands/operations.rs
+++ b/packages/fermata/src-tauri/src/commands/operations.rs
@@ -19,6 +19,20 @@ impl Default for RenderOptions {
     }
 }
 
+/// Resolve the cinemon `--main-audio` target for a recording.
+/// Prefers the polished Bitwig master at `mixed/master.wav` (returned as an absolute
+/// path, since the cinemon master-aware selection expects one), so the render picks
+/// `master_analysis.json`. Returns None when the master is absent, letting callers
+/// keep their existing audio resolution.
+fn resolve_master_main_audio(recording_path: &std::path::Path) -> Option<String> {
+    let master = recording_path.join("mixed").join("master.wav");
+    if master.exists() {
+        Some(master.to_string_lossy().to_string())
+    } else {
+        None
+    }
+}
+
 /// Run the next step in the pipeline for a specific recording
 #[tauri::command]
 pub async fn run_next_step(recording_name: String, config: State<'_, AppConfig>) -> Result<String, String> {
@@ -136,53 +150,23 @@ async fn execute_step(
             return Err("Extract step not implemented in fermata - use obsession package".to_string());
         }
         NextStep::Analyze => {
-            // Look for audio file in extracted directory
-            let extracted_dir = recording.path.join("extracted");
-            if !extracted_dir.exists() {
-                return Err("Extracted directory not found - run extract step first".to_string());
-            }
-
-            log::info!("🔍 Searching for audio files in: {}", extracted_dir.display());
-
-            // Find audio file (typically .m4a)
-            let audio_files: Vec<_> = std::fs::read_dir(&extracted_dir)
-                .map_err(|e| format!("Failed to read extracted directory: {}", e))?
-                .filter_map(|entry| {
-                    let entry = entry.ok()?;
-                    let path = entry.path();
-                    log::info!("📁 Found file: {:?}", path);
-                    if path.extension()?.to_str()? == "m4a" {
-                        path.file_name()?.to_str().map(|s| s.to_string())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            log::info!("🎵 Found {} audio files: {:?}", audio_files.len(), audio_files);
-
-            if audio_files.is_empty() {
-                // List all files in directory for debugging
-                if let Ok(entries) = std::fs::read_dir(&extracted_dir) {
-                    let all_files: Vec<_> = entries
-                        .filter_map(|e| e.ok())
-                        .map(|e| e.file_name().to_string_lossy().to_string())
-                        .collect();
-                    log::warn!("❌ No .m4a files found. All files in directory: {:?}", all_files);
-                    return Err(format!("No audio file (.m4a) found in extracted directory. Found files: {:?}", all_files));
-                } else {
-                    return Err("No audio file (.m4a) found in extracted directory".to_string());
-                }
-            }
-
-            let audio_file = &audio_files[0]; // Take first audio file
-            log::info!("🎯 Using audio file: {}", audio_file);
-            runner.run_beatrix_analyze(&recording.path, audio_file).await
+            // beatrix analyze-recording resolves audio sources itself (mixed/ master +
+            // stems, extracted/ fallback) and reports missing audio or stem-name
+            // collisions via a non-zero exit + stderr, which the caller surfaces as Err.
+            log::info!("🎵 Running analyze for recording: {}", recording.path.display());
+            runner.run_beatrix_analyze(&recording.path).await
         }
         NextStep::SetupRender => {
             // Check if analysis exists
             if !recording.path.join("analysis").exists() {
                 return Err("Analysis directory not found - run analyze step first".to_string());
+            }
+
+            // Prefer the polished Bitwig master so cinemon selects master_analysis.json.
+            if let Some(master_audio) = resolve_master_main_audio(&recording.path) {
+                log::info!("🎯 Using mixed master as main audio: {}", master_audio);
+                return runner.run_cinemon_render(&recording.path, "beat-switch", Some(&master_audio)).await
+                    .map_err(|e| format!("Command execution failed: {}", e));
             }
 
             // Check if we have multiple audio files and use configured main audio
@@ -372,8 +356,14 @@ async fn execute_step_with_preset(
                 return Err("Analysis directory not found - run analyze step first".to_string());
             }
 
-            log::info!("🎬 Setting up render with preset: {}, main_audio: {:?}", preset, main_audio);
-            runner.run_cinemon_render(&recording.path, preset, main_audio).await
+            // Prefer an explicit main_audio; otherwise fall back to the polished master
+            // so cinemon selects master_analysis.json without a manual override.
+            let resolved_audio = main_audio
+                .map(|a| a.to_string())
+                .or_else(|| resolve_master_main_audio(&recording.path));
+
+            log::info!("🎬 Setting up render with preset: {}, main_audio: {:?}", preset, resolved_audio);
+            runner.run_cinemon_render(&recording.path, preset, resolved_audio.as_deref()).await
                 .map_err(|e| format!("Command execution failed: {}", e))
         }
         _ => {
@@ -481,15 +471,99 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_missing_dependencies() {
+    async fn test_setup_render_requires_analysis_dir() {
         let temp_dir = TempDir::new().unwrap();
         let config = create_test_config(&temp_dir);
 
-        // Try to analyze without extracted directory
+        // SetupRender still guards on the analysis directory existing first.
+        let recording = create_test_recording(&temp_dir, "test_recording", RecordingStatus::Recorded);
+
+        let result = execute_step(&recording, &NextStep::SetupRender, &config).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Analysis directory not found"));
+    }
+
+    #[tokio::test]
+    async fn test_analyze_step_invokes_analyze_recording_subcommand() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(&temp_dir);
+
+        // No extracted/ directory: source selection now lives in beatrix, so the Rust
+        // side no longer pre-checks extracted/ nor filters .m4a.
         let recording = create_test_recording(&temp_dir, "test_recording", RecordingStatus::Recorded);
 
         let result = execute_step(&recording, &NextStep::Analyze, &config).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Extracted directory not found"));
+        assert!(result.is_ok());
+        let process_result = result.unwrap();
+        assert!(process_result.success);
+        // echo stub: stdout echoes the constructed command line.
+        assert!(process_result.stdout.contains("analyze-recording"));
+        assert!(!process_result.stdout.contains("extracted"));
+    }
+
+    #[tokio::test]
+    async fn test_analyze_step_surfaces_beatrix_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        // `false` stands in for a beatrix run that exits non-zero (e.g. no audio).
+        let config = AppConfig {
+            recordings_path: temp_dir.path().to_path_buf(),
+            cli_paths: crate::commands::recordings::CliPaths {
+                uv_path: "false".to_string(),
+                workspace_root: temp_dir.path().to_path_buf(),
+            },
+            main_audio_file: "".to_string(),
+        };
+
+        let recording = create_test_recording(&temp_dir, "test_recording", RecordingStatus::Extracted);
+
+        let result = execute_step(&recording, &NextStep::Analyze, &config).await;
+        // execute_step returns Ok with the failed ProcessResult; run_specific_step turns
+        // !success into Err(stderr) for the UI.
+        assert!(result.is_ok());
+        assert!(!result.unwrap().success);
+    }
+
+    #[test]
+    fn test_resolve_master_main_audio_prefers_mixed_master() {
+        let temp_dir = TempDir::new().unwrap();
+        let recording_path = temp_dir.path().join("rec");
+        let mixed_dir = recording_path.join("mixed");
+        fs::create_dir_all(&mixed_dir).unwrap();
+        fs::write(mixed_dir.join("master.wav"), "wav").unwrap();
+
+        let resolved = resolve_master_main_audio(&recording_path);
+        assert_eq!(resolved, Some(mixed_dir.join("master.wav").to_string_lossy().to_string()));
+    }
+
+    #[test]
+    fn test_resolve_master_main_audio_none_when_absent() {
+        let temp_dir = TempDir::new().unwrap();
+        let recording_path = temp_dir.path().join("rec");
+        fs::create_dir_all(&recording_path).unwrap();
+
+        assert_eq!(resolve_master_main_audio(&recording_path), None);
+    }
+
+    #[tokio::test]
+    async fn test_setup_render_uses_mixed_master_when_present() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(&temp_dir);
+
+        // Analyzed recording plus a polished master in mixed/.
+        let recording = create_test_recording(&temp_dir, "test_recording", RecordingStatus::Analyzed);
+        let mixed_dir = recording.path.join("mixed");
+        fs::create_dir_all(&mixed_dir).unwrap();
+        fs::write(mixed_dir.join("master.wav"), "wav").unwrap();
+
+        // No explicit main_audio: should resolve to the master and not error out.
+        let result = execute_step_with_preset(
+            &recording,
+            &NextStep::SetupRender,
+            &config,
+            "vintage",
+            None,
+        ).await;
+
+        assert!(result.is_ok());
     }
 }

--- a/packages/fermata/src-tauri/src/services/process_runner.rs
+++ b/packages/fermata/src-tauri/src/services/process_runner.rs
@@ -23,17 +23,15 @@ impl ProcessRunner {
         }
     }
 
-    /// Run beatrix analyze command
-    pub async fn run_beatrix_analyze(&self, recording_path: &Path, audio_file: &str) -> anyhow::Result<ProcessResult> {
-        let audio_path = recording_path.join("extracted").join(audio_file);
-        let analysis_dir = recording_path.join("analysis");
-
-        log::info!("🎵 Running beatrix analyze: audio={}, output={}", audio_path.display(), analysis_dir.display());
+    /// Run beatrix analyze on a whole recording.
+    /// beatrix analyze-recording selects audio sources itself (mixed/ master + stems,
+    /// extracted/ fallback) and writes one {stem}_analysis.json per file.
+    pub async fn run_beatrix_analyze(&self, recording_path: &Path) -> anyhow::Result<ProcessResult> {
+        log::info!("🎵 Running beatrix analyze-recording: {}", recording_path.display());
 
         let mut cmd = AsyncCommand::new(&self.uv_path);
-        cmd.args(&["run", "--package", "beatrix", "beatrix", "analyze"])
-            .arg(&audio_path)
-            .arg(&analysis_dir)
+        cmd.args(&["run", "--package", "beatrix", "beatrix", "analyze-recording"])
+            .arg(recording_path)
             .current_dir(&self.workspace_root);
 
         self.execute_command(cmd).await
@@ -234,17 +232,18 @@ mod tests {
 
         // Create test directory structure
         let recording_path = temp_dir.path().join("test_recording");
-        let extracted_dir = recording_path.join("extracted");
-        fs::create_dir_all(&extracted_dir).unwrap();
+        fs::create_dir_all(&recording_path).unwrap();
 
-        let audio_file = "audio.m4a";
-        fs::write(extracted_dir.join(audio_file), "test audio").unwrap();
-
-        // This will fail because we're using echo instead of uv, but we can test the structure
-        let result = runner.run_beatrix_analyze(&recording_path, audio_file).await;
+        // echo stands in for uv, so stdout echoes the constructed command line.
+        let result = runner.run_beatrix_analyze(&recording_path).await;
 
         // Should not panic and should return some result
         assert!(result.is_ok());
+        let process_result = result.unwrap();
+        // Uses the directory-mode subcommand on the recording, not the old
+        // per-file analyze against extracted/<file>.
+        assert!(process_result.stdout.contains("analyze-recording"));
+        assert!(!process_result.stdout.contains("extracted"));
     }
 
     #[tokio::test]

--- a/packages/fermata/src/components/RecordingList.test.tsx
+++ b/packages/fermata/src/components/RecordingList.test.tsx
@@ -34,7 +34,8 @@ const mockUseRecordingOperations = {
   runNextStep: vi.fn(),
   runSpecificStep: vi.fn(),
   running: {},
-  output: ''
+  output: '',
+  error: null as string | null
 };
 
 vi.mock('../hooks/useRecordings', () => ({
@@ -45,6 +46,7 @@ vi.mock('../hooks/useRecordings', () => ({
 describe('RecordingList Delete Button', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseRecordingOperations.error = null;
   });
 
   it('should render delete button for each recording', () => {
@@ -79,5 +81,42 @@ describe('RecordingList Delete Button', () => {
 
     const deleteButton = screen.getByRole('button', { name: /usuń/i });
     expect(deleteButton).not.toBeDisabled();
+  });
+});
+
+describe('RecordingList operation error display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRecordingOperations.running = {};
+    mockUseRecordingOperations.output = '';
+    mockUseRecordingOperations.error = null;
+  });
+
+  it('should not render operation error when error is null', () => {
+    mockUseRecordingOperations.error = null;
+
+    render(<RecordingList />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('should render operation error message when operationError is set', () => {
+    mockUseRecordingOperations.error = 'No audio files found in recording directory';
+
+    render(<RecordingList />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('No audio files found in recording directory');
+  });
+
+  it('should render Error: prefix in operation error', () => {
+    mockUseRecordingOperations.error = 'beatrix: analysis failed';
+
+    render(<RecordingList />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Error:');
+    expect(alert).toHaveTextContent('beatrix: analysis failed');
   });
 });

--- a/packages/fermata/src/components/RecordingList.tsx
+++ b/packages/fermata/src/components/RecordingList.tsx
@@ -158,7 +158,7 @@ interface RecordingListProps {
 
 export function RecordingList({ onSelectRecording }: RecordingListProps) {
   const { recordings, loading, error, refreshRecordings, showDeletionDialog, deletionState, deleteRecording, hideDeletionDialog } = useRecordings();
-  const { runNextStep, runSpecificStep, running, output } = useRecordingOperations();
+  const { runNextStep, runSpecificStep, running, output, error: operationError } = useRecordingOperations();
   const {
     processedRecordings,
     filterConfig,
@@ -272,6 +272,12 @@ export function RecordingList({ onSelectRecording }: RecordingListProps) {
           <div className="operation-status">
             <div className="title">Operation in progress...</div>
             {output && <div className="output">{output}</div>}
+          </div>
+        )}
+
+        {operationError && (
+          <div className="operation-error" role="alert">
+            <strong>Error:</strong> {operationError}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
Domyka „ostatnią milę" pipeline'u audio: po Export Audio z Bitwig do `mixed/master.wav`, jedno kliknięcie „Analizuj" w fermacie analizuje master (i ewentualne stemy z `mixed/stems/`), a render automatycznie wybiera `master_analysis.json`. Realizacja planu `docs/plans/2026-06-04-001-feat-bitwig-master-to-beatrix-plan.md` (5 jednostek).

- **setka-common**: kanoniczny katalog `bitwig/` (dom na projekt Bitwig) + resolver `find_analysis_audio_sources` — preferuje `mixed/` (master + `stems/`), fallback `extracted/`, fail-fast przy kolizji `{stem}_analysis.json`.
- **beatrix**: nowa subkomenda `analyze-recording <dir>` iterująca po źródłach (jedna `{stem}_analysis.json` per plik); single-file `analyze` bez zmian.
- **fermata**: „Analizuj" woła `analyze-recording` raz na nagraniu (koniec hardkodu `extracted/` + `.m4a` + `[0]`); błąd widoczny w UI zamiast cichego faila; SetupRender celuje `--main-audio` w absolutny `mixed/master.wav`.
- **docs**: `CLAUDE.md` (struktura katalogów: `bitwig/` + `mixed/`).

Kod cinemon nietknięty — selekcja master-aware już istniała.

## Testing
- `setka-common`: 43 passed (`test_recording_structure.py`); `beatrix`: 16 passed (`test_cli_click.py`); ruff clean — uruchamiane po ścieżce (pełne `uv run pytest` zepsute).
- `fermata`: +6 nowych testów cargo zielonych, +3 nowe vitest zielone.
- Pre-existing na `master` (nie regresja tego PR, zweryfikowane przez baseline): 3 cargo (`models::recording`, `status_detector::test_get_file_info`) + 4 vitest („Delete Button" — szukają `/usuń/i`, UI renderuje „Delete").
- Ręcznie do potwierdzenia: Export Audio → `mixed/master.wav` → klik „Analizuj" tworzy `analysis/master_analysis.json`; nagranie bez audio → czytelny błąd w UI.

## Post-Deploy Monitoring & Validation
- **Co obserwować**: logi backendu Tauri przy kroku Analyze/SetupRender (`🎵 Running beatrix analyze-recording`, `🎯 Using mixed master as main audio`); obecność `analysis/{stem}_analysis.json` po kliknięciu.
- **Walidacja**: na realnym nagraniu z `mixed/master.wav` — klik „Analizuj" → istnieje `analysis/master_analysis.json`; render → cinemon użył `master_analysis.json`. Na nagraniu bez audio → komunikat błędu w UI (nie cisza).
- **Sygnał zdrowy**: jedna analiza per plik źródłowy; brak cichych failów.
- **Sygnał awarii / rollback**: brak `*_analysis.json` mimo obecnego audio, albo render bierze złą analizę → rollback przez revert gałęzi (zmiana czysto addytywna, stare nagrania bez `mixed/` działają przez fallback `extracted/`).
- **Okno / właściciel**: pierwszy realny post-prod teledysku; Wojtas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)