### PR TITLE
fix(fermata): sync preset list with cinemon (minimal, multi_pip)

### DIFF
--- a/packages/fermata/src-tauri/src/commands/operations.rs
+++ b/packages/fermata/src-tauri/src/commands/operations.rs
@@ -13,7 +13,7 @@ pub struct RenderOptions {
 impl Default for RenderOptions {
     fn default() -> Self {
         Self {
-            preset: "beat-switch".to_string(),  // Zachowanie kompatybilności
+            preset: "minimal".to_string(),  // Zachowanie kompatybilności
             main_audio: None,
         }
     }
@@ -165,7 +165,7 @@ async fn execute_step(
             // Prefer the polished Bitwig master so cinemon selects master_analysis.json.
             if let Some(master_audio) = resolve_master_main_audio(&recording.path) {
                 log::info!("🎯 Using mixed master as main audio: {}", master_audio);
-                return runner.run_cinemon_render(&recording.path, "beat-switch", Some(&master_audio)).await
+                return runner.run_cinemon_render(&recording.path, "minimal", Some(&master_audio)).await
                     .map_err(|e| format!("Command execution failed: {}", e));
             }
 
@@ -191,18 +191,18 @@ async fn execute_step(
                     // Use configured main audio file if available
                     if !config.main_audio_file.is_empty() && audio_files.contains(&config.main_audio_file) {
                         log::info!("🎯 Using configured main audio: {}", config.main_audio_file);
-                        runner.run_cinemon_render(&recording.path, "beat-switch", Some(&config.main_audio_file)).await
+                        runner.run_cinemon_render(&recording.path, "minimal", Some(&config.main_audio_file)).await
                     } else {
                         log::warn!("⚠️ Multiple audio files found but main audio '{}' not available in: {:?}", config.main_audio_file, audio_files);
                         return Err(format!("Multiple audio files found: {:?}. Configure FERMATA_MAIN_AUDIO environment variable to specify which one to use.", audio_files));
                     }
                 } else {
                     // Single audio file, use without --main-audio parameter
-                    runner.run_cinemon_render(&recording.path, "beat-switch", None).await
+                    runner.run_cinemon_render(&recording.path, "minimal", None).await
                 }
             } else {
                 // No extracted directory, use basic render
-                runner.run_cinemon_render(&recording.path, "beat-switch", None).await
+                runner.run_cinemon_render(&recording.path, "minimal", None).await
             }
         }
         NextStep::Render => {
@@ -560,10 +560,19 @@ mod tests {
             &recording,
             &NextStep::SetupRender,
             &config,
-            "vintage",
+            "minimal",
             None,
         ).await;
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_render_options_default_uses_supported_preset() {
+        // The default preset must be one cinemon actually ships (see
+        // `cinemon-generate-config --list-presets`); a stale default makes the
+        // quick "Setup" button fail with "Preset '<name>' not found".
+        let supported = ["minimal", "multi_pip"];
+        assert!(supported.contains(&RenderOptions::default().preset.as_str()));
     }
 }

--- a/packages/fermata/src-tauri/src/services/process_runner.rs
+++ b/packages/fermata/src-tauri/src/services/process_runner.rs
@@ -253,7 +253,7 @@ mod tests {
         let recording_path = temp_dir.path().join("test_recording");
         fs::create_dir_all(&recording_path).unwrap();
 
-        let result = runner.run_cinemon_render(&recording_path, "beat-switch", None).await;
+        let result = runner.run_cinemon_render(&recording_path, "minimal", None).await;
 
         // Should not panic and should return some result
         assert!(result.is_ok());

--- a/packages/fermata/src/components/RecordingDetails.tsx
+++ b/packages/fermata/src/components/RecordingDetails.tsx
@@ -17,7 +17,7 @@ export function RecordingDetails({ recordingName, onBack, onRecordingRenamed }: 
   const [recording, setRecording] = useState<Recording | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedPreset, setSelectedPreset] = useState("beat-switch");
+  const [selectedPreset, setSelectedPreset] = useState("minimal");
   const [showPresetConfig, setShowPresetConfig] = useState(false);
   const [showVideoPlayer, setShowVideoPlayer] = useState(false);
   const [videoPath, setVideoPath] = useState<string | null>(null);

--- a/packages/fermata/src/types/index.ts
+++ b/packages/fermata/src/types/index.ts
@@ -99,20 +99,12 @@ export interface PresetOption {
 
 export const AVAILABLE_PRESETS: PresetOption[] = [
   {
-    name: 'beat-switch',
-    description: 'Dynamic camera switching synchronized with beat detection'
-  },
-  {
     name: 'minimal',
     description: 'Clean, simple layout with minimal animations'
   },
   {
-    name: 'music-video',
-    description: 'High-energy effects perfect for music content'
-  },
-  {
-    name: 'vintage',
-    description: 'Retro-style effects with film grain and color grading'
+    name: 'multi_pip',
+    description: 'Multiple picture-in-picture layout with per-strip animations'
   }
 ];
 

--- a/packages/fermata/src/types/presets.test.ts
+++ b/packages/fermata/src/types/presets.test.ts
@@ -1,0 +1,22 @@
+// ABOUTME: Guards the fermata preset list against drift from cinemon's actual presets.
+// ABOUTME: cinemon-generate-config --list-presets is the source of truth (minimal, multi_pip).
+import { describe, it, expect } from 'vitest';
+import { AVAILABLE_PRESETS } from './index';
+
+// Keep in sync with `cinemon-generate-config --list-presets`. fermata historically
+// offered beat-switch/music-video/vintage, which cinemon no longer ships, so the
+// render step failed with "Preset '<name>' not found".
+const CINEMON_PRESETS = ['minimal', 'multi_pip'];
+
+describe('AVAILABLE_PRESETS', () => {
+  it('only offers presets that cinemon actually supports', () => {
+    const names = AVAILABLE_PRESETS.map((p) => p.name);
+    expect(names).toEqual(CINEMON_PRESETS);
+  });
+
+  it('gives every preset a non-empty description', () => {
+    for (const preset of AVAILABLE_PRESETS) {
+      expect(preset.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Naprawia dryf presetów między fermatą a cinemonem. fermata oferowała `beat-switch`/`music-video`/`vintage` (których cinemon już nie ma — zostały tylko `minimal` i `multi_pip`), a quick-button „Setup" hardkodował `beat-switch` → setup renderu padał z `Error: Preset '<name>' not found`. Ujawnione przy realnym nagraniu po naprawie cichego faila „Analizuj" (PR #35).

- `types/index.ts` `AVAILABLE_PRESETS` → `minimal`, `multi_pip`.
- `RecordingDetails.tsx`: domyślny `selectedPreset` `beat-switch` → `minimal`.
- `operations.rs`: hardkod `beat-switch` w ścieżkach SetupRender + `RenderOptions::default` → `minimal`.
- `process_runner.rs`: test struktury używa `minimal`.

**Poza zakresem:** martwa funkcja `run_cinemon_render_with_audio` (kompilator: „never used") nadal mapuje stare nazwy presetów — zostawiona świadomie.

## Testing
- Nowy `src/types/presets.test.ts`: pin listy presetów do `{minimal, multi_pip}` + niepuste opisy → 2 passed (guard przed przyszłym dryfem; źródło prawdy: `cinemon-generate-config --list-presets`).
- Nowy Rust `test_render_options_default_uses_supported_preset` → pin domyślnego presetu do wspieranego.
- `cargo test`: 48 passed / 3 failed (3 pre-existing na master: `models::recording` ×2, `status_detector::test_get_file_info`).
- Vitest cała suita: 9 passed / 6 failed (6 pre-existing: „Delete Button" `/usuń/i` + inne; brak nowych regresji).
- Zweryfikowane ręcznie: `cinemon-generate-config --preset minimal --main-audio .../mixed/master.wav` → config powstaje z `main_audio = master`; `cinemon-blend-setup --config` → projekt `.blend` utworzony.

## Post-Deploy Monitoring & Validation
- **Co obserwować**: po restarcie fermaty selektor presetów pokazuje `minimal`/`multi_pip`; klik „Setup"/render nie zwraca `Preset '...' not found`.
- **Walidacja**: na nagraniu z `extracted/` + `mixed/master.wav` + `analysis/` — render setup tworzy `animation_config_<preset>.yaml` i projekt `blender/*.blend`.
- **Sygnał awarii / rollback**: powrót `Preset '...' not found` lub pusty selektor → revert gałęzi (zmiana czysto konfiguracyjna, niskie ryzyko).
- **Okno / właściciel**: najbliższy render teledysku; Wojtas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)