### PR TITLE
feat: Analiza per-track z bitwig/samples + manifest odkrywania (index.json)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,11 @@ recording_name/
 ├── extracted/              # Individual sources
 ├── mixed/                  # Bitwig master (master.wav) + optional stems/ for analysis
 ├── bitwig/                 # Bitwig project home (Save As here)
+│   └── samples/            # Raw per-track capture (non-destructive; effects live in .bwproject)
+│                           # Used as stem fallback for analysis when mixed/stems/ is absent
 ├── analysis/               # Audio analysis JSON ({stem}_analysis.json per source)
+│   └── index.json          # Discovery manifest: [{role, origin, label, source, analysis, …}]
+│                           # role∈{master,stem,main}; consumers read via load_analysis_index()
 └── blender/               # VSE projects
     └── render/            # Final outputs
 ```
@@ -276,10 +280,17 @@ obs-extract /path/to/recording.mkv
 #    drives analysis AND becomes the final clip soundtrack; extracted/ stays as
 #    the video source. The mixed/ directory is managed by RecordingStructureManager.
 
-# 3. Analyze audio for animation timing (analyze the Bitwig master)
-uv run --package beatrix python -m beatrix.cli.analyze_audio \
-  "/path/to/recording/mixed/master.wav" \
-  "/path/to/recording/analysis"
+# 3. Analyze audio for animation timing (one click in Fermata / CLI below)
+#    beatrix analyze-recording analyzes ALL tracks in one shot:
+#      - master from mixed/master.wav
+#      - stems from mixed/stems/ (or bitwig/samples/ as fallback, or extracted/ as last resort)
+#    Writes per-track *_analysis.json + discovery manifest analysis/index.json.
+#    Consumers read the manifest via: from setka_common import load_analysis_index
+beatrix analyze-recording "/path/to/recording"
+# (legacy single-file form still works for one-off analysis:)
+# uv run --package beatrix python -m beatrix.cli.analyze_audio \
+#   "/path/to/recording/mixed/master.wav" \
+#   "/path/to/recording/analysis"
 
 # 4. Create Blender VSE project with preset-based animations
 #    Point --main-audio at the master using an ABSOLUTE path. Cinemon is
@@ -293,8 +304,8 @@ python -m medusa.cli upload /path/to/recording/blender/render/output.mp4
 ```
 
 > Audio/video drift is compensated manually in Blender (the pipeline does not
-> auto-sync). Per-instrument stems (`mixed/stems/`) and per-track animation
-> targeting are a future phase.
+> auto-sync). Per-instrument stems (`mixed/stems/`) are analyzed automatically
+> by `beatrix analyze-recording`; per-strip animation targeting is a future phase.
 
 ### Beatrix Audio Analysis Examples
 

--- a/docs/plans/2026-06-04-003-feat-bitwig-per-track-analysis-plan.md
+++ b/docs/plans/2026-06-04-003-feat-bitwig-per-track-analysis-plan.md
@@ -1,0 +1,561 @@
+---
+title: "feat: Analiza per-track z bitwig/ + manifest odkrywania dla cymatic/cinemon"
+type: feat
+status: completed
+date: 2026-06-04
+origin: docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md
+deepened: 2026-06-04
+---
+
+# feat: Analiza per-track z bitwig/ + manifest odkrywania dla cymatic/cinemon
+
+## Overview
+
+Rozszerzamy istniejącą akcję „Analizuj" (fermata → `beatrix analyze-recording`),
+żeby jednym kliknięciem analizowała **wszystkie ścieżki nagrania**, biorąc stemy z
+hybrydowego źródła: preferuj polerowane `mixed/stems/`, a gdy ich brak — sięgnij po
+**surowy multitrack capture leżący już w `bitwig/<…>/samples/`**. Każda ścieżka
+dostaje znormalizowaną (sanityzowaną) nazwę i własną `analysis/<stem>_analysis.json`,
+a całość spinamy nowym manifestem **`analysis/index.json`** — kontraktem odkrywania,
+dzięki któremu cymatic i cinemon **enumerują i rozróżniają** analizy (master vs
+per-track, czysta etykieta, ścieżka źródłowa) bez zgadywania po globie.
+
+Punkt wyjścia: poprzedni, **zmergowany** plan
+(`2026-06-04-001-feat-bitwig-master-to-beatrix-plan.md`) zbudował już: kanoniczny
+katalog `bitwig/`, resolver `find_analysis_audio_sources` (mixed/ → fallback
+extracted/), subkomendę `beatrix analyze-recording <dir>` oraz wywołanie jej z
+fermaty jednym kliknięciem. **Ten plan jest czysto addytywny** względem tamtego —
+nie przepisujemy działającej logiki, dokładamy warstwę „bitwig jako źródło stemów"
+i warstwę odkrywania.
+
+## Problem Frame
+
+Operator nagrywa live wielościeżkowo do Bitwiga; surowe ścieżki lądują w
+`bitwig/<projekt>/samples/` (np. `m_s-24.wav`, `track 4+git-24.wav`,
+`track 5_6+mic+freak-24.wav`). To gotowy, izolowany per-instrument materiał idealny
+do **wyzwalaczy animacji** (beat/onset/energy) — ale dziś „Analizuj" go nie widzi
+(iteruje tylko `mixed/`), a nawet gdyby widział, surowe nazwy z sufiksem Bitwiga
+(`-24`, `-25`) i znakami `+`/`/`/spacja są niewygodne, a żaden moduł nie ma jak
+**odróżnić** mastera od ścieżki ani znaleźć „tej właściwej" analizy. Wojtas chce:
+wcisnąć „Analizuj" mając katalog `bitwig/` → dostać analizy wszystkich ścieżek →
+a cymatic/cinemon mają je łatwo znaleźć i rozróżnić.
+
+**Model zapisu audio w Bitwigu (ustalony w trakcie planowania):** pliki w `samples/`
+to **surowy capture z nagrywania**, niezależny od miksu. Dodanie efektu, zmiana
+głośności/EQ/panoramy są **nieniszczące** — żyją w `.bwproject`, nie ruszają plików
+w `samples/`. Przetworzony dźwięk powstaje wyłącznie przez ręczne **Export Audio**
+(→ `mixed/`) albo destrukcyjne Bounce/Freeze. Stąd podział:
+- **`mixed/master.wav`** (Export Audio) — ścieżka dźwiękowa klipu + globalne triggery.
+- **`bitwig/…/samples/*.wav`** (surowe) — per-instrumentowe triggery animacji „za darmo".
+
+(see origin: docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md,
+docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md)
+
+## Requirements Trace
+
+- R1. „Analizuj" produkuje analizę **dla każdej ścieżki** nagrania, biorąc stemy z
+  hybrydy: preferuj `mixed/stems/`, fallback do `bitwig/<…>/samples/`. Master z
+  `mixed/master.wav` pozostaje osobnym, „master"-owym źródłem. Zero dodatkowej akcji
+  operatora poza dotychczasowym kliknięciem (fermata już woła `analyze-recording`).
+- R2. Nazwy analiz są **sanityzowane** ze stemu źródła (zdjęcie sufiksu Bitwiga
+  `-NN`, normalizacja spacji/`+`/`/` → `_`), tak by `analysis/<clean>_analysis.json`
+  były stabilne i bez znaków uwierających downstream. Kolizja sanityzowanych nazw →
+  **fail-fast** (bez cichego nadpisania), spójnie z polityką poprzedniego planu.
+- R3. Powstaje **manifest `analysis/index.json`** — kontrakt odkrywania: lista źródeł
+  z `role` (`master`/`stem`), `origin` (`mixed`/`bitwig`/`extracted`), czystą
+  `label`, względną ścieżką `source` i `analysis`. cymatic/cinemon mogą enumerować i
+  **rozróżniać** analizy bez globowania ani zgadywania po nazwie.
+- R4. setka-common udostępnia **mały reader manifestu** (typowane wejście kontraktu),
+  by konsumenci czytali `index.json` jednolicie zamiast parsować JSON ad-hoc.
+- R5. Zachowana **zgodność wstecz**: nagrania bez `bitwig/`/`mixed/stems/` analizują
+  się jak dotąd (master z `mixed/`, ostateczny fallback `extracted/`); single-file
+  `beatrix analyze <plik> <out>` i istniejące zachowanie `analyze-recording` (n=1
+  master) bez regresji.
+
+## Scope Boundaries
+
+- **Bez zmian w konsumpcji** w cinemon/cymatic — nie wiążemy stripów/elementów wizualnych
+  z konkretnymi analizami per-track. Dostarczamy tylko *analizy* + *kontrakt odkrywania*
+  (manifest + reader). Pełny per-strip targeting w cinemon to osobna, przyszła robota
+  (świadomie utrzymana granica z poprzednich brainstormów).
+- **Bez zmian w kodzie Rust fermaty** — „Analizuj" już woła `beatrix analyze-recording
+  <recording_path>` (poprzedni plan, Unit 4). Per-track analiza i manifest powstają po
+  stronie Pythona, więc przycisk działa bez modyfikacji frontendu/backendu fermaty.
+- **Bez parsowania `.bwproject`** dla ludzkich nazw ścieżek — odrzucone (format binarny,
+  kruche, sprzęga z wersją Bitwiga). Nazwy bierzemy z nazw plików + sanityzacja. (Nazwy
+  plików — `m_s`, `track 4+git`, `mic+freak` — i tak niosą sens.)
+- **Bez watchera/daemona, bez skryptowania Bitwiga, bez auto-eksportu** — jak w origin.
+- **Bez filtrowania „co jest nagraniem vs zaimportowanym samplem" w `samples/`** —
+  na start analizujemy wszystkie audio w `samples/`; ewentualne wykluczanie
+  bibliotecznych sampli odłożone (patrz Risks/Deferred).
+- Korekta dryfu audio/wideo zostaje ręczna w Blenderze.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **setka-common** `packages/common/src/setka_common/file_structure/specialized/recording.py`
+  - Stałe (l. 63–64): `MIXED_DIRNAME = "mixed"`, `BITWIG_DIRNAME = "bitwig"` — już są.
+  - `RecordingStructure.bitwig_dir` (l. 28), tworzony w `create_structure` (l. 125);
+    `ensure_bitwig_dir` (l. 322+) — `bitwig/` istnieje jako kanoniczny dom.
+  - **`find_analysis_audio_sources(recording_dir)` (l. 364–413)** — sedno do
+    rozszerzenia. Dziś: zbiera `mixed/` + `mixed/stems/` (non-rekurencyjnie, dwa
+    wywołania `find_files_by_type`), fallback `extracted/`, collision-check po
+    `stem.lower()`, zwraca posortowaną listę. Wzorzec do utrzymania.
+  - `get_analysis_file_path` (l. 415+) i `find_audio_analysis` — istniejące helpery
+    nazewnictwa `{stem}_analysis.json`. `ensure_analysis_dir` — dom na `index.json`.
+  - Prymityw skanu: `setka_common.utils.files.find_files_by_type(dir, MediaType.AUDIO)`
+    — **nierekurencyjny** (`iterdir`), sort case-insensitive.
+- **beatrix** `packages/beatrix/src/beatrix/cli/click_cli.py`
+  - `analyze-recording` (l. 124–171): woła resolver, `ensure_analysis_dir`, pętla
+    `_analyze_single_file(audio, analysis_dir, …)` (l. 60: nazwa
+    `{audio_file.stem}_analysis.json`), błędy przez `ClickException`. Tu wchodzi:
+    sanityzacja nazwy wyjścia + zapis `index.json` po pętli.
+  - `analyze <plik> <out>` (l. 97) — **nie ruszać** (zgodność wstecz, R5).
+  - Testy: `packages/beatrix/tests/test_cli_click.py` (`CliRunner`).
+- **fermata** — `process_runner.rs::run_beatrix_analyze` woła
+  `beatrix analyze-recording <recording_path>`; `commands/operations.rs::NextStep::Analyze`
+  woła to raz; `services/status_detector.rs::has_analysis_files` liczy **dowolny** `.json`
+  w `analysis/` → `Analyzed` (dojście `index.json` nieszkodliwe). **Bez zmian.**
+- **Konsumenci (tylko do zrozumienia kontraktu — nie zmieniamy):**
+  - cinemon `config/cinemon_config_generator.py:186-201` — master-aware: dobiera
+    `analysis/<main_audio.stem>_analysis.json`.
+  - cymatic `src/cymatic/cli.py` — `--analysis-file PATH` (jawnie) lub detekcja z
+    `extracted/`; `analysis_loader.load_analysis(config)` czyta ścieżkę z konfiga.
+  - Oba selekcjonują **po nazwie stem / jawnej ścieżce** — manifest `index.json`
+    dostarcza tej nazwy/ścieżki w jednym miejscu (to jest „rozróżnianie").
+
+### Institutional Learnings
+
+- Precedens addytywnego rozszerzania struktury: `docs/plans/2026-06-02-001-...` i
+  `2026-06-04-001-...` (oba completed) — `mkdir(exist_ok=True)`, „purely additive",
+  matryca testów resolvera. Trzymać ten styl.
+- `docs/solutions/` nie ma wpisów dot. file-structure/beatrix — kandydat na nowy wpis
+  po wdrożeniu (gotcha: „bitwig/samples to surowy capture, niezależny od miksu").
+- **Test gotcha (MEMORY):** pytest uruchamiać **po ścieżce**
+  (`uv run --package <pkg> pytest <path>`), nie pełne `uv run pytest` (zepsute);
+  `uv sync --all-packages`.
+
+### External References
+
+- Brak nowych. Model zapisu audio Bitwiga (capture vs Export Audio vs Bounce/Freeze)
+  ustalony w trakcie planowania; udokumentowany w `~/dev/music-box-wiki` (Bitwig Studio).
+
+## Key Technical Decisions
+
+- **Hybryda jako tiery w resolverze, nie nowa komenda.** `find_analysis_audio_sources`
+  rozbudowujemy w dwa tiery: (1) **master/mixed-root** = audio bezpośrednio w `mixed/`;
+  (2) **stems** = `mixed/stems/` jeśli niepuste, **inaczej** `bitwig/…/samples/`.
+  Łączymy, collision-check, sort. Ostateczny fallback `extracted/` zachowany. Rationale:
+  jedno źródło prawdy o „co analizować", beatrix i fermata bez zmian sygnatur (R1, R5).
+- **Sanityzacja nazwy przy wyznaczaniu pliku wyjściowego**, nie przy źródle (plików nie
+  ruszamy). Czysty `label`/stem trafia do `<clean>_analysis.json` i do manifestu.
+  Konsekwencja: konsumenci **nie** wyprowadzą nazwy analizy z surowej nazwy pliku —
+  i właśnie dlatego potrzebny jest manifest jako bridge (spójne z wyborem „sanityzacja
+  + manifest"). Master (`master.wav`) sanityzuje się do `master` (bez zmiany).
+- **Manifest `analysis/index.json` jako kontrakt odkrywania** (nie zmiana nazewnictwa
+  istniejących analiz poza sanityzacją). Pisany przez `analyze-recording` po pętli;
+  zawiera `role`/`origin`/`label`/`source`/`analysis`. Rationale: cymatic/cinemon
+  dostają stabilny, enumerowany spis „co jest dostępne i czym jest" bez globowania
+  i bez wnioskowania po nazwie pliku (R3).
+- **Reader manifestu w setka-common** (nie w każdym konsumencie osobno) — DRY, typowane
+  wejście kontraktu; setka-common to wspólna twarda zależność (R4). Reader **rozwija**
+  ścieżki względne do absolutnych (`recording_dir / value`) — to on, nie konsument,
+  zna konwencję bazy (inaczej każdy konsument odtwarzałby tę samą sklejkę).
+- **`analysis` jest jedynym poprawnym kluczem do pliku analizy.** Kontrakt jawnie mówi
+  konsumentom: **nie** wyprowadzaj nazwy analizy z `main_audio` przez `<stem>_analysis.json`.
+  Powód: sanityzacja rozjeżdża nazwę dla źródeł innych niż `master.wav` (np. surowy stem
+  `track 4+git-24` → analiza `track_4_git_analysis.json`; derywacja po surowym stemie
+  trafiłaby w pustkę i cinemon cicho spadłby na `analysis_files[0]`). **Master jest
+  bezpieczny** (`sanitize("master") == "master"`), więc istniejąca master-aware selekcja
+  cinemon działa bez zmian; ostrzeżenie dotyczy przyszłej selekcji per-stem.
+- **Lokalizacja sampli Bitwiga elastyczna:** szukamy `samples/` w `bitwig/` — najpierw
+  `bitwig/samples/`, potem jeden poziom `bitwig/*/samples/` (Save As do podkatalogu).
+  Bez głębokiej rekursji (uniknięcie wciągnięcia niezwiązanego audio). Rationale: realne
+  nagranie ma `bitwig/samples/`, ale `.bwproject` bywa zapisany w podkatalogu projektu.
+- **Fail-fast na kolizji sanityzowanych nazw** (jak w poprzednim planie) — dwa źródła →
+  ten sam `<clean>_analysis.json` → przerwij z czytelnym błędem wskazującym kolidujące
+  pliki. Bez cichego nadpisania.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Źródło stemów?** → Hybryda: `mixed/stems/` preferowane, fallback `bitwig/…/samples/`.
+  Master nadal z `mixed/master.wav`.
+- **Skąd sensowne nazwy?** → Sanityzacja nazw plików (bez parsowania `.bwproject`) +
+  manifest `index.json` jako kontrakt odkrywania.
+- **Zakres?** → Analizy per-track + manifest + reader. Bez wiązania konsumpcji
+  (per-strip targeting) w cinemon/cymatic.
+- **Czy fermata wymaga zmian?** → Nie; „Analizuj" już woła `analyze-recording`.
+- **Czy ruszać master flow / single-file `analyze`?** → Nie; czysto addytywne (R5).
+- **Baza ścieżek w manifeście i rozwijanie do absolutnych?** → `source` i `analysis` oba
+  względne do `recording_dir` (z prefiksem katalogu); reader rozwija przez
+  `resolved_analysis_path(recording_dir)`. (decyzja z walidacji architektonicznej)
+- **Co konsument dostaje do walidacji zgodności ścieżek?** → `duration`+`sample_rate`
+  w każdym wpisie manifestu (manifest samowystarczalny).
+- **Lookup po etykiecie w readerze?** → Tak, `by_label(label)` jest częścią kontraktu.
+
+### Deferred to Implementation
+
+- **Filtrowanie `samples/`** — czy wykluczać zaimportowane/biblioteczne sample (nie-capture)
+  z analizy. Na MVP analizujemy wszystkie audio w `samples/`; reguła wykluczeń odłożona.
+- **Czyszczenie stale `*_analysis.json`/`index.json`** przy ponownym „Analizuj" gdy zmienił
+  się zestaw źródeł — ocenić przy implementacji (czy nadpisywać/czyścić osierocone).
+- **Dokładny kształt `role` przy fallbacku `extracted/`** (gdy brak `mixed/` i `bitwig/`) —
+  proponowane `role: "main"`/`origin: "extracted"`; doprecyzować w testach.
+- **Wersjonowanie schematu manifestu** (`version`) — start `1`; polityka ewolucji odłożona.
+
+## High-Level Technical Design
+
+> *Ilustruje zamierzony kształt rozwiązania i jest wskazówką do recenzji, nie specyfikacją
+> implementacji. Implementujący traktuje to jako kontekst, nie kod do odtworzenia.*
+
+**Tiery resolvera (źródła do analizy):**
+
+```
+find_analysis_audio_sources(recording_dir):
+  master_tier = audio bezpośrednio w mixed/        # zwykle mixed/master.wav
+  stems_tier  = audio w mixed/stems/  (jeśli niepuste)
+                else audio w <bitwig samples dir>  (fallback)
+  sources = master_tier + stems_tier
+  if sources: collision-check(po sanitize(stem)); return sorted(sources)
+  else: return sorted(audio w extracted/)          # zgodność wstecz
+```
+
+**Manifest `analysis/index.json` (kontrakt odkrywania; WSZYSTKIE ścieżki względne do
+katalogu nagrania — jednolita baza dla `source` i `analysis`):**
+
+```jsonc
+{
+  "version": 1,
+  "sources": [
+    { "role": "master", "origin": "mixed",  "label": "master",
+      "source": "mixed/master.wav",
+      "analysis": "analysis/master_analysis.json",
+      "duration": 182.4, "sample_rate": 44100 },
+    { "role": "stem",   "origin": "bitwig", "label": "m_s",
+      "source": "bitwig/samples/m_s-24.wav",
+      "analysis": "analysis/m_s_analysis.json",
+      "duration": 182.4, "sample_rate": 44100 },
+    { "role": "stem",   "origin": "bitwig", "label": "track_4_git",
+      "source": "bitwig/samples/track 4+git-24.wav",
+      "analysis": "analysis/track_4_git_analysis.json",
+      "duration": 182.4, "sample_rate": 48000 }
+  ]
+}
+```
+
+Konsument (cymatic/cinemon, w przyszłej fazie) robi: wczytaj `index.json` → wybierz wpis
+po `role`/`label` → użyj **`analysis` jako jedynego klucza** do pliku analizy (reader
+rozwija względną ścieżkę do absolutnej). To jest cała „łatwość odnajdywania i rozróżniania".
+
+**Dwie świadome decyzje kontraktu (z walidacji architektonicznej):**
+- **Jednolita baza ścieżek:** `source` i `analysis` są oba względne do `recording_dir`
+  (`analysis/<plik>`, nie goła nazwa) — jedna reguła rozwijania `recording_dir / value`
+  działa dla obu i likwiduje klasę błędów asymetrii prefiksu.
+- **`duration`/`sample_rate` w każdym wpisie** (beatrix już je emituje) — manifest jest
+  samowystarczalny do walidacji zgodności master↔per-track (różne SR/długości stemów
+  z `bitwig/samples/`) bez otwierania N plików JSON.
+
+> **Uwaga dla przyszłej fazy konsumpcji:** `label` NIE jest gwarantowanym stabilnym
+> identyfikatorem między uruchomieniami — zależy od nazwy pliku w Bitwigu. Per-strip
+> targeting (wiązanie audio-stem ↔ wideo-strip) nie powinien budować trwałego mapowania
+> na `label`; to przyszła robota i wymaga osobnego, stabilnego id (świadomie poza zakresem,
+> YAGNI — nie dodajemy pustego pola `id` bez konsumenta).
+
+## Implementation Units
+
+- [ ] **Unit 1: `sanitize_stem_name` — czysta nazwa stemu**
+
+**Goal:** Deterministyczna funkcja zamieniająca surową nazwę pliku Bitwiga na stabilny,
+bezpieczny stem (label) dla nazwy analizy i manifestu.
+
+**Requirements:** R2
+
+**Dependencies:** Brak.
+
+**Files:**
+- Modify: `packages/common/src/setka_common/file_structure/specialized/recording.py`
+  (lub nowy mały moduł `setka_common/utils/naming.py` jeśli czytelniej — decyzja przy
+  implementacji; preferuj umieszczenie blisko resolvera)
+- Test: `packages/common/tests/test_recording_structure.py` (lub `tests/test_naming.py`)
+
+**Approach:**
+- `sanitize_stem_name(name: str) -> str`: zdejmij rozszerzenie jeśli podano pełną nazwę
+  (przyjmij już-stem lub pełną — ustalić), zdejmij **sufiks Bitwiga** `-<cyfry>` na końcu
+  (`track 4+git-24` → `track 4+git`), zamień separatory/znaki problematyczne
+  (spacja, `+`, `/`, `\`) na `_`, scal wielokrotne `_`, przytnij brzegowe `_`, lower-case
+  opcjonalnie (ustalić — proponowane: zachować wielkość liter, tylko normalizacja znaków).
+- Idempotentność: `sanitize(sanitize(x)) == sanitize(x)`.
+- Pusty wynik (np. nazwa same znaki spec.) → fail-fast `ValueError` (czytelny komunikat).
+
+**Patterns to follow:** styl pojedynczych helperów w `setka_common/utils/files.py`.
+
+**Test scenarios:**
+- Happy path: `"track 4+git-24"` → `"track_4_git"`.
+- Happy path: `"m_s-24"` → `"m_s"`; `"track 5_6+mic+freak-24"` → `"track_5_6_mic_freak"`.
+- Happy path: `"master"` → `"master"` (bez zmian; brak sufiksu liczbowego).
+- Edge case: brak sufiksu `-NN` → tylko normalizacja znaków.
+- Edge case: idempotentność (drugie wywołanie nie zmienia wyniku).
+- Edge case: kropki/rozszerzenie w wejściu obsłużone zgodnie z ustaloną sygnaturą.
+- Error path: nazwa redukująca się do pustego stringu → `ValueError`.
+
+**Execution note:** Zacznij od failującego testu tabelarycznego (mapowania nazw realnych
+z `bitwig/samples/`).
+
+**Verification:** Testy zielone (po ścieżce); realne nazwy z nagrania mapują się czysto.
+
+---
+
+- [ ] **Unit 2: Lokalizator sampli Bitwiga + hybrydowy resolver źródeł**
+
+**Goal:** `find_analysis_audio_sources` zwraca master z `mixed/` + stemy z
+`mixed/stems/` **lub** (fallback) z `bitwig/…/samples/`, z collision-check po
+sanityzowanym stemie. Zgodność wstecz zachowana.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** Unit 1 (sanityzacja do collision-check).
+
+**Files:**
+- Modify: `packages/common/src/setka_common/file_structure/specialized/recording.py`
+- Test: `packages/common/tests/test_recording_structure.py`
+
+**Approach:**
+- Dodaj `find_bitwig_sample_sources(recording_dir) -> list[Path]`: zlokalizuj katalog
+  `samples/` w `bitwig/` — najpierw `bitwig/samples/`, w razie braku przeskanuj jeden
+  poziom `bitwig/*/samples/`; zbierz audio przez `find_files_by_type(..., AUDIO)`
+  (non-rekurencyjnie). Brak `bitwig/`/`samples/` → `[]`.
+- Refaktor `find_analysis_audio_sources` na tiery (patrz High-Level Technical Design):
+  master-tier = audio w `mixed/` (root); stems-tier = `mixed/stems/` jeśli niepuste,
+  inaczej `find_bitwig_sample_sources(...)`. Połącz, **collision-check po
+  `sanitize_stem_name(p.stem)`** (nie po surowym stemie), sort case-insensitive.
+- Zachowaj ostateczny fallback `extracted/` (gdy master-tier i stems-tier puste).
+- Stałe katalogów z managera (`MIXED_DIRNAME`/`BITWIG_DIRNAME`/`EXTRACTED_DIRNAME`),
+  bez hardkodu. `"stems"` jak dziś (literał już w kodzie).
+
+**Patterns to follow:** istniejące `find_analysis_audio_sources` (l. 364–413) i jego
+collision-check; `find_files_by_type` non-rekurencyjne (dlatego osobne skany katalogów).
+
+**Test scenarios:**
+- Happy path: `mixed/master.wav` + `mixed/stems/{a,b}.wav` → master + 2 stemy (bitwig
+  zignorowany, bo `mixed/stems/` niepuste).
+- Happy path (nowy): `mixed/master.wav` + `mixed/stems/` puste/brak + `bitwig/samples/`
+  z 3 wav → master + 3 stemy z bitwig.
+- Happy path (czysto bitwig): brak `mixed/`, `bitwig/samples/` z N wav → N źródeł
+  (master-tier pusty, stems-tier = bitwig). *(Uwaga: jeśli równolegle brak mastera,
+  manifest oznaczy je `role: stem`.)*
+- Edge case: `bitwig/<proj>/samples/` (jeden poziom zagnieżdżenia) wykryte.
+- Edge case: `mixed/stems/` niepuste **wygrywa** nad `bitwig/samples/` (fallback nie odpala).
+- Edge case: brak `mixed/` i `bitwig/`, `extracted/` ma pliki → fallback `extracted/`
+  (zgodność wstecz).
+- Edge case: wszystko puste/nieobecne → `[]`.
+- Error path: dwa źródła sanityzują się do tej samej nazwy (np. `track 4+git-24.wav`
+  i `track_4_git.wav`) → `ValueError` z oboma plikami, bez nadpisania.
+- Edge case: kolejność deterministyczna (sort, case-insensitive).
+
+**Verification:** Testy resolvera zielone; na realnym katalogu nagrania resolver zwraca
+master + 6 ścieżek z `bitwig/samples/` gdy `mixed/stems/` puste.
+
+---
+
+- [ ] **Unit 3: beatrix `analyze-recording` — sanityzowane nazwy + zapis `index.json`**
+
+**Goal:** Jedno wywołanie analizuje wszystkie źródła, pisząc `<clean>_analysis.json`
+per ścieżka oraz manifest `analysis/index.json` z rolami/etykietami/ścieżkami.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** Unit 1 (sanityzacja), Unit 2 (resolver hybrydowy).
+
+**Files:**
+- Modify: `packages/beatrix/src/beatrix/cli/click_cli.py`
+- Test: `packages/beatrix/tests/test_cli_click.py`
+- (Bez zmian w `pyproject.toml`.)
+
+**Approach:**
+- W `analyze-recording`: dla każdego źródła wyznacz `label = sanitize_stem_name(stem)`
+  i nazwę wyjścia `<label>_analysis.json` (zamiast surowego `{stem}_analysis.json`).
+  Przekaż jawną nazwę wyjścia do `_analyze_single_file` (rozszerz o opcjonalny
+  `output_name`/`label`, zachowując dotychczasowe zachowanie dla single-file `analyze`).
+- Wyznacz `role`/`origin` per źródło z jego lokalizacji: w `mixed/` root → `master`/`mixed`;
+  w `mixed/stems/` → `stem`/`mixed`; w `bitwig/…/samples/` → `stem`/`bitwig`; w `extracted/`
+  → `main`/`extracted` (fallback). Zbieraj wpisy podczas pętli.
+- Po pętli zapisz `analysis/index.json` (`version: 1`, `sources: [...]`). Pola wpisu:
+  `role`/`origin`/`label`/`source`/`analysis` (**oba** `source` i `analysis` względne do
+  `recording_dir`, z prefiksem katalogu — `analysis/<label>_analysis.json`, nie goła nazwa)
+  oraz `duration`/`sample_rate` wzięte z właśnie wyliczonej analizy (beatrix je zwraca w
+  JSON-ie). Zapis atomowy-ish (write + rename) opcjonalnie.
+- Pustą listę źródeł i kolizję nadal sygnalizuj `ClickException` (zasila błąd w UI fermaty
+  przez stderr — mechanizm z poprzedniego planu, bez zmian).
+
+**Patterns to follow:** obecny `analyze-recording`/`_analyze_single_file` (l. 60, 124–171);
+testy `CliRunner`; nazewnictwo `{stem}_analysis.json` jako baza.
+
+**Test scenarios:** (przez `CliRunner`)
+- Happy path: katalog z `mixed/master.wav` + `bitwig/samples/{m_s-24,track 4+git-24}.wav`
+  (puste `mixed/stems/`) → powstają `master_analysis.json`, `m_s_analysis.json`,
+  `track_4_git_analysis.json` **oraz** `index.json`.
+- Integration: `index.json` ma 3 wpisy z poprawnymi `role` (`master` + 2× `stem`),
+  `origin` (`mixed` + 2× `bitwig`), `label` (sanityzowane), względnymi z prefiksem
+  `source`/`analysis` (`analysis/<label>_analysis.json`) oraz `duration`/`sample_rate`
+  zgodnymi z wartościami z wygenerowanych analiz.
+- Happy path: `mixed/stems/` niepuste → wpisy `origin: mixed`, bitwig pominięty.
+- Edge case: fallback `extracted/` (brak `mixed/`/`bitwig/`) → wpisy `role: main`/`origin: extracted`.
+- Error path: brak audio → niezerowy exit + komunikat (bez `index.json`).
+- Error path: kolizja sanityzowanych nazw → niezerowy exit, żaden plik nie nadpisany,
+  brak/niezmieniony `index.json`.
+- Edge case: `--beat-division`/`--min-onset-interval` propagują do każdej analizy.
+- Regression: single-file `analyze <plik> <out>` bez zmian (sygnatura/zachowanie).
+- Regression: n=1 (sam `mixed/master.wav`) → `master_analysis.json` + `index.json`
+  z jednym wpisem `role: master`.
+
+**Execution note:** Zacznij od failującego testu kontraktu „N źródeł → N analiz +
+poprawny index.json".
+
+**Verification:** `test_cli_click.py` zielone; jedno wywołanie generuje komplet analiz
++ manifest; single-file bez regresji.
+
+---
+
+- [ ] **Unit 4: Reader manifestu w setka-common (kontrakt dla konsumentów)**
+
+**Goal:** Typowane, jednolite czytanie `analysis/index.json`, by cymatic/cinemon (w
+przyszłości) nie parsowały JSON ad-hoc.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 3 (kształt manifestu ustalony) — może powstać równolegle do testów
+Unit 3, byle schema była zgodna.
+
+**Files:**
+- Modify: `packages/common/src/setka_common/file_structure/specialized/recording.py`
+  (lub dedykowany `setka_common/file_structure/analysis_index.py`)
+- Test: `packages/common/tests/test_recording_structure.py` (lub `tests/test_analysis_index.py`)
+
+**Approach:**
+- Lekki dataclass `AnalysisIndexEntry(role, origin, label, source, analysis, duration,
+  sample_rate)` i `AnalysisIndex(version, sources)`.
+- `load_analysis_index(recording_dir) -> AnalysisIndex | None`: czyta
+  `analysis/index.json`; brak pliku → `None` (zgodność wstecz dla nagrań bez manifestu).
+- Helpery wygody: `entries_by_role(role)`, `master()` (pierwszy/jedyny `master`),
+  `stems()` oraz **`by_label(label)`** (selekcja po etykiecie — to deklarowany klucz
+  rozróżniania, więc lookup jest częścią kontraktu, nie filtrowaniem po stronie konsumenta).
+- **Rozwiązywanie ścieżek — ZDECYDOWANE (nie opcja):** pole przechowuje wartość względną,
+  a wpis udostępnia metodę `resolved_analysis_path(recording_dir) -> Path` (i analogicznie
+  dla `source`), składającą `recording_dir / value`. To jedyna droga, którą cymatic
+  `--analysis-file` dostaje istniejącą, absolutną ścieżkę; bez tego R4 (DRY) nie jest
+  spełnione (każdy konsument sklejałby ścieżkę sam).
+- Walidacja: brak wymaganego pola / zły `version` → czytelny `ValueError` (fail-fast).
+
+**Patterns to follow:** styl dataclass `RecordingStructure`; istniejące helpery
+ścieżek w managerze.
+
+**Test scenarios:**
+- Happy path: poprawny `index.json` → `AnalysisIndex` z N wpisami; `master()` zwraca
+  wpis `role: master`; `stems()` zwraca resztę.
+- Happy path: `by_label("track_4_git")` zwraca właściwy wpis; nieznana etykieta → `None`.
+- Happy path: `resolved_analysis_path(recording_dir)` zwraca **absolutną, istniejącą**
+  ścieżkę (`recording_dir/analysis/<label>_analysis.json`) — gotową pod cymatic `--analysis-file`.
+- Edge case: brak `index.json` → `None` (bez wyjątku).
+- Edge case: `sources: []` → pusty `AnalysisIndex`, `master()` → `None`.
+- Edge case: wpis bez `duration`/`sample_rate` (starszy manifest) — reader nie wybucha
+  (pola opcjonalne/`None`), zgodność wprzód.
+- Error path: brakujące pole wymagane/nieznany `version` → `ValueError`.
+- Integration: round-trip — manifest zapisany przez `analyze-recording` (Unit 3) czyta
+  się readerem bez utraty informacji (test na realnie wygenerowanym pliku).
+
+**Verification:** Testy readera zielone; round-trip z Unit 3 spójny.
+
+---
+
+- [ ] **Unit 5: Dokumentacja — CLAUDE.md, wiki, kontrakt manifestu**
+
+**Goal:** Workflow i kontrakt odkrywania są udokumentowane, by operator i przyszli
+konsumenci wiedzieli, skąd biorą się analizy i jak je rozróżnić.
+
+**Requirements:** R1, R3 (dokumentacyjnie)
+
+**Dependencies:** Unit 1–4 (opis musi odpowiadać zachowaniu).
+
+**Files:**
+- Modify: `CLAUDE.md` (sekcja file-structure: zaznaczyć, że `bitwig/…/samples/` to
+  źródło stemów fallback dla analizy; opis `analysis/index.json`).
+- Modify: `~/dev/music-box-wiki` (workflow „Post-prod teledysk": „Analizuj" analizuje
+  master + per-track z `bitwig/samples/`; sekcja Bitwig: capture vs Export Audio).
+- (Opcjonalnie) Create: `docs/solutions/` wpis — gotcha „bitwig/samples = surowy capture
+  niezależny od miksu; per-track triggery za darmo".
+
+**Approach:**
+- Krótko: drzewo struktury z adnotacją źródeł analizy; przykład `index.json` i jak
+  konsument go czyta (`load_analysis_index`).
+- Nie dokumentować per-strip targetingu jako gotowego — to wciąż przyszła robota.
+
+**Test scenarios:** *(dokumentacja — brak testów automatycznych; weryfikacja przeglądem)*
+
+**Verification:** Przegląd: opis zgodny z zachowaniem `analyze-recording`; przykład
+`index.json` zgodny ze schematem z Unit 3/4.
+
+## System-Wide Impact
+
+- **Interaction graph:** „Analizuj" (fermata, **bez zmian**) → `beatrix analyze-recording`
+  → `find_analysis_audio_sources` (tiery: mixed + stems|bitwig) → per-track
+  `<clean>_analysis.json` + `analysis/index.json` → `status_detector.has_analysis_files`
+  (dowolny `.json` → `Analyzed`, działa) → (przyszłość) cymatic/cinemon czytają manifest
+  przez `load_analysis_index`.
+- **Error propagation:** brak audio / kolizja → `ClickException` → stderr subprocessu →
+  `Err(String)` w komendzie Tauri → `operationState.error` → render w `RecordingList`
+  (ścieżka błędu naprawiona w poprzednim planie; tu bez zmian).
+- **State lifecycle risks:** ponowne „Analizuj" przy zmienionym zestawie źródeł może
+  zostawić **osierocone** `*_analysis.json`/nieaktualny `index.json` (stale). Manifest
+  łagodzi (źródło prawdy o aktualnym zestawie), ale czyszczenie osieroconych plików
+  odłożone (Deferred). Konsumenci powinni ufać `index.json`, nie globowi.
+- **API surface parity:** nowe: `sanitize_stem_name`, `find_bitwig_sample_sources`,
+  `load_analysis_index`, manifest `index.json`. Bez zmian: single-file `beatrix analyze`,
+  sygnatury fermaty, kod cinemon/cymatic.
+- **Integration coverage:** testy Python (CliRunner + tmp_path z atrapą `bitwig/samples/`,
+  `mixed/`, `extracted/`) pokrywają tiery, sanityzację, manifest i round-trip readera.
+  Realna analiza beatrix (librosa) niewymagana w testach CLI poza istniejącym wzorcem.
+
+## Risks & Dependencies
+
+- **`samples/` może zawierać nie-capture audio** (zaimportowane/biblioteczne sample) →
+  zostaną zanalizowane jako „stem". MVP akceptuje; filtrowanie odłożone (Deferred).
+  Ryzyko: nadmiarowe analizy + zaśmiecony manifest. Łagodzi: operator trzyma w projekcie
+  tylko nagrane ścieżki.
+- **Zmiana nazwy analiz (sanityzacja) vs dotychczasowa derywacja po stemie** — gdyby
+  ktoś (lub stary skrypt) wyprowadzał nazwę analizy z surowej nazwy pliku, nie trafi.
+  Dlatego manifest jest kontraktem; master (`master`) niezmieniony, więc istniejący
+  master-aware cinemon działa dalej. **Konkretny footgun:** cinemon master-aware dopasowuje
+  po stemie *dowolnego* `--main-audio` (`<stem>_analysis.json`), nie tylko `master.wav`.
+  Dla nie-masterowego `main_audio` o nazwie ze znakami normalizowanymi przez `sanitize`
+  (spacja/`+`/sufiks `-NN`) derywacja rozjedzie się z sanityzowaną nazwą analizy →
+  cinemon cicho spadnie na `analysis_files[0]`. Mityguje: kontraktowa reguła „selekcja
+  przez pole `analysis` z manifestu, nie przez derywację" (Key Decisions). Pełne
+  podpięcie tej reguły w cinemon to przyszła faza konsumpcji (poza zakresem).
+- **Stale pliki analiz** przy ponownym uruchomieniu — patrz State lifecycle.
+- **Sekwencja:** Unit 2 zależy od Unit 1; Unit 3 od Unit 1+2; Unit 4 od kształtu z Unit 3;
+  Unit 5 na końcu.
+- **Test gotcha:** pytest po ścieżce (`uv run --package <pkg> pytest <path>`), nie pełne
+  `uv run pytest`; `uv sync --all-packages`.
+
+## Documentation / Operational Notes
+
+- Po wdrożeniu: CLAUDE.md (file-structure + `index.json`) i `~/dev/music-box-wiki`
+  (workflow „Post-prod teledysk", Bitwig capture vs Export Audio).
+- Kandydat na wpis `docs/solutions/`: „bitwig/samples = surowy capture, per-track
+  triggery animacji za darmo; mixed/ = polerowany Export Audio".
+
+## Sources & References
+
+- **Origin documents:**
+  [docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md](docs/brainstorms/2026-06-04-bitwig-master-to-beatrix-requirements.md),
+  [docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md](docs/brainstorms/2026-06-02-bitwig-mixed-audio-pipeline-requirements.md)
+- Poprzednik (completed): `docs/plans/2026-06-04-001-feat-bitwig-master-to-beatrix-plan.md`
+- Kod: `recording.py` (`find_analysis_audio_sources` l.364–413, `BITWIG_DIRNAME`),
+  `beatrix/cli/click_cli.py` (`analyze-recording` l.124–171, `_analyze_single_file` l.60),
+  `cinemon/config/cinemon_config_generator.py:186-201`, `cymatic/src/cymatic/cli.py`,
+  `cymatic/src/cymatic/analysis_loader.py`
+- Realne nagranie: `/home/wojtas/Wideo/obs/2026-06-04 15-15-01/` (`bitwig/samples/` z 6
+  ścieżkami, `mixed/master.wav`, `analysis/master_analysis.json`)

--- a/docs/solutions/2026-06-04-bitwig-samples-raw-capture-vs-mixed-export.md
+++ b/docs/solutions/2026-06-04-bitwig-samples-raw-capture-vs-mixed-export.md
@@ -1,0 +1,59 @@
+---
+title: "bitwig/samples/ = surowy capture niezależny od miksu — per-track triggery animacji za darmo"
+date: 2026-06-04
+tags: [bitwig, audio, analysis, beatrix, per-track, stems, pipeline, setka-common]
+component: audio-analysis
+status: resolved
+related_plans:
+  - docs/plans/2026-06-04-003-feat-bitwig-per-track-analysis-plan.md
+---
+
+# bitwig/samples/ — surowy capture vs mixed/ — przetworzony eksport
+
+## Symptom / kontekst
+
+Pipeline Setka ma dwa miejsca z plikami audio per-instrument:
+- `bitwig/samples/` — pliki pojawiające się automatycznie po nagraniu multitrack w Bitwigu
+- `mixed/stems/` — pliki eksportowane ręcznie przez `File → Export Audio`
+
+Pytanie: które z nich nadają się do analizy audio w Beatrixie? Czy muszę eksportować stemy, żeby dostać per-track analizę?
+
+## Przyczyna (rdzeń)
+
+**Efekty, EQ i głośności ścieżek w Bitwigu są niededestrukcyjne** — zapisane w `.bwproject`, nie w plikach audio. Pliki w `bitwig/samples/` to zawsze **surowy capture** z chwili nagrywania. Przetworzony (z efektami, EQ, głośnością) dźwięk istnieje tylko w pamięci podczas odtwarzania projektu lub po jawnym Bounce/Export Audio.
+
+Konsekwencja: `bitwig/samples/*.wav` to czyste surowe przebiegi per-instrument — i właśnie to jest wystarczające do wykrywania bitów, energii i segmentów per-track (Beatrix potrzebuje charakteru rytmicznego ścieżki, nie jej finalnej brzmienia).
+
+## Hierarchia źródeł w beatrix analyze-recording
+
+```
+1. mixed/master.wav      → role=master, origin=mixed  (finalny mix z efektami)
+2. mixed/stems/*.wav     → role=stem,   origin=mixed  (przetworzone stemy)
+3. bitwig/samples/*.wav  → role=stem,   origin=bitwig (surowy capture — fallback)
+4. extracted/*.wav       → role=main,   origin=extracted (audio z OBS — ostatni fallback)
+```
+
+`beatrix analyze-recording <dir>` przechodzi przez tę hierarchię automatycznie i zapisuje `analysis/index.json` (manifest) + `analysis/<track>_analysis.json` per ścieżka.
+
+## Rozwiązanie
+
+Nie trzeba eksportować stemów żeby dostać per-track analizę. `bitwig/samples/` wystarczą jako fallback. Jeśli zależy ci na dokładności (np. po wyciszeniu basu w projekcie — nie chcesz żeby basy triggerowały animacje), wyeksportuj stemy do `mixed/stems/` — wtedy to one mają pierwszeństwo.
+
+## Reguły operacyjne
+
+- **Nie czyść `bitwig/samples/`** po nagraniu — to źródło per-track analizy dopóki nie masz stemów
+- **Export stemów = lepsza jakość analizy** (z efektami) ale nie jest obowiązkowy
+- **`analysis/index.json`** to kontrakt odkrywania — czytaj przez `load_analysis_index()` z setka-common, nie skanuj `analysis/` ręcznie
+- Nazwy plików w `samples/` są sanityzowane przy tworzeniu wpisów index (`track 4+git-24.wav` → `track_4_git_analysis.json`)
+
+## Weryfikacja
+
+```bash
+beatrix analyze-recording "/path/to/recording"
+cat "/path/to/recording/analysis/index.json"
+# Powinno zawierać wpisy z origin="bitwig" gdy brak mixed/stems/
+```
+
+## Powiązania
+
+- [Plan 003 — per-track analysis](../plans/2026-06-04-003-feat-bitwig-per-track-analysis-plan.md)

--- a/packages/beatrix/src/beatrix/cli/click_cli.py
+++ b/packages/beatrix/src/beatrix/cli/click_cli.py
@@ -8,6 +8,7 @@ This module provides a more robust and user-friendly command-line interface
 for audio analysis, replacing the manual sys.argv parsing approach.
 """
 
+import json
 import logging
 from pathlib import Path
 
@@ -15,7 +16,10 @@ import click
 
 from ..core.audio_analyzer import AudioAnalyzer
 from .. import __version__
-from setka_common.file_structure.specialized.recording import RecordingStructureManager
+from setka_common.file_structure.specialized.recording import (
+    RecordingStructureManager,
+    sanitize_stem_name,
+)
 
 
 @click.group(
@@ -49,15 +53,19 @@ def _analyze_single_file(
     output_dir: Path,
     beat_division: int,
     min_onset_interval: float,
-) -> Path:
+    output_name: str | None = None,
+) -> tuple[Path, dict]:
     """Analyze a single audio file and save results to output_dir.
 
-    Returns the path to the written analysis file.
+    Returns a (output_path, analysis_result) tuple.
+    When output_name is provided, uses <output_name>_analysis.json as the
+    output filename; otherwise falls back to {audio_file.stem}_analysis.json.
     Raises click.ClickException on any failure.
     """
     logger = logging.getLogger(__name__)
 
-    output_filename = f"{audio_file.stem}_analysis.json"
+    label = output_name if output_name is not None else audio_file.stem
+    output_filename = f"{label}_analysis.json"
     output_path = output_dir / output_filename
 
     logger.info(f"Analyzing audio file: {audio_file}")
@@ -76,7 +84,7 @@ def _analyze_single_file(
 
     click.echo(f"Analysis complete: {output_path}")
     logger.info(f"Analysis completed successfully: {output_path}")
-    return output_path
+    return output_path, analysis_result
 
 
 @cli.command()
@@ -110,7 +118,7 @@ def analyze(audio_file, output_dir, beat_division, min_onset_interval):
         # Ensure output directory exists
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        _analyze_single_file(audio_file, output_dir, beat_division, min_onset_interval)
+        _analyze_single_file(audio_file, output_dir, beat_division, min_onset_interval)  # noqa: result unused
 
     except FileNotFoundError as e:
         click.echo(f"Error: Audio file not found: {audio_file}", err=True)
@@ -119,6 +127,38 @@ def analyze(audio_file, output_dir, beat_division, min_onset_interval):
         logger.error(f"Analysis failed: {e}")
         click.echo(f"Error: Audio analysis failed: {e}", err=True)
         raise click.ClickException(f"Audio analysis failed: {e}")
+
+
+def _determine_role_and_origin(
+    audio_file: Path, recording_dir: Path
+) -> tuple[str, str]:
+    """Determine role and origin of an audio source based on its location.
+
+    Location rules:
+    - directly in mixed/        → role="master", origin="mixed"
+    - in mixed/stems/           → role="stem",   origin="mixed"
+    - anywhere under bitwig/    → role="stem",   origin="bitwig"
+    - in extracted/             → role="main",   origin="extracted"
+
+    Falls back to role="main", origin="extracted" for unrecognised paths.
+    """
+    try:
+        rel = audio_file.relative_to(recording_dir)
+    except ValueError:
+        return "main", "extracted"
+
+    parts = rel.parts
+    if parts[0] == RecordingStructureManager.MIXED_DIRNAME:
+        if len(parts) >= 3 and parts[1] == "stems":
+            return "stem", "mixed"
+        if len(parts) == 2:
+            return "master", "mixed"
+    if parts[0] == RecordingStructureManager.BITWIG_DIRNAME:
+        return "stem", "bitwig"
+    if parts[0] == RecordingStructureManager.EXTRACTED_DIRNAME:
+        return "main", "extracted"
+
+    return "main", "extracted"
 
 
 @cli.command("analyze-recording")
@@ -142,7 +182,9 @@ def analyze_recording(recording_dir, beat_division, min_onset_interval):
     RECORDING_DIR: Path to the recording directory
 
     Prefers mixed/ (master + stems) over extracted/ as audio source.
-    Writes one {stem}_analysis.json per audio file into analysis/.
+    Writes one <label>_analysis.json per audio file into analysis/ and
+    saves a manifest analysis/index.json with role/origin/label/source/analysis
+    for each source.
     """
     logger = logging.getLogger(__name__)
 
@@ -161,14 +203,42 @@ def analyze_recording(recording_dir, beat_division, min_onset_interval):
 
     analysis_dir = RecordingStructureManager.ensure_analysis_dir(recording_dir)
 
+    manifest_sources = []
     for audio_file in audio_sources:
+        label = sanitize_stem_name(audio_file.stem)
+        role, origin = _determine_role_and_origin(audio_file, recording_dir)
         try:
-            _analyze_single_file(
-                audio_file, analysis_dir, beat_division, min_onset_interval
+            output_path, analysis_result = _analyze_single_file(
+                audio_file,
+                analysis_dir,
+                beat_division,
+                min_onset_interval,
+                output_name=label,
             )
         except Exception as e:
             logger.error(f"Analysis failed for {audio_file}: {e}")
             raise click.ClickException(f"Audio analysis failed for '{audio_file}': {e}")
+
+        manifest_sources.append(
+            {
+                "role": role,
+                "origin": origin,
+                "label": label,
+                "source": audio_file.relative_to(recording_dir).as_posix(),
+                "analysis": output_path.relative_to(recording_dir).as_posix(),
+                "duration": analysis_result.get("duration"),
+                "sample_rate": analysis_result.get("sample_rate"),
+            }
+        )
+
+    index_path = analysis_dir / "index.json"
+    index_path.write_text(
+        json.dumps(
+            {"version": 1, "sources": manifest_sources}, indent=2, ensure_ascii=False
+        ),
+        encoding="utf-8",
+    )
+    logger.info(f"Manifest written: {index_path}")
 
 
 def main():

--- a/packages/beatrix/tests/test_cli_click.py
+++ b/packages/beatrix/tests/test_cli_click.py
@@ -354,3 +354,232 @@ class TestAnalyzeRecordingCommand:
 
             assert result.exit_code == 0
             mock_analyzer.analyze_for_animation.assert_called_once()
+
+    def test_master_only_produces_index_json(self, tmp_path):
+        """Regression n=1: master.wav → master_analysis.json + index.json with one entry."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        _write_wav(mixed_dir / "master.wav")
+
+        result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        index_file = tmp_path / "analysis" / "index.json"
+        assert index_file.exists(), f"index.json missing; output: {result.output}"
+
+        import json
+
+        index = json.loads(index_file.read_text())
+        assert index["version"] == 1
+        assert len(index["sources"]) == 1
+        entry = index["sources"][0]
+        assert entry["role"] == "master"
+        assert entry["origin"] == "mixed"
+        assert entry["label"] == "master"
+        assert entry["source"] == "mixed/master.wav"
+        assert entry["analysis"] == "analysis/master_analysis.json"
+        assert "duration" in entry
+        assert "sample_rate" in entry
+
+    def test_bitwig_samples_produce_index_json(self, tmp_path):
+        """Happy path: mixed/master.wav + bitwig/samples/{m_s-24,track 4+git-24}.wav
+        → index.json with 3 entries, correct roles/origins/labels/paths."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        bitwig_samples_dir = tmp_path / "bitwig" / "samples"
+        bitwig_samples_dir.mkdir(parents=True)
+
+        with patch("beatrix.cli.click_cli.AudioAnalyzer") as mock_analyzer_class:
+            mock_analyzer = Mock()
+            mock_analyzer_class.return_value = mock_analyzer
+            mock_analyzer.analyze_for_animation.return_value = {
+                "duration": 10.0,
+                "sample_rate": 44100,
+                "tempo": {"bpm": 120.0},
+                "animation_events": {"beats": []},
+            }
+
+            _write_wav(mixed_dir / "master.wav")
+            _write_wav(bitwig_samples_dir / "m_s-24.wav")
+            _write_wav(bitwig_samples_dir / "track 4+git-24.wav")
+
+            result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+            assert result.exit_code == 0, result.output
+
+        # Verify index.json — the manifest written by analyze-recording
+        import json
+
+        analysis_dir = tmp_path / "analysis"
+        index_file = analysis_dir / "index.json"
+        assert index_file.exists(), "index.json missing"
+        index = json.loads(index_file.read_text())
+        assert index["version"] == 1
+        assert len(index["sources"]) == 3
+
+        by_label = {e["label"]: e for e in index["sources"]}
+
+        master_entry = by_label["master"]
+        assert master_entry["role"] == "master"
+        assert master_entry["origin"] == "mixed"
+        assert master_entry["source"] == "mixed/master.wav"
+        assert master_entry["analysis"] == "analysis/master_analysis.json"
+        assert master_entry["duration"] == 10.0
+        assert master_entry["sample_rate"] == 44100
+
+        ms_entry = by_label["m_s"]
+        assert ms_entry["role"] == "stem"
+        assert ms_entry["origin"] == "bitwig"
+        assert ms_entry["source"] == "bitwig/samples/m_s-24.wav"
+        assert ms_entry["analysis"] == "analysis/m_s_analysis.json"
+
+        track_entry = by_label["track_4_git"]
+        assert track_entry["role"] == "stem"
+        assert track_entry["origin"] == "bitwig"
+        assert track_entry["source"] == "bitwig/samples/track 4+git-24.wav"
+        assert track_entry["analysis"] == "analysis/track_4_git_analysis.json"
+
+    def test_mixed_stems_produce_index_json_with_mixed_origin(self, tmp_path):
+        """Happy path: mixed/stems/ non-empty → entries use origin=mixed, bitwig ignored."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+        bitwig_samples_dir = tmp_path / "bitwig" / "samples"
+        bitwig_samples_dir.mkdir(parents=True)
+
+        with patch("beatrix.cli.click_cli.AudioAnalyzer") as mock_analyzer_class:
+            mock_analyzer = Mock()
+            mock_analyzer_class.return_value = mock_analyzer
+            mock_analyzer.analyze_for_animation.return_value = {
+                "duration": 5.0,
+                "sample_rate": 48000,
+                "tempo": {"bpm": 90.0},
+                "animation_events": {"beats": []},
+            }
+
+            _write_wav(mixed_dir / "master.wav")
+            _write_wav(stems_dir / "drums.wav")
+            _write_wav(stems_dir / "bass.wav")
+            _write_wav(bitwig_samples_dir / "ignored.wav")
+
+            result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+            assert result.exit_code == 0, result.output
+
+        import json
+
+        index_file = tmp_path / "analysis" / "index.json"
+        assert index_file.exists()
+        index = json.loads(index_file.read_text())
+        assert len(index["sources"]) == 3
+
+        by_label = {e["label"]: e for e in index["sources"]}
+        assert by_label["master"]["origin"] == "mixed"
+        assert by_label["drums"]["role"] == "stem"
+        assert by_label["drums"]["origin"] == "mixed"
+        assert by_label["drums"]["source"] == "mixed/stems/drums.wav"
+        assert by_label["bass"]["origin"] == "mixed"
+        # bitwig/ignored.wav must NOT appear
+        assert "ignored" not in by_label
+
+    def test_extracted_fallback_produces_index_json_with_main_role(self, tmp_path):
+        """Edge case: extracted/ fallback → role=main, origin=extracted in index.json."""
+        runner = CliRunner()
+        extracted_dir = tmp_path / "extracted"
+        extracted_dir.mkdir()
+
+        with patch("beatrix.cli.click_cli.AudioAnalyzer") as mock_analyzer_class:
+            mock_analyzer = Mock()
+            mock_analyzer_class.return_value = mock_analyzer
+            mock_analyzer.analyze_for_animation.return_value = {
+                "duration": 3.0,
+                "sample_rate": 44100,
+                "tempo": {"bpm": 100.0},
+                "animation_events": {"beats": []},
+            }
+
+            _write_wav(extracted_dir / "source.wav")
+
+            result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+            assert result.exit_code == 0, result.output
+
+        import json
+
+        index_file = tmp_path / "analysis" / "index.json"
+        assert index_file.exists()
+        index = json.loads(index_file.read_text())
+        assert len(index["sources"]) == 1
+        entry = index["sources"][0]
+        assert entry["role"] == "main"
+        assert entry["origin"] == "extracted"
+        assert entry["label"] == "source"
+        assert entry["source"] == "extracted/source.wav"
+        assert entry["analysis"] == "analysis/source_analysis.json"
+
+    def test_no_audio_does_not_write_index_json(self, tmp_path):
+        """Error path: no audio → nonzero exit, index.json NOT written."""
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert not (tmp_path / "analysis" / "index.json").exists()
+
+    def test_collision_does_not_write_index_json(self, tmp_path):
+        """Error path: sanitised name collision → nonzero exit, index.json NOT written."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+        _write_wav(mixed_dir / "master.wav")
+        _write_wav(stems_dir / "master.wav")  # collision
+
+        result = runner.invoke(cli, ["analyze-recording", str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert not (tmp_path / "analysis" / "index.json").exists()
+
+    def test_options_propagate_to_all_sources(self, tmp_path):
+        """Edge case: --beat-division/--min-onset-interval forwarded to every source."""
+        runner = CliRunner()
+        mixed_dir = tmp_path / "mixed"
+        mixed_dir.mkdir()
+        bitwig_samples_dir = tmp_path / "bitwig" / "samples"
+        bitwig_samples_dir.mkdir(parents=True)
+
+        with patch("beatrix.cli.click_cli.AudioAnalyzer") as mock_analyzer_class:
+            mock_analyzer = Mock()
+            mock_analyzer_class.return_value = mock_analyzer
+            mock_analyzer.analyze_for_animation.return_value = {
+                "duration": 1.0,
+                "sample_rate": 44100,
+                "tempo": {"bpm": 120.0},
+                "animation_events": {"beats": []},
+            }
+
+            _write_wav(mixed_dir / "master.wav")
+            _write_wav(bitwig_samples_dir / "track-24.wav")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "analyze-recording",
+                    str(tmp_path),
+                    "--beat-division",
+                    "4",
+                    "--min-onset-interval",
+                    "1.5",
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            assert mock_analyzer.analyze_for_animation.call_count == 2
+            for call in mock_analyzer.analyze_for_animation.call_args_list:
+                assert call.kwargs["beat_division"] == 4
+                assert call.kwargs["min_onset_interval"] == 1.5

--- a/packages/common/src/setka_common/__init__.py
+++ b/packages/common/src/setka_common/__init__.py
@@ -3,7 +3,12 @@ ABOUTME: Main package entry point for setka-common - provides shared utilities a
 ABOUTME: Exports key classes for easy importing by other packages in the monorepo.
 """
 
-from .file_structure.specialized import RecordingStructureManager
+from .file_structure.specialized import (
+    RecordingStructureManager,
+    AnalysisIndex,
+    AnalysisIndexEntry,
+    load_analysis_index,
+)
 from .config import (
     BlenderYAMLConfig,
     YAMLConfigLoader,
@@ -22,6 +27,9 @@ from .config import (
 
 __all__ = [
     "RecordingStructureManager",
+    "AnalysisIndex",
+    "AnalysisIndexEntry",
+    "load_analysis_index",
     "BlenderYAMLConfig",
     "YAMLConfigLoader",
     "ConfigValidator",

--- a/packages/common/src/setka_common/file_structure/specialized/__init__.py
+++ b/packages/common/src/setka_common/file_structure/specialized/__init__.py
@@ -1,3 +1,10 @@
 from .recording import RecordingStructure, RecordingStructureManager
+from .analysis_index import AnalysisIndex, AnalysisIndexEntry, load_analysis_index
 
-__all__ = ["RecordingStructure", "RecordingStructureManager"]
+__all__ = [
+    "RecordingStructure",
+    "RecordingStructureManager",
+    "AnalysisIndex",
+    "AnalysisIndexEntry",
+    "load_analysis_index",
+]

--- a/packages/common/src/setka_common/file_structure/specialized/analysis_index.py
+++ b/packages/common/src/setka_common/file_structure/specialized/analysis_index.py
@@ -1,0 +1,150 @@
+# ABOUTME: Typed reader for analysis/index.json manifest produced by beatrix analyze-recording.
+# ABOUTME: Provides AnalysisIndex and AnalysisIndexEntry dataclasses plus load_analysis_index().
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .recording import RecordingStructureManager
+
+logger = logging.getLogger(__name__)
+
+# Filename of the manifest inside the analysis directory.
+INDEX_FILENAME = "index.json"
+
+# Only version 1 is currently understood.
+_SUPPORTED_VERSIONS = {1}
+
+# Required fields in every source entry.
+_REQUIRED_ENTRY_FIELDS = ("role", "origin", "label", "source", "analysis")
+
+
+@dataclass
+class AnalysisIndexEntry:
+    """Single entry in the analysis index manifest.
+
+    All relative paths (``source``, ``analysis``) are relative to the
+    recording directory.  Use ``resolved_*`` helpers to obtain absolute paths.
+    """
+
+    role: str
+    origin: str
+    label: str
+    source: str
+    analysis: str
+    duration: float | None = None
+    sample_rate: int | None = None
+
+    def resolved_analysis_path(self, recording_dir: Path) -> Path:
+        """Return the absolute path to the analysis JSON file.
+
+        Args:
+            recording_dir: Root directory of the recording.
+
+        Returns:
+            Absolute ``Path`` constructed from ``recording_dir`` and
+            ``self.analysis``.
+        """
+        return Path(recording_dir) / self.analysis
+
+    def resolved_source_path(self, recording_dir: Path) -> Path:
+        """Return the absolute path to the audio source file.
+
+        Args:
+            recording_dir: Root directory of the recording.
+
+        Returns:
+            Absolute ``Path`` constructed from ``recording_dir`` and
+            ``self.source``.
+        """
+        return Path(recording_dir) / self.source
+
+
+@dataclass
+class AnalysisIndex:
+    """Parsed contents of ``analysis/index.json``.
+
+    Provides convenience accessors to retrieve the master entry and per-stem
+    entries without ad-hoc JSON parsing in consuming packages.
+    """
+
+    version: int
+    sources: list[AnalysisIndexEntry] = field(default_factory=list)
+
+    def master(self) -> AnalysisIndexEntry | None:
+        """Return the first entry with ``role == "master"``, or ``None``."""
+        for entry in self.sources:
+            if entry.role == "master":
+                return entry
+        return None
+
+    def stems(self) -> list[AnalysisIndexEntry]:
+        """Return all entries with ``role == "stem"``."""
+        return [entry for entry in self.sources if entry.role == "stem"]
+
+    def by_label(self, label: str) -> AnalysisIndexEntry | None:
+        """Return the entry matching *label*, or ``None`` if not found."""
+        for entry in self.sources:
+            if entry.label == label:
+                return entry
+        return None
+
+
+def load_analysis_index(recording_dir: Path) -> AnalysisIndex | None:
+    """Load and parse ``analysis/index.json`` from *recording_dir*.
+
+    Args:
+        recording_dir: Root directory of the recording.
+
+    Returns:
+        Parsed :class:`AnalysisIndex` when the manifest file exists, or
+        ``None`` when the file is absent (backward compatibility with
+        recordings that pre-date the manifest).
+
+    Raises:
+        ValueError: When the manifest contains an unsupported ``version`` or
+                    when a source entry is missing a required field.
+    """
+    index_path = (
+        Path(recording_dir)
+        / RecordingStructureManager.ANALYSIS_DIRNAME
+        / INDEX_FILENAME
+    )
+
+    if not index_path.exists():
+        logger.debug("analysis/index.json not found at %s — skipping", index_path)
+        return None
+
+    with open(index_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    version = data.get("version")
+    if version not in _SUPPORTED_VERSIONS:
+        raise ValueError(
+            f"Unsupported analysis index version {version!r}. "
+            f"Supported versions: {sorted(_SUPPORTED_VERSIONS)}."
+        )
+
+    sources: list[AnalysisIndexEntry] = []
+    for i, raw in enumerate(data.get("sources", [])):
+        for required_field in _REQUIRED_ENTRY_FIELDS:
+            if required_field not in raw:
+                raise ValueError(
+                    f"analysis/index.json source entry at index {i} is missing "
+                    f"required field {required_field!r}."
+                )
+        entry = AnalysisIndexEntry(
+            role=raw["role"],
+            origin=raw["origin"],
+            label=raw["label"],
+            source=raw["source"],
+            analysis=raw["analysis"],
+            duration=raw.get("duration"),
+            sample_rate=raw.get("sample_rate"),
+        )
+        sources.append(entry)
+
+    return AnalysisIndex(version=version, sources=sources)

--- a/packages/common/src/setka_common/file_structure/specialized/recording.py
+++ b/packages/common/src/setka_common/file_structure/specialized/recording.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 import json
 import logging
+import re
 
 from ..base import MediaStructure, StructureManager
 from ...utils.files import find_files_by_type, MediaType
@@ -17,6 +18,70 @@ from ...exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Bitwig appends a numeric suffix like "-24" or "-100" to recorded track filenames.
+_BITWIG_SUFFIX_RE = re.compile(r"-\d+$")
+
+# Characters that act as separators and should become underscores.
+_SEPARATOR_CHARS_RE = re.compile(r"[ +/\\]+")
+
+# Collapse multiple underscores into one.
+_MULTI_UNDERSCORE_RE = re.compile(r"_+")
+
+
+def sanitize_stem_name(name: str) -> str:
+    """Convert a raw Bitwig filename or stem into a stable, filesystem-safe label.
+
+    Steps applied in order:
+    1. Strip file extension (handles both bare stems and full filenames like ``foo.wav``).
+    2. Remove the Bitwig numeric recording suffix ``-<digits>`` at the end
+       (e.g. ``track 4+git-24`` → ``track 4+git``).
+    3. Replace separator characters (space, ``+``, ``/``, ``\\``) with ``_``.
+    4. Collapse consecutive underscores into one and strip leading/trailing ``_``.
+
+    Case is preserved — no lower-casing.  The function is idempotent:
+    ``sanitize_stem_name(sanitize_stem_name(x)) == sanitize_stem_name(x)``.
+
+    Args:
+        name: Raw stem name or full filename from a Bitwig ``samples/`` directory
+              or any other audio source.
+
+    Returns:
+        Normalised label suitable for use in ``<label>_analysis.json`` and the
+        ``analysis/index.json`` manifest.
+
+    Raises:
+        ValueError: When the resulting label is empty (e.g. input was only
+                    separator characters), with a message referencing
+                    ``sanitize_stem_name`` for easy grep.
+    """
+    # Step 1: replace path separators (/ \) with underscores BEFORE Path.stem so
+    # that "my track/stem" is not interpreted as a filesystem path component.
+    # Spaces and + are not path separators on Linux but are still replaced here
+    # pre-emptively; they will also be caught in step 3.
+    pre = name.replace("/", "_").replace("\\", "_")
+
+    # Step 1b: strip file extension using Path.stem (handles e.g. "track-24.wav").
+    stem = Path(pre).stem
+
+    # Step 2: remove Bitwig numeric suffix "-<digits>" at the end.
+    stem = _BITWIG_SUFFIX_RE.sub("", stem)
+
+    # Step 3: replace remaining separator characters (space, +) with underscore.
+    stem = _SEPARATOR_CHARS_RE.sub("_", stem)
+
+    # Step 4: collapse and strip underscores.
+    stem = _MULTI_UNDERSCORE_RE.sub("_", stem)
+    stem = stem.strip("_")
+
+    if not stem:
+        raise ValueError(
+            f"sanitize_stem_name: input {name!r} reduces to an empty label after "
+            "removing extension, Bitwig suffix, and separator characters. "
+            "Provide a name with at least one alphanumeric character."
+        )
+
+    return stem
 
 
 @dataclass
@@ -362,15 +427,68 @@ class RecordingStructureManager(StructureManager):
             )
 
     @staticmethod
+    def find_bitwig_sample_sources(recording_dir: Path) -> list[Path]:
+        """Locate audio files in the Bitwig samples directory.
+
+        Looks for a ``samples/`` subdirectory inside ``bitwig/``:
+        - First checks ``bitwig/samples/`` (flat layout).
+        - If not found, scans one level deep: ``bitwig/*/samples/`` (project-in-subfolder
+          layout produced by Bitwig's Save As).
+        No deeper recursion is performed to avoid pulling in unrelated audio.
+
+        Args:
+            recording_dir: Recording directory path
+
+        Returns:
+            Sorted (case-insensitive) list of audio file paths found in samples/,
+            or an empty list when ``bitwig/`` or any ``samples/`` directory is absent.
+        """
+        recording_dir = Path(recording_dir)
+        bitwig_dir = recording_dir / RecordingStructureManager.BITWIG_DIRNAME
+
+        if not bitwig_dir.exists():
+            return []
+
+        # Prefer flat bitwig/samples/ layout first
+        flat_samples = bitwig_dir / "samples"
+        if flat_samples.exists() and flat_samples.is_dir():
+            return sorted(
+                find_files_by_type(flat_samples, MediaType.AUDIO),
+                key=lambda p: p.name.lower(),
+            )
+
+        # Fallback: scan one level of subdirectories for a samples/ folder
+        for child in bitwig_dir.iterdir():
+            if not child.is_dir():
+                continue
+            nested_samples = child / "samples"
+            if nested_samples.exists() and nested_samples.is_dir():
+                return sorted(
+                    find_files_by_type(nested_samples, MediaType.AUDIO),
+                    key=lambda p: p.name.lower(),
+                )
+
+        return []
+
+    @staticmethod
     def find_analysis_audio_sources(recording_dir: Path) -> list[Path]:
-        """Resolve audio sources for analysis: prefer mixed/ (master + stems), fallback extracted/.
+        """Resolve audio sources for analysis using a hybrid two-tier approach.
 
-        Scans mixed/ and mixed/stems/ separately (find_files_by_type is non-recursive),
-        merges results. Falls back to extracted/ when mixed/ has no audio files or does
-        not exist.
+        **Tier resolution:**
 
-        Raises ValueError on stem name collision (two sources would produce the same
-        {stem}_analysis.json output file), enforcing fail-fast policy.
+        1. *master-tier* — audio files directly in ``mixed/`` (non-recursive).
+           Typically a single ``master.wav`` from a Bitwig Export Audio.
+        2. *stems-tier* — audio files in ``mixed/stems/`` if that directory is
+           non-empty; otherwise falls back to ``find_bitwig_sample_sources``
+           (``bitwig/…/samples/`` raw capture files).
+
+        The two tiers are merged and a collision check is performed using
+        ``sanitize_stem_name`` on each file's stem — two files producing the same
+        sanitised label would map to the same ``<label>_analysis.json`` output,
+        which is rejected with ``ValueError``.
+
+        If both tiers are empty (no ``mixed/`` audio and no bitwig samples), the
+        function falls back to ``extracted/`` for backward compatibility.
 
         Args:
             recording_dir: Recording directory path
@@ -379,35 +497,47 @@ class RecordingStructureManager(StructureManager):
             Sorted (case-insensitive) list of audio file paths to analyze
 
         Raises:
-            ValueError: When two source files share the same stem (collision)
+            ValueError: When two source files sanitise to the same label (collision)
         """
         recording_dir = Path(recording_dir)
 
         mixed_dir = recording_dir / RecordingStructureManager.MIXED_DIRNAME
         stems_dir = mixed_dir / "stems"
 
-        mixed_files: list[Path] = []
+        # --- master-tier: audio directly in mixed/ root ---
+        master_tier: list[Path] = []
         if mixed_dir.exists():
-            mixed_files.extend(find_files_by_type(mixed_dir, MediaType.AUDIO))
-            if stems_dir.exists():
-                mixed_files.extend(find_files_by_type(stems_dir, MediaType.AUDIO))
+            master_tier.extend(find_files_by_type(mixed_dir, MediaType.AUDIO))
 
-        if mixed_files:
-            # Detect stem name collisions before returning
-            seen_stems: dict[str, Path] = {}
-            for audio_file in mixed_files:
-                stem_key = audio_file.stem.lower()
-                if stem_key in seen_stems:
+        # --- stems-tier: mixed/stems/ preferred; bitwig/samples/ as fallback ---
+        stems_tier: list[Path] = []
+        if stems_dir.exists():
+            stems_tier.extend(find_files_by_type(stems_dir, MediaType.AUDIO))
+        if not stems_tier:
+            # mixed/stems/ absent or empty — try bitwig samples
+            stems_tier.extend(
+                RecordingStructureManager.find_bitwig_sample_sources(recording_dir)
+            )
+
+        sources = master_tier + stems_tier
+
+        if sources:
+            # Detect sanitised label collisions before returning
+            seen_labels: dict[str, Path] = {}
+            for audio_file in sources:
+                label = sanitize_stem_name(audio_file.stem)
+                if label in seen_labels:
                     raise ValueError(
-                        f"Stem name collision: '{audio_file}' and '{seen_stems[stem_key]}' "
-                        f"would both produce '{audio_file.stem}_analysis.json'. "
-                        "Use unique stem names in mixed/ and mixed/stems/."
+                        f"Stem name collision after sanitisation: "
+                        f"'{audio_file}' and '{seen_labels[label]}' "
+                        f"would both produce '{label}_analysis.json'. "
+                        "Use unique stem names across mixed/ and stems sources."
                     )
-                seen_stems[stem_key] = audio_file
+                seen_labels[label] = audio_file
 
-            return sorted(mixed_files, key=lambda p: p.name.lower())
+            return sorted(sources, key=lambda p: p.name.lower())
 
-        # Fallback: no audio in mixed/ (or mixed/ absent) — use extracted/
+        # Fallback: no audio in mixed/ or bitwig — use extracted/ (backward compat)
         extracted_dir = recording_dir / RecordingStructureManager.EXTRACTED_DIRNAME
         extracted_files = find_files_by_type(extracted_dir, MediaType.AUDIO)
         return sorted(extracted_files, key=lambda p: p.name.lower())

--- a/packages/common/tests/test_analysis_index.py
+++ b/packages/common/tests/test_analysis_index.py
@@ -1,0 +1,244 @@
+# ABOUTME: Tests for AnalysisIndex reader - the typed manifest loader for analysis/index.json
+# ABOUTME: Covers happy path, edge cases, and error scenarios for the analysis index reader.
+
+import json
+import pytest
+from pathlib import Path
+
+from setka_common.file_structure.specialized.analysis_index import (
+    load_analysis_index,
+)
+from setka_common.file_structure.specialized.recording import RecordingStructureManager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_index(recording_dir: Path, data: dict) -> Path:
+    """Write index.json to analysis/ subdirectory and return the path."""
+    analysis_dir = recording_dir / RecordingStructureManager.ANALYSIS_DIRNAME
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+    index_path = analysis_dir / "index.json"
+    index_path.write_text(json.dumps(data), encoding="utf-8")
+    return index_path
+
+
+MASTER_ENTRY = {
+    "role": "master",
+    "origin": "mixed",
+    "label": "master",
+    "source": "mixed/master.wav",
+    "analysis": "analysis/master_analysis.json",
+    "duration": 182.4,
+    "sample_rate": 44100,
+}
+
+STEM_ENTRY = {
+    "role": "stem",
+    "origin": "bitwig",
+    "label": "track_4_git",
+    "source": "bitwig/samples/track_4_git-24.wav",
+    "analysis": "analysis/track_4_git_analysis.json",
+    "duration": 182.4,
+    "sample_rate": 44100,
+}
+
+
+# ---------------------------------------------------------------------------
+# Happy path tests
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_loads_correct_entry_count(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY, STEM_ENTRY]})
+        index = load_analysis_index(tmp_path)
+        assert index is not None
+        assert len(index.sources) == 2
+
+    def test_master_returns_first_master_role(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY, STEM_ENTRY]})
+        index = load_analysis_index(tmp_path)
+        master = index.master()
+        assert master is not None
+        assert master.role == "master"
+        assert master.label == "master"
+
+    def test_stems_returns_stem_role_entries(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY, STEM_ENTRY]})
+        index = load_analysis_index(tmp_path)
+        stems = index.stems()
+        assert len(stems) == 1
+        assert stems[0].role == "stem"
+        assert stems[0].label == "track_4_git"
+
+    def test_by_label_returns_correct_entry(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY, STEM_ENTRY]})
+        index = load_analysis_index(tmp_path)
+        entry = index.by_label("track_4_git")
+        assert entry is not None
+        assert entry.label == "track_4_git"
+        assert entry.origin == "bitwig"
+
+    def test_by_label_unknown_returns_none(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY, STEM_ENTRY]})
+        index = load_analysis_index(tmp_path)
+        assert index.by_label("does_not_exist") is None
+
+    def test_resolved_analysis_path_is_absolute(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY]})
+        index = load_analysis_index(tmp_path)
+        entry = index.master()
+        resolved = entry.resolved_analysis_path(tmp_path)
+        assert resolved.is_absolute()
+        assert resolved == tmp_path / "analysis/master_analysis.json"
+
+    def test_resolved_source_path_is_absolute(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY]})
+        index = load_analysis_index(tmp_path)
+        entry = index.master()
+        resolved = entry.resolved_source_path(tmp_path)
+        assert resolved.is_absolute()
+        assert resolved == tmp_path / "mixed/master.wav"
+
+    def test_resolved_analysis_path_exists_when_file_present(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY]})
+        # Create the actual analysis file so .exists() can be asserted
+        analysis_file = tmp_path / "analysis" / "master_analysis.json"
+        analysis_file.parent.mkdir(parents=True, exist_ok=True)
+        analysis_file.write_text("{}", encoding="utf-8")
+
+        index = load_analysis_index(tmp_path)
+        entry = index.master()
+        assert entry.resolved_analysis_path(tmp_path).exists()
+
+    def test_duration_and_sample_rate_populated(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": [MASTER_ENTRY]})
+        index = load_analysis_index(tmp_path)
+        entry = index.master()
+        assert entry.duration == 182.4
+        assert entry.sample_rate == 44100
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_missing_index_returns_none(self, tmp_path):
+        # No index.json written at all
+        result = load_analysis_index(tmp_path)
+        assert result is None
+
+    def test_empty_sources_list(self, tmp_path):
+        _write_index(tmp_path, {"version": 1, "sources": []})
+        index = load_analysis_index(tmp_path)
+        assert index is not None
+        assert index.sources == []
+        assert index.master() is None
+        assert index.stems() == []
+
+    def test_entry_without_duration_and_sample_rate(self, tmp_path):
+        entry_no_optional = {
+            "role": "master",
+            "origin": "mixed",
+            "label": "master",
+            "source": "mixed/master.wav",
+            "analysis": "analysis/master_analysis.json",
+        }
+        _write_index(tmp_path, {"version": 1, "sources": [entry_no_optional]})
+        index = load_analysis_index(tmp_path)
+        entry = index.master()
+        assert entry is not None
+        assert entry.duration is None
+        assert entry.sample_rate is None
+
+
+# ---------------------------------------------------------------------------
+# Error / validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_missing_required_field_role_raises_value_error(self, tmp_path):
+        bad_entry = {
+            "origin": "mixed",
+            "label": "master",
+            "source": "mixed/master.wav",
+            "analysis": "analysis/master_analysis.json",
+        }
+        _write_index(tmp_path, {"version": 1, "sources": [bad_entry]})
+        with pytest.raises(ValueError, match="role"):
+            load_analysis_index(tmp_path)
+
+    def test_missing_required_field_analysis_raises_value_error(self, tmp_path):
+        bad_entry = {
+            "role": "master",
+            "origin": "mixed",
+            "label": "master",
+            "source": "mixed/master.wav",
+        }
+        _write_index(tmp_path, {"version": 1, "sources": [bad_entry]})
+        with pytest.raises(ValueError, match="analysis"):
+            load_analysis_index(tmp_path)
+
+    def test_unknown_version_raises_value_error(self, tmp_path):
+        _write_index(tmp_path, {"version": 999, "sources": []})
+        with pytest.raises(ValueError, match="version"):
+            load_analysis_index(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Integration round-trip test
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_round_trip_with_manually_crafted_index(self, tmp_path):
+        """Verify full round-trip: write index.json in Unit-3 schema, read back without loss."""
+        data = {
+            "version": 1,
+            "sources": [
+                {
+                    "role": "master",
+                    "origin": "mixed",
+                    "label": "master",
+                    "source": "mixed/master.wav",
+                    "analysis": "analysis/master_analysis.json",
+                    "duration": 200.0,
+                    "sample_rate": 48000,
+                },
+                {
+                    "role": "stem",
+                    "origin": "bitwig",
+                    "label": "m_s",
+                    "source": "bitwig/samples/m_s-24.wav",
+                    "analysis": "analysis/m_s_analysis.json",
+                    "duration": 200.0,
+                    "sample_rate": 48000,
+                },
+            ],
+        }
+        _write_index(tmp_path, data)
+        index = load_analysis_index(tmp_path)
+
+        assert index.version == 1
+        assert len(index.sources) == 2
+
+        master = index.master()
+        assert master.role == "master"
+        assert master.origin == "mixed"
+        assert master.label == "master"
+        assert master.source == "mixed/master.wav"
+        assert master.analysis == "analysis/master_analysis.json"
+        assert master.duration == 200.0
+        assert master.sample_rate == 48000
+
+        stem = index.by_label("m_s")
+        assert stem is not None
+        assert stem.role == "stem"
+        assert stem.origin == "bitwig"
+        assert stem.source == "bitwig/samples/m_s-24.wav"

--- a/packages/common/tests/test_recording_structure.py
+++ b/packages/common/tests/test_recording_structure.py
@@ -2,9 +2,12 @@
 Testy dla modułu recording structure.
 """
 
+import pytest
+
 from setka_common.file_structure.specialized.recording import (
     RecordingStructure,
     RecordingStructureManager,
+    sanitize_stem_name,
 )
 
 
@@ -683,3 +686,418 @@ class TestFindAnalysisAudioSources:
         result_names = [f.name.lower() for f in result]
 
         assert result_names == sorted(result_names)
+
+
+class TestFindBitwigSampleSources:
+    """Testy dla find_bitwig_sample_sources (Unit 2)."""
+
+    def test_bitwig_samples_flat(self, tmp_path):
+        """bitwig/samples/ z wav → zwraca te pliki."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        samples_dir = recording_dir / "bitwig" / "samples"
+        samples_dir.mkdir(parents=True)
+        a = samples_dir / "m_s-24.wav"
+        a.touch()
+        b = samples_dir / "track 4+git-24.wav"
+        b.touch()
+
+        result = RecordingStructureManager.find_bitwig_sample_sources(recording_dir)
+
+        assert a in result
+        assert b in result
+        assert len(result) == 2
+
+    def test_bitwig_samples_nested_one_level(self, tmp_path):
+        """bitwig/<proj>/samples/ (jeden poziom zagnieżdżenia) jest wykrywane."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        samples_dir = recording_dir / "bitwig" / "MyProject" / "samples"
+        samples_dir.mkdir(parents=True)
+        wav = samples_dir / "m_s-24.wav"
+        wav.touch()
+
+        result = RecordingStructureManager.find_bitwig_sample_sources(recording_dir)
+
+        assert wav in result
+
+    def test_bitwig_flat_takes_priority_over_nested(self, tmp_path):
+        """bitwig/samples/ (flat) wykryte zamiast bitwig/*/samples/ gdy oba istnieją."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        # flat samples dir
+        flat_samples = recording_dir / "bitwig" / "samples"
+        flat_samples.mkdir(parents=True)
+        flat_wav = flat_samples / "flat.wav"
+        flat_wav.touch()
+        # nested samples dir
+        nested_samples = recording_dir / "bitwig" / "proj" / "samples"
+        nested_samples.mkdir(parents=True)
+        nested_wav = nested_samples / "nested.wav"
+        nested_wav.touch()
+
+        result = RecordingStructureManager.find_bitwig_sample_sources(recording_dir)
+
+        # flat bierze priorytet
+        assert flat_wav in result
+        assert nested_wav not in result
+
+    def test_no_bitwig_dir_returns_empty(self, tmp_path):
+        """Brak bitwig/ → zwraca []."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+
+        result = RecordingStructureManager.find_bitwig_sample_sources(recording_dir)
+
+        assert result == []
+
+    def test_bitwig_exists_no_samples_dir_returns_empty(self, tmp_path):
+        """bitwig/ istnieje ale bez samples/ → zwraca []."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        bitwig_dir = recording_dir / "bitwig"
+        bitwig_dir.mkdir()
+
+        result = RecordingStructureManager.find_bitwig_sample_sources(recording_dir)
+
+        assert result == []
+
+    def test_bitwig_samples_empty_dir_returns_empty(self, tmp_path):
+        """bitwig/samples/ istnieje ale puste → zwraca []."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        samples_dir = recording_dir / "bitwig" / "samples"
+        samples_dir.mkdir(parents=True)
+
+        result = RecordingStructureManager.find_bitwig_sample_sources(recording_dir)
+
+        assert result == []
+
+    def test_non_audio_files_ignored(self, tmp_path):
+        """Pliki nie-audio w bitwig/samples/ są pomijane."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        samples_dir = recording_dir / "bitwig" / "samples"
+        samples_dir.mkdir(parents=True)
+        wav = samples_dir / "track.wav"
+        wav.touch()
+        bwproject = samples_dir / "project.bwproject"
+        bwproject.touch()
+
+        result = RecordingStructureManager.find_bitwig_sample_sources(recording_dir)
+
+        assert wav in result
+        assert bwproject not in result
+        assert len(result) == 1
+
+
+class TestFindAnalysisAudioSourcesHybrid:
+    """Testy hybrydowego resolvera (Unit 2) — tiery master + stems|bitwig."""
+
+    def test_master_plus_mixed_stems(self, tmp_path):
+        """mixed/master.wav + mixed/stems/{a,b}.wav → master + 2 stemy (bitwig ignorowany)."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+        master = mixed_dir / "master.wav"
+        master.touch()
+        stem_a = stems_dir / "bass.wav"
+        stem_a.touch()
+        stem_b = stems_dir / "guitar.wav"
+        stem_b.touch()
+        # bitwig/samples/ — powinien być ignorowany gdy mixed/stems/ niepuste
+        bitwig_samples = recording_dir / "bitwig" / "samples"
+        bitwig_samples.mkdir(parents=True)
+        (bitwig_samples / "ignored.wav").touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert master in result
+        assert stem_a in result
+        assert stem_b in result
+        assert len(result) == 3
+
+    def test_master_plus_bitwig_stems_when_no_mixed_stems(self, tmp_path):
+        """mixed/master.wav + brak/puste mixed/stems/ + bitwig/samples/ z 3 wav → master + 3 stemy."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        # stems/ puste (nie istnieje)
+        master = mixed_dir / "master.wav"
+        master.touch()
+        bitwig_samples = recording_dir / "bitwig" / "samples"
+        bitwig_samples.mkdir(parents=True)
+        b1 = bitwig_samples / "m_s-24.wav"
+        b1.touch()
+        b2 = bitwig_samples / "track 4+git-24.wav"
+        b2.touch()
+        b3 = bitwig_samples / "track 5_6+mic+freak-24.wav"
+        b3.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert master in result
+        assert b1 in result
+        assert b2 in result
+        assert b3 in result
+        assert len(result) == 4
+
+    def test_only_bitwig_no_mixed(self, tmp_path):
+        """Brak mixed/, bitwig/samples/ z N wav → N źródeł (master-tier pusty)."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        bitwig_samples = recording_dir / "bitwig" / "samples"
+        bitwig_samples.mkdir(parents=True)
+        b1 = bitwig_samples / "m_s-24.wav"
+        b1.touch()
+        b2 = bitwig_samples / "track 1-25.wav"
+        b2.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert b1 in result
+        assert b2 in result
+        assert len(result) == 2
+
+    def test_bitwig_nested_project_detected(self, tmp_path):
+        """bitwig/<proj>/samples/ (jeden poziom zagnieżdżenia) wykryte jako fallback stemów."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        master = mixed_dir / "master.wav"
+        master.touch()
+        # nested bitwig project
+        nested_samples = recording_dir / "bitwig" / "LiveSession" / "samples"
+        nested_samples.mkdir(parents=True)
+        stem = nested_samples / "m_s-24.wav"
+        stem.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert master in result
+        assert stem in result
+        assert len(result) == 2
+
+    def test_mixed_stems_wins_over_bitwig(self, tmp_path):
+        """mixed/stems/ niepuste → bitwig/samples/ nie jest odpytywany (fallback nie odpala)."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+        master = mixed_dir / "master.wav"
+        master.touch()
+        mixed_stem = stems_dir / "polished.wav"
+        mixed_stem.touch()
+        # bitwig istnieje i ma pliki — ale stems/ wygrywa
+        bitwig_samples = recording_dir / "bitwig" / "samples"
+        bitwig_samples.mkdir(parents=True)
+        bitwig_wav = bitwig_samples / "raw.wav"
+        bitwig_wav.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert master in result
+        assert mixed_stem in result
+        assert bitwig_wav not in result
+        assert len(result) == 2
+
+    def test_fallback_extracted_when_no_mixed_no_bitwig(self, tmp_path):
+        """Brak mixed/ i bitwig/, extracted/ ma pliki → fallback extracted/ (zgodność wstecz)."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        extracted_dir = recording_dir / "extracted"
+        extracted_dir.mkdir()
+        ext_audio = extracted_dir / "source.m4a"
+        ext_audio.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert result == [ext_audio]
+
+    def test_all_empty_returns_empty_list(self, tmp_path):
+        """Wszystko puste/nieobecne → [] bez wyjątku."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert result == []
+
+    def test_collision_via_sanitize_raises_value_error(self, tmp_path):
+        """Dwa źródła o kolidujących sanityzowanych nazwach → ValueError z oboma plikami."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        bitwig_samples = recording_dir / "bitwig" / "samples"
+        bitwig_samples.mkdir(parents=True)
+        # Oba sanityzują się do "track_1"
+        f1 = bitwig_samples / "track 1-24.wav"
+        f1.touch()
+        f2 = bitwig_samples / "track_1.wav"
+        f2.touch()
+
+        with pytest.raises(ValueError):
+            RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+    def test_collision_error_mentions_both_files(self, tmp_path):
+        """ValueError z collision-check wymienia oba kolidujące pliki."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        bitwig_samples = recording_dir / "bitwig" / "samples"
+        bitwig_samples.mkdir(parents=True)
+        f1 = bitwig_samples / "track 1-24.wav"
+        f1.touch()
+        f2 = bitwig_samples / "track_1.wav"
+        f2.touch()
+
+        with pytest.raises(ValueError) as exc_info:
+            RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        error_msg = str(exc_info.value)
+        # Błąd musi wymienić sanityzowaną etykietę kolizji
+        assert "track_1" in error_msg
+
+    def test_deterministic_order_with_bitwig(self, tmp_path):
+        """Kolejność wyników deterministyczna (sort case-insensitive) przy źródłach bitwig."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        bitwig_samples = recording_dir / "bitwig" / "samples"
+        bitwig_samples.mkdir(parents=True)
+        # Nazwy ze zróżnicowaną wielkością liter
+        (bitwig_samples / "Zebra-24.wav").touch()
+        (bitwig_samples / "apple-24.wav").touch()
+        (bitwig_samples / "Master-24.wav").touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+        result_names = [f.name.lower() for f in result]
+
+        assert result_names == sorted(result_names)
+
+    def test_empty_mixed_stems_uses_bitwig(self, tmp_path):
+        """mixed/stems/ ISTNIEJE ale pusta → używa bitwig/samples/ (fallback odpala)."""
+        recording_dir = tmp_path / "recording"
+        recording_dir.mkdir()
+        mixed_dir = recording_dir / "mixed"
+        mixed_dir.mkdir()
+        stems_dir = mixed_dir / "stems"
+        stems_dir.mkdir()
+        # stems/ istnieje ale puste — fallback do bitwig
+        master = mixed_dir / "master.wav"
+        master.touch()
+        bitwig_samples = recording_dir / "bitwig" / "samples"
+        bitwig_samples.mkdir(parents=True)
+        bitwig_wav = bitwig_samples / "raw.wav"
+        bitwig_wav.touch()
+
+        result = RecordingStructureManager.find_analysis_audio_sources(recording_dir)
+
+        assert master in result
+        assert bitwig_wav in result
+        assert len(result) == 2
+
+
+class TestSanitizeStemName:
+    """Testy dla funkcji sanitize_stem_name (Unit 1).
+
+    Mapowania realnych nazw z nagrania (bitwig/samples/):
+    - "m_s-24"               → "m_s"
+    - "track 1-25"           → "track_1"
+    - "track 2-26"           → "track_2"
+    - "track 3-25"           → "track_3"
+    - "track 4+git-24"       → "track_4_git"
+    - "track 5_6+mic+freak-24" → "track_5_6_mic_freak"
+    - "master"               → "master"
+    """
+
+    @pytest.mark.parametrize(
+        "input_name, expected",
+        [
+            # Realne nazwy z nagrania (surowy stem Bitwiga)
+            ("m_s-24", "m_s"),
+            ("track 1-25", "track_1"),
+            ("track 2-26", "track_2"),
+            ("track 3-25", "track_3"),
+            ("track 4+git-24", "track_4_git"),
+            ("track 5_6+mic+freak-24", "track_5_6_mic_freak"),
+            # Master — brak sufiksu liczbowego, bez zmian
+            ("master", "master"),
+            # Brak sufiksu -NN — tylko normalizacja separatorów
+            ("bass+guitar", "bass_guitar"),
+            ("my track/stem", "my_track_stem"),
+            (r"path\to\stem", "path_to_stem"),
+            # Zachowanie wielkości liter (NIE lower-case)
+            ("MyTrack-24", "MyTrack"),
+            ("DRUMS-10", "DRUMS"),
+            # Rozszerzenie .wav w wejściu — zdejmij
+            ("master.wav", "master"),
+            ("track 4+git-24.wav", "track_4_git"),
+            ("m_s-24.wav", "m_s"),
+            # Wielokrotne podkreślniki → scalone
+            ("track__double-24", "track_double"),
+            # Brzegowe podkreślniki → przycięte
+            (" leading space-24", "leading_space"),
+            # Sufiks -NN z wielocyfrową liczbą
+            ("stem-100", "stem"),
+            ("stem-9", "stem"),
+        ],
+    )
+    def test_real_name_mappings(self, input_name, expected):
+        """Test tabelaryczny: realne nazwy z nagrania mapują się na oczekiwane etykiety."""
+        assert sanitize_stem_name(input_name) == expected
+
+    def test_idempotent_on_real_names(self):
+        """sanitize(sanitize(x)) == sanitize(x) dla realnych nazw."""
+        raw_names = [
+            "m_s-24",
+            "track 4+git-24",
+            "track 5_6+mic+freak-24",
+            "master",
+            "DRUMS-10",
+        ]
+        for name in raw_names:
+            once = sanitize_stem_name(name)
+            twice = sanitize_stem_name(once)
+            assert once == twice, f"Nie idempotentne dla '{name}': {once!r} → {twice!r}"
+
+    def test_idempotent_on_already_clean_names(self):
+        """sanitize(x) == x gdy wejście jest już czyste."""
+        clean_names = ["master", "m_s", "track_1", "track_4_git", "DRUMS"]
+        for name in clean_names:
+            assert sanitize_stem_name(name) == name, (
+                f"Czysta nazwa '{name}' zmodyfikowana przez sanitize"
+            )
+
+    def test_error_on_pure_separator_input(self):
+        """Wejście złożone z samych znaków specjalnych → ValueError."""
+        with pytest.raises(ValueError, match="sanitize_stem_name"):
+            sanitize_stem_name("+/\\")
+
+    def test_error_on_empty_string(self):
+        """Pusty string → ValueError z czytelnym komunikatem."""
+        with pytest.raises(ValueError, match="sanitize_stem_name"):
+            sanitize_stem_name("")
+
+    def test_error_on_only_spaces(self):
+        """Sama spacja/whitespace po normalizacji → ValueError."""
+        with pytest.raises(ValueError, match="sanitize_stem_name"):
+            sanitize_stem_name("   ")
+
+    def test_preserves_case(self):
+        """Zachowuje wielkość liter — NIE robi lower-case."""
+        assert sanitize_stem_name("MyTrack-24") == "MyTrack"
+        assert sanitize_stem_name("DRUMS") == "DRUMS"
+
+    def test_dot_in_middle_of_name_treated_as_extension(self):
+        """Nazwa pliku z kropką — Path.stem zdejmuje sufiks, nie środkową kropkę.
+
+        Np. 'track.stem-24.wav' → Path.stem daje 'track.stem-24' → sanitize daje 'track.stem'.
+        To zachowanie jest akceptowalne (nazwy z kropką w środku są rzadkie w Bitwigu).
+        """
+        # 'track-24.wav' — typowe: zdejmuje .wav, potem usuwa -24
+        assert sanitize_stem_name("track-24.wav") == "track"


### PR DESCRIPTION
## Summary

Rozszerza akcję **„Analizuj"** (fermata → `beatrix analyze-recording`), żeby jednym kliknięciem analizowała **wszystkie ścieżki nagrania**, a inne moduły (cymatic/cinemon) **łatwo je odnajdywały i rozróżniały**.

- **Hybrydowe źródło stemów** — master z `mixed/master.wav`, stemy z `mixed/stems/` lub (fallback) z **surowego multitrack capture w `bitwig/<…>/samples/`**. Ostateczny fallback `extracted/` zachowany (zgodność wstecz).
- **Sanityzacja nazw** — `track 4+git-24.wav` → `track_4_git_analysis.json` (zdjęcie sufiksu Bitwiga `-NN`, normalizacja spacji/`+`/`/`). Collision-check po sanityzowanym labelu (fail-fast).
- **Manifest `analysis/index.json`** — kontrakt odkrywania: `role` (master/stem/main), `origin` (mixed/bitwig/extracted), `label`, względne `source`/`analysis` (z prefiksem katalogu), `duration`/`sample_rate`.
- **Reader w setka-common** — `load_analysis_index()` + `AnalysisIndex`/`AnalysisIndexEntry` z `master()`, `stems()`, `by_label()`, `resolved_analysis_path()`. Brak manifestu → `None` (zgodność wstecz).

**Czysto addytywne** względem zmergowanego poprzednika (`2026-06-04-001-...`). Bez zmian w kodzie Rust fermaty (przycisk już woła `analyze-recording`), bez zmian w konsumpcji cinemon/cymatic (per-strip targeting to przyszła faza), bez zmian w single-file `beatrix analyze`.

Plan: `docs/plans/2026-06-04-003-feat-bitwig-per-track-analysis-plan.md`

## Testing

- **126 testów jednostkowych zielonych**: setka-common (103: `test_recording_structure.py` + `test_analysis_index.py`) + beatrix (23: `test_cli_click.py`). Zero regresji.
- Pokrycie: sanityzacja (mapowania realnych nazw, idempotentność, error path), tiery resolvera (mixed/stems wygrywa nad bitwig, fallback bitwig, fallback extracted, kolizje), generowanie `index.json` (role/origin/label/duration/sample_rate, błędy), reader (round-trip, opcjonalne pola, walidacja).
- **E2E na realnym nagraniu** `2026-06-04 15-15-01`: jedno wywołanie wygenerowało 7 analiz (master z `mixed/` + 6 per-track z `bitwig/samples/`) + `index.json`; reader odczytał manifest round-trip (`master()`, `stems()`, `by_label()`, ścieżki absolutne istnieją). Czas ~26 s.
- Lint `ruff check` czysty; pre-commit (ruff + testy zmienionych pakietów) zielony na każdym commicie.

## Post-Deploy Monitoring & Validation

Bez wpływu na produkcję/runtime — lokalne narzędzie CLI/biblioteka analizy audio. `No additional operational monitoring required: zmiana dotyczy lokalnego pipeline'u analizy (beatrix CLI + setka-common), bez usług sieciowych ani danych produkcyjnych.`

Walidacja manualna po merge: wcisnąć „Analizuj" w fermacie na nagraniu z katalogiem `bitwig/samples/` → oczekiwane `analysis/<label>_analysis.json` per ścieżka + `analysis/index.json` z 1× `role: master` i N× `role: stem`.

---

🤖 Generated with Claude Opus 4.8 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering