### PR TITLE
feat(live): szybkie akcje operatorskie — launcher + przenieś ostatnie nagranie do kosza

### DIFF
--- a/deploy/live/README.md
+++ b/deploy/live/README.md
@@ -29,12 +29,39 @@ go brak (nie blokuje instalacji): `sudo apt install wmctrl`.
 ## Komendy operatorskie
 
 ```bash
-setka-live start     # postaw komplet (OBS + Bitwig + kiosk) po preflighcie; na końcu układa okna
-setka-live stop      # zatrzymaj całą warstwę GUI
-setka-live restart   # całościowy restart GUI (stop+start; re-weryfikuje preflight)
-setka-live status    # stan członków + paternologia /health + środowisko graficzne
-setka-live show      # wyciągnij na wierzch i ułóż okna na dwóch monitorach (patrz niżej)
+setka-live start        # postaw komplet (OBS + Bitwig + kiosk) po preflighcie; na końcu układa okna
+setka-live stop         # zatrzymaj całą warstwę GUI
+setka-live restart      # całościowy restart GUI (stop+start; re-weryfikuje preflight)
+setka-live status       # stan członków + paternologia /health + środowisko graficzne
+setka-live show         # wyciągnij na wierzch i ułóż okna na dwóch monitorach (patrz niżej)
+setka-live delete-last  # przenieś ostatnie nagranie do kosza z potwierdzeniem (patrz niżej)
 ```
+
+### `setka-live delete-last` — przeniesienie ostatniego nagrania do kosza
+
+Przenosi **cały katalog** najnowszego nagrania do kosza GNOME (`gio trash`) — operacja **odwracalna**
+(przywrócisz z Kosza w Menedżerze Plików / Nautilusa).
+
+Przepływ:
+
+1. Ustala root nagrań z `SETKA_RECORDINGS_ROOT` (lub fallback `~/Wideo/obs` → `~/Videos/obs`).
+2. Znajduje najnowszy (wg mtime) podkatalog roota zawierający `metadata.json` + plik wideo.
+3. Pyta przez `zenity` o potwierdzenie — pokazuje nazwę, wiek i rozmiar katalogu.
+4. Po potwierdzeniu przenosi do kosza przez `gio trash`; informuje przez `notify-send`.
+5. Anulowanie lub zamknięcie okna → brak akcji (fail-safe).
+
+Zmienne środowiskowe:
+
+| Zmienna | Domyślna wartość | Opis |
+|---------|-----------------|------|
+| `SETKA_RECORDINGS_ROOT` | `~/Wideo/obs` (fallback `~/Videos/obs`) | Root katalogu nagrań |
+| `REC_VIDEO_GLOBS` | `*.mp4 *.mkv *.mov *.flv` | Rozszerzenia plików wideo |
+
+Walidacja roota: musi być niepustą, **absolutną** ścieżką do istniejącego katalogu, różną od
+`$HOME` i `/`. Zmienna ustawiona na pusty string lub ścieżkę względną → odmowa z komunikatem błędu.
+
+Wymagane narzędzia: `zenity` (potwierdzenie — bez niego operacja jest blokowana), `gio` (kosz),
+`notify-send` (powiadomienia, best-effort).
 
 ### `setka-live show` — układanie okien
 

--- a/deploy/live/README.md
+++ b/deploy/live/README.md
@@ -143,10 +143,50 @@ Rzadki restart samego mostu MIDI (poza zakresem `setka-live`):
 systemctl --user restart paternologia.service
 ```
 
+## Ikona tray i autostart
+
+`setka-tray` (zainstalowany przez `install.sh`) to lekka apka systemu tray — ikona z menu
+szybkich akcji operatorskich. Startuje automatycznie przy logowaniu do sesji GNOME (przez
+`~/.config/autostart/setka-tray.desktop`).
+
+Menu traya:
+- **Pokaż okna** → wywołuje `setka-live show`
+- **Usuń ostatnie nagranie** → wywołuje `setka-live delete-last`
+- **Zakończ** → zamyka samą apkę tray
+
+Wymagania traya (instalator ostrzega, gdy brakuje):
+- Rozszerzenie GNOME: `gnome-shell-extension-appindicator` (StatusNotifierWatcher) — na Ubuntu
+  24.04 zazwyczaj preinstalowane.
+- Pakiety apt: `python3-gi`, `gir1.2-gtk-3.0`, `gir1.2-ayatanaappindicator3-0.1`.
+
+Jeśli ikona nie pojawia się po zalogowaniu: sprawdź rozszerzenie w _GNOME Tweaks → Rozszerzenia_
+lub uruchom `setka-tray` ręcznie z terminala i sprawdź błędy.
+
+## Globalne skróty klawiaturowe GNOME
+
+Instalowane przez `install.sh` (idempotentnie; działają bez restartu sesji):
+
+| Skrót | Akcja |
+|-------|-------|
+| `Super+Shift+S` | `setka-live show` (pokaż/ułóż okna) |
+| `Super+Shift+D` | `setka-live delete-last` (usuń ostatnie nagranie) |
+
+Skróty wpisywane są do `org.gnome.settings-daemon.plugins.media-keys.custom-keybindings`
+i nie nadpisują skrótów użytkownika — nowe ścieżki są tylko dołączane (append-if-absent).
+
+Aby zmienić domyślne klawisze — ustaw env przed `install.sh`:
+
+```bash
+KB_SHOW='<Super><Shift>F1' KB_DELETE='<Super><Shift>F2' deploy/live/install.sh
+```
+
+Zmiana działa bez restartu sesji GNOME — skróty są aktywne od razu po instalacji.
+
 ## Testy
 
 ```bash
 deploy/live/tests/test_install.sh
+deploy/live/tests/test_keybindings.sh
 deploy/live/tests/test_live_preflight.sh
 deploy/live/tests/test_setka_live.sh
 deploy/live/tests/test_live_layout.sh
@@ -154,4 +194,4 @@ deploy/live/tests/test_kiosk_class.sh
 ```
 
 Plain shell (`bats` nie jest wymagany). Logikę warunków/dyspozytora testujemy na realnych
-kształtach danych i przez indirekcję komend — bez mutowania żywego systemd.
+kształtach danych i przez indirekcję komend — bez mutowania żywego systemd ani gsettings.

--- a/deploy/live/autostart/setka-tray.desktop
+++ b/deploy/live/autostart/setka-tray.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=Setka Live Tray
+Comment=Ikona tray z szybkimi akcjami operatorskimi sesji live (setka-live)
+# Exec uzupełniany przez install.sh do ścieżki absolutnej.
+# Placeholder __SETKA_TRAY_EXEC__ zastępowany przez install.sh wartością ~/.local/bin/setka-tray.
+Exec=__SETKA_TRAY_EXEC__
+StartupNotify=false
+OnlyShowIn=GNOME;Unity;
+X-GNOME-Autostart-enabled=true
+# Drobne opóźnienie na wypadek późnego StatusNotifierWatcher przy starcie sesji.
+X-GNOME-Autostart-Delay=3

--- a/deploy/live/bin/live-keybindings.sh
+++ b/deploy/live/bin/live-keybindings.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# ABOUTME: Instaluje globalne skróty GNOME dla akcji setka-live przez gsettings (custom-keybindings).
+# ABOUTME: Idempotentny: append-if-absent; nie nadpisuje customów użytkownika; obsługuje @as [].
+set -uo pipefail
+
+# Indirekcja przez env — dla testów zamienialna na recorder-mock.
+GSETTINGS_BIN="${GSETTINGS_BIN:-gsettings}"
+
+# Domyślne klawisze — nadpisywalne przez env.
+KB_SHOW="${KB_SHOW:-<Super><Shift>s}"
+KB_DELETE="${KB_DELETE:-<Super><Shift>d}"
+
+# Komenda setka-live — absolutna ścieżka z env (przekazywana przez install.sh).
+# Bez absolutnej ścieżki GNOME może jej nie znaleźć (skróty uruchamiane bez PATH użytkownika).
+SETKA_LIVE_CMD="${SETKA_LIVE_CMD:-setka-live}"
+
+# Stałe gsettings
+MEDIA_KEYS_SCHEMA="org.gnome.settings-daemon.plugins.media-keys"
+BINDING_SCHEMA="org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"
+BINDING_PREFIX="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings"
+
+log() { printf 'keybindings: %s\n' "$*"; }
+err() { printf 'keybindings: BŁĄD: %s\n' "$*" >&2; }
+
+# Pobiera bieżącą listę custom-keybindings jako surowy string z gsettings.
+_get_list() {
+    "$GSETTINGS_BIN" get "$MEDIA_KEYS_SCHEMA" custom-keybindings
+}
+
+# Sprawdza, czy podana ścieżka <path> już jest w liście gsettings.
+# Zwraca 0 jeśli jest, 1 jeśli nie.
+_path_in_list() {
+    local path="$1"
+    local current
+    current="$(_get_list)"
+    case "$current" in
+        *"$path"*) return 0 ;;
+        *)          return 1 ;;
+    esac
+}
+
+# Buduje nową listę gsettings z istniejącą zawartością + nową ścieżką.
+# Obsługuje dwa przypadki:
+#   @as []  →  nowa lista z jednym elementem
+#   [...]   →  dołącz nowy element na końcu
+_append_path() {
+    local path="$1"
+    local current
+    current="$(_get_list)"
+
+    local new_list
+    if [ "$current" = "@as []" ]; then
+        # Pusta lista — tylko nasz element
+        new_list="['${path}']"
+    else
+        # Niepusta lista: usuń końcowy ']', dołącz ', <path>']
+        # Format: ['a/', 'b/'] → ['a/', 'b/', '<path>']
+        new_list="${current%]}, '${path}']"
+    fi
+
+    "$GSETTINGS_BIN" set "$MEDIA_KEYS_SCHEMA" custom-keybindings "$new_list"
+}
+
+# Ustawia atrybuty per-binding dla relocatable schema.
+# Ścieżka MUSI kończyć się '/'.
+_set_binding() {
+    local path="$1" name="$2" command="$3" keys="$4"
+    local schema_with_path="${BINDING_SCHEMA}:${path}"
+    "$GSETTINGS_BIN" set "$schema_with_path" name "$name"
+    "$GSETTINGS_BIN" set "$schema_with_path" command "$command"
+    "$GSETTINGS_BIN" set "$schema_with_path" binding "$keys"
+}
+
+# Dodaje skrót GNOME idempotentnie.
+# Argumenty: <path> <name> <command> <keys>
+# Ścieżka musi kończyć się '/'.
+kb_add() {
+    local path="$1" name="$2" command="$3" keys="$4"
+
+    if _path_in_list "$path"; then
+        log "skrót już w liście: $path (no-op)"
+    else
+        log "dodaję skrót: $path"
+        _append_path "$path"
+    fi
+
+    # Per-binding ustawiamy zawsze (idempotentne set nie szkodzi; może zaktualizować binding/cmd).
+    _set_binding "$path" "$name" "$command" "$keys"
+    log "  name='$name' command='$command' binding='$keys'"
+}
+
+# Instaluje oba skróty setka-live.
+main() {
+    local show_path="${BINDING_PREFIX}/setka-show/"
+    local delete_path="${BINDING_PREFIX}/setka-delete-last/"
+
+    kb_add "$show_path" \
+        "Setka: Pokaż okna" \
+        "${SETKA_LIVE_CMD} show" \
+        "$KB_SHOW"
+
+    kb_add "$delete_path" \
+        "Setka: Usuń ostatnie nagranie" \
+        "${SETKA_LIVE_CMD} delete-last" \
+        "$KB_DELETE"
+
+    log "skróty zainstalowane: show=$KB_SHOW delete-last=$KB_DELETE"
+}
+
+# Odpal main lub zadaną funkcję zależnie od argumentów.
+# Bez argumentów: main() instaluje oba skróty.
+# Z argumentem 'kb_add ...': wywołuje kb_add (dla testów i ręcznych wywołań).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    case "${1:-}" in
+        kb_add)
+            shift
+            kb_add "$@"
+            ;;
+        *)
+            main "$@"
+            ;;
+    esac
+fi

--- a/deploy/live/bin/setka-live
+++ b/deploy/live/bin/setka-live
@@ -180,11 +180,19 @@ is_recording_dir() {
 
   [ -f "$dir/metadata.json" ] || return 1
 
-  # Sprawdź każdy glob osobno (nullglob nie jest domyślny; używamy find/ls przez pętlę).
+  # Dopasowanie globów przez TABLICĘ w podpowłoce z nullglob. Tablica zachowuje całe
+  # nazwy plików jako pojedyncze elementy — odporne na spacje w nazwie (realne nagrania
+  # OBS to np. "2026-06-04 17-30-58.mp4" czy "Projekt bez nazwy.mp4"). Wcześniejsze
+  # `ls "$dir"/$glob | grep` rozbijało nazwy ze spacjami na osobne argumenty i zawodziło.
+  # nullglob ograniczony do podpowłoki, by nie zmieniać zachowania globów w reszcie skryptu.
   local glob
   for glob in $REC_VIDEO_GLOBS; do
-    # shellcheck disable=SC2086  # glob celowo niecytowany.
-    if ls "$dir"/$glob 2>/dev/null | grep -q .; then
+    if (
+      shopt -s nullglob
+      # shellcheck disable=SC2206  # glob celowo niecytowany — to wzorzec dopasowania.
+      matches=( "$dir"/$glob )
+      [ ${#matches[@]} -gt 0 ]
+    ); then
       return 0
     fi
   done

--- a/deploy/live/bin/setka-live
+++ b/deploy/live/bin/setka-live
@@ -3,29 +3,45 @@
 # ABOUTME: Owija pułapki: restart = stop+start (nie `restart .target`); nigdy nie tyka paternologii ani PipeWire.
 set -euo pipefail
 
-# Indirekcja przez env wyłącznie dla testów — domyślnie realny systemctl --user.
+# Indirekcja przez env wyłącznie dla testów — domyślnie realne narzędzia.
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:8000/health}"
 # Siostrzany skrypt układania okien (w tym samym katalogu bin); env override dla testów.
 LAYOUT_BIN="${LAYOUT_BIN:-$(dirname "$0")/live-layout.sh}"
+# Narzędzia potrzebne do podkomendy delete-last; env override dla testów.
+GIO_BIN="${GIO_BIN:-gio}"
+ZENITY_BIN="${ZENITY_BIN:-zenity}"
+NOTIFY_BIN="${NOTIFY_BIN:-notify-send}"
+# Root katalogu nagrań; env override. Default: ~/Wideo/obs, fallback: ~/Videos/obs.
+# Nie ustawiamy tutaj wartości — resolve_recordings_root obsługuje logikę fallbacku.
+
+# Glob rozszerzeń plików wideo uznawanych za prawidłowe nagranie (space-separated).
+REC_VIDEO_GLOBS="${REC_VIDEO_GLOBS:-*.mp4 *.mkv *.mov *.flv}"
 
 TARGET="live-recording.target"
 MEMBERS="live-preflight.service obs.service bitwig.service kiosk.service"
 
 sctl() { "$SYSTEMCTL_BIN" --user "$@"; }
+log() { printf 'setka-live: %s\n' "$*"; }
+err() { printf 'setka-live: %s\n' "$*" >&2; }
 
 usage() {
   cat >&2 <<EOF
-Użycie: setka-live <start|stop|restart|status|show>
+Użycie: setka-live <start|stop|restart|status|show|delete-last>
 
-  start    postaw komplet live (OBS + Bitwig + kiosk) po preflighcie; na końcu układa okna
-  stop     zatrzymaj całą warstwę GUI
-  restart  całościowy restart warstwy GUI (stop+start; re-weryfikuje preflight)
-  status   stan członków + paternologia /health + środowisko graficzne
-  show     wyciągnij na wierzch i ułóż okna: Bitwig (lewy) | OBS+Paternologia (prawy)
+  start        postaw komplet live (OBS + Bitwig + kiosk) po preflighcie; na końcu układa okna
+  stop         zatrzymaj całą warstwę GUI
+  restart      całościowy restart warstwy GUI (stop+start; re-weryfikuje preflight)
+  status       stan członków + paternologia /health + środowisko graficzne
+  show         wyciągnij na wierzch i ułóż okna: Bitwig (lewy) | OBS+Paternologia (prawy)
+  delete-last  przenieś ostatnie nagranie do kosza (z potwierdzeniem)
 
 Most MIDI (paternologia.service) jest poza zakresem — rzadki restart ręcznie:
   systemctl --user restart paternologia.service
+
+Zmienne środowiskowe (delete-last):
+  SETKA_RECORDINGS_ROOT  root katalogu nagrań (default: ~/Wideo/obs, fallback: ~/Videos/obs)
+  REC_VIDEO_GLOBS        glob rozszerzeń wideo (default: *.mp4 *.mkv *.mov *.flv)
 EOF
 }
 
@@ -75,15 +91,259 @@ cmd_status() {
     || echo "brak DISPLAY/WAYLAND_DISPLAY w activation env — GUI nie wstanie"
 }
 
-main() {
-  case "${1:-}" in
-    start)   cmd_start ;;
-    stop)    cmd_stop ;;
-    restart) cmd_restart ;;
-    status)  cmd_status ;;
-    show)    cmd_show ;;
-    *)       usage; exit 2 ;;
+# Rozwiń ~ na początku ścieżki (bez eval; obsługuje tylko wiodące ~).
+expand_tilde() {
+  local path="$1"
+  case "$path" in
+    "~/"*) printf '%s' "$HOME/${path#~/}" ;;
+    "~")   printf '%s' "$HOME" ;;
+    *)     printf '%s' "$path" ;;
   esac
 }
 
-main "$@"
+# Zwraca zwalidowany absolutny root nagrań lub exit !=0 z komunikatem błędu na stderr.
+# Jeśli SETKA_RECORDINGS_ROOT ustawiony — użyj go (rozwijając ~).
+# Inaczej: pierwszy istniejący z ~/Wideo/obs, ~/Videos/obs.
+# Walidacja: niepusty, absolutny, istnieje, jest katalogiem, != $HOME, != /.
+resolve_recordings_root() {
+  local root
+
+  # Rozróżniamy "zmienna ustawiona (nawet na pusty string)" od "zmienna nieustawiona".
+  # ${VAR+x} daje 'x' gdy VAR jest ustawiona (w tym na ""), puste gdy nieustawiona.
+  if [ -n "${SETKA_RECORDINGS_ROOT+isset}" ]; then
+    # Zmienna ustawiona — walidujemy jej wartość (pusty string = błąd, nie fallback).
+    if [ -z "${SETKA_RECORDINGS_ROOT}" ]; then
+      err "SETKA_RECORDINGS_ROOT jest pusty."
+      return 1
+    fi
+    root="$(expand_tilde "$SETKA_RECORDINGS_ROOT")"
+  else
+    # Fallback: próbuj domyślne lokalizacje w ustalonej kolejności.
+    local candidate
+    for candidate in "$HOME/Wideo/obs" "$HOME/Videos/obs"; do
+      if [ -d "$candidate" ]; then
+        root="$candidate"
+        break
+      fi
+    done
+    if [ -z "${root:-}" ]; then
+      err "Brak katalogu nagrań: ~/Wideo/obs ani ~/Videos/obs nie istnieje. Ustaw SETKA_RECORDINGS_ROOT."
+      return 1
+    fi
+  fi
+
+  # Walidacja: niepusty.
+  if [ -z "$root" ]; then
+    err "SETKA_RECORDINGS_ROOT jest pusty."
+    return 1
+  fi
+
+  # Walidacja: absolutny (musi zaczynać się od /).
+  case "$root" in
+    /*) ;;
+    *)
+      err "SETKA_RECORDINGS_ROOT musi być ścieżką absolutną (podano: '$root')."
+      return 1
+      ;;
+  esac
+
+  # Walidacja: != /.
+  if [ "$root" = "/" ]; then
+    err "SETKA_RECORDINGS_ROOT nie może być '/'."
+    return 1
+  fi
+
+  # Walidacja: != $HOME.
+  if [ "$root" = "$HOME" ]; then
+    err "SETKA_RECORDINGS_ROOT nie może być katalogiem domowym (\$HOME)."
+    return 1
+  fi
+
+  # Walidacja: istnieje i jest katalogiem.
+  if [ ! -e "$root" ]; then
+    err "SETKA_RECORDINGS_ROOT nie istnieje: '$root'."
+    return 1
+  fi
+  if [ ! -d "$root" ]; then
+    err "SETKA_RECORDINGS_ROOT nie jest katalogiem: '$root'."
+    return 1
+  fi
+
+  printf '%s' "$root"
+}
+
+# Sprawdza czy podany katalog jest prawidłowym katalogiem nagrania.
+# Prawidłowy = zawiera metadata.json ORAZ co najmniej jeden plik wideo wg REC_VIDEO_GLOBS.
+# exit 0 → prawidłowy; exit !=0 → nieprawidłowy.
+is_recording_dir() {
+  local dir="$1"
+
+  [ -f "$dir/metadata.json" ] || return 1
+
+  # Sprawdź każdy glob osobno (nullglob nie jest domyślny; używamy find/ls przez pętlę).
+  local glob
+  for glob in $REC_VIDEO_GLOBS; do
+    # shellcheck disable=SC2086  # glob celowo niecytowany.
+    if ls "$dir"/$glob 2>/dev/null | grep -q .; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# Zwraca ścieżkę najnowszego (wg mtime) bezpośredniego podkatalogu roota,
+# dla którego is_recording_dir == 0. Pomija nie-katalogi i symlinki.
+# Anty-symlink-escape: sprawdza że realpath kandydata ma rodzica == root.
+find_latest_recording() {
+  local root="$1"
+  local latest_time=0
+  local latest_path=""
+  local real_root
+  real_root="$(realpath "$root")"
+
+  local entry
+  while IFS= read -r -d '' entry; do
+    # Pomiń symlinki.
+    [ -L "$entry" ] && continue
+    # Pomiń nie-katalogi.
+    [ -d "$entry" ] || continue
+
+    # Anty-symlink-escape: rodzic realpath kandydata musi == real_root.
+    local real_entry real_parent
+    real_entry="$(realpath "$entry")"
+    real_parent="$(dirname "$real_entry")"
+    [ "$real_parent" = "$real_root" ] || continue
+
+    # Sprawdź czy prawidłowe nagranie.
+    is_recording_dir "$entry" || continue
+
+    # Pobierz mtime jako sekundy od epoch (stat -c %Y = Linux).
+    local mtime
+    mtime="$(stat -c '%Y' "$entry" 2>/dev/null)" || continue
+
+    if [ "$mtime" -gt "$latest_time" ]; then
+      latest_time="$mtime"
+      latest_path="$entry"
+    fi
+  done < <(find "$root" -maxdepth 1 -mindepth 1 -print0 2>/dev/null)
+
+  printf '%s' "$latest_path"
+}
+
+# Zwraca opis katalogu nagrania: "nazwa | wiek czytelnie | rozmiar".
+describe_recording() {
+  local dir="$1"
+  local name
+  name="$(basename "$dir")"
+
+  # Wiek: czas od mtime katalogu do teraz (w sekundach → czytelna jednostka).
+  local mtime now age_s age_str
+  mtime="$(stat -c '%Y' "$dir" 2>/dev/null)" || mtime=0
+  now="$(date +%s)"
+  age_s=$(( now - mtime ))
+  if [ "$age_s" -lt 60 ]; then
+    age_str="${age_s}s temu"
+  elif [ "$age_s" -lt 3600 ]; then
+    age_str="$(( age_s / 60 )) min temu"
+  elif [ "$age_s" -lt 86400 ]; then
+    age_str="$(( age_s / 3600 )) godz temu"
+  else
+    age_str="$(( age_s / 86400 )) dni temu"
+  fi
+
+  # Rozmiar z du -sh.
+  local size
+  size="$(du -sh "$dir" 2>/dev/null | cut -f1)" || size="?"
+
+  printf '%s | %s | %s' "$name" "$age_str" "$size"
+}
+
+# Podkomenda: przenieś ostatnie nagranie do kosza z potwierdzeniem zenity.
+# R3, R3a, R4, R5, R6.
+cmd_delete_last() {
+  # Ustal root nagrań.
+  local root
+  if ! root="$(resolve_recordings_root)"; then
+    # resolve_recordings_root już wypisało błąd na stderr.
+    return 1
+  fi
+
+  # Znajdź najnowszy prawidłowy katalog nagrania.
+  local latest
+  latest="$(find_latest_recording "$root")"
+
+  if [ -z "$latest" ]; then
+    # Brak nagrania → informuj operatora, exit 0 (nie błąd).
+    log "Brak nagrania do usunięcia w: $root"
+    if command -v "$NOTIFY_BIN" >/dev/null 2>&1; then
+      "$NOTIFY_BIN" --urgency=normal "setka-live" "Brak nagrania do usunięcia w: $root" || true
+    fi
+    return 0
+  fi
+
+  local desc name
+  desc="$(describe_recording "$latest")"
+  name="$(basename "$latest")"
+
+  # Potwierdzenie przez zenity — twarda bramka: bez zenity nie wolno trashować.
+  if ! command -v "$ZENITY_BIN" >/dev/null 2>&1; then
+    err "Brak zenity — nie można uzyskać potwierdzenia usunięcia. Odmawiam."
+    err "Zainstaluj zenity: sudo apt install zenity"
+    return 1
+  fi
+
+  local msg
+  msg="Przenieść do kosza katalog nagrania?
+
+$desc
+
+Ścieżka: $latest
+
+Operacja jest odwracalna — przywrócisz z Kosza w Menedżerze Plików."
+
+  # rc != 0 → anulowanie lub zamknięcie okna → fail-safe, brak akcji.
+  if ! "$ZENITY_BIN" \
+      --question \
+      --default-cancel \
+      --icon=dialog-warning \
+      --title="Usuń ostatnie nagranie" \
+      --text="$msg" 2>/dev/null; then
+    log "Anulowano przeniesienie nagrania: $name"
+    return 0
+  fi
+
+  # Przenieś do kosza.
+  if "$GIO_BIN" trash "$latest" 2>/dev/null; then
+    log "Przeniesiono do kosza: $name"
+    if command -v "$NOTIFY_BIN" >/dev/null 2>&1; then
+      "$NOTIFY_BIN" --urgency=normal "setka-live" \
+        "Przeniesiono do kosza: $name (przywrócisz z Kosza w Plikach)" || true
+    fi
+  else
+    err "Błąd: nie udało się przenieść do kosza: $latest"
+    if command -v "$NOTIFY_BIN" >/dev/null 2>&1; then
+      "$NOTIFY_BIN" --urgency=critical "setka-live" \
+        "Błąd: nie udało się przenieść do kosza: $name" || true
+    fi
+    return 1
+  fi
+}
+
+main() {
+  case "${1:-}" in
+    start)       cmd_start ;;
+    stop)        cmd_stop ;;
+    restart)     cmd_restart ;;
+    status)      cmd_status ;;
+    show)        cmd_show ;;
+    delete-last) cmd_delete_last ;;
+    *)           usage; exit 2 ;;
+  esac
+}
+
+# Source-guard: main wywołany tylko przy bezpośrednim wykonaniu.
+# Sourcowanie (testy jednostkowe funkcji) daje same definicje, bez uruchamiania main.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/deploy/live/bin/setka-tray
+++ b/deploy/live/bin/setka-tray
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# ABOUTME: Ikona system tray (GTK3 + AyatanaAppIndicator3) z menu wyzwalającym podkomendy setka-live.
+# ABOUTME: Czysta tabela menu zdefiniowana na top-level (testowalnie bez GTK); warstwa GTK tylko w main().
+
+import subprocess
+
+
+# ---------------------------------------------------------------------------
+# Czysta struktura menu — testowalna bez importu GTK.
+# Krotka: (etykieta, argv) gdzie argv=None oznacza czyste wyjście (brak komendy).
+# Separator: (None, None)
+# ---------------------------------------------------------------------------
+
+
+def build_menu_items():
+    """Zwraca tabelę pozycji menu jako listę krotek (etykieta, argv_lub_None).
+
+    Separatory reprezentowane jako (None, None).
+    Pozycja "Zakończ" ma argv=None — wyzwala Gtk.main_quit(), nie zewnętrzną komendę.
+    """
+    return [
+        ("Pokaż okna", ["setka-live", "show"]),
+        ("Usuń ostatnie nagranie", ["setka-live", "delete-last"]),
+        (None, None),  # separator
+        ("Zakończ", None),
+    ]
+
+
+def run_command(argv):
+    """Odpala komendę jako podzapis (fire-and-forget). Nie czeka na zakończenie."""
+    subprocess.Popen(argv)
+
+
+# ---------------------------------------------------------------------------
+# Warstwa GTK — ładowana wyłącznie w main(), nigdy na poziomie modułu.
+# Dzięki temu import czystej logiki (w testach) nie wymaga gi/X11.
+# ---------------------------------------------------------------------------
+
+
+def main():
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("AyatanaAppIndicator3", "0.1")
+    from gi.repository import Gtk
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator
+
+    indicator = AppIndicator.Indicator.new(
+        "setka-tray",
+        "media-record",
+        AppIndicator.IndicatorCategory.APPLICATION_STATUS,
+    )
+    indicator.set_status(AppIndicator.IndicatorStatus.ACTIVE)
+
+    menu = Gtk.Menu()
+
+    for label, argv in build_menu_items():
+        if label is None:
+            # separator
+            item = Gtk.SeparatorMenuItem()
+        elif argv is None:
+            # Zakończ — czyste wyjście z pętli GTK
+            item = Gtk.MenuItem(label=label)
+            item.connect("activate", lambda _: Gtk.main_quit())
+        else:
+            # Normalna pozycja menu — odpala podkomendę setka-live
+            item = Gtk.MenuItem(label=label)
+            # Domknięcie: kopiuje argv przez default-argument, by uniknąć późnego wiązania.
+            item.connect("activate", lambda _, cmd=argv: run_command(cmd))
+
+        menu.append(item)
+
+    menu.show_all()
+    indicator.set_menu(menu)
+
+    Gtk.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/live/install.sh
+++ b/deploy/live/install.sh
@@ -13,6 +13,12 @@ AUTOSTART_DIR="${AUTOSTART_DIR:-$HOME/.config/autostart}"
 # Default dla porównania, czy warto robić daemon-reload (sensowny tylko dla prawdziwego katalogu).
 DEFAULT_SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
 
+# Indirekcja gdbus przez env — dla testów zamienialna na mock.
+GDBUS_BIN="${GDBUS_BIN:-gdbus}"
+
+# Gate dla efektów ubocznych gsettings: pomijaj keybindings w testach lub przy env SKIP_KEYBINDINGS.
+SKIP_KEYBINDINGS="${SKIP_KEYBINDINGS:-}"
+
 STAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Kopiuje plik z backupem tylko gdy treść się różni (idempotencja: identyczna treść = no-op).
@@ -45,6 +51,58 @@ main() {
     install_file "$script" "$BIN_DIR/$(basename "$script")" 0755
   done
   shopt -u nullglob
+
+  # Instalacja autostart .desktop dla setka-tray z podstawieniem absolutnej ścieżki Exec.
+  # Placeholder __SETKA_TRAY_EXEC__ zastępowany przez bezwzględną ścieżkę setka-tray w BIN_DIR.
+  local desktop_src="$SCRIPT_DIR/autostart/setka-tray.desktop"
+  if [ -f "$desktop_src" ]; then
+    mkdir -p "$AUTOSTART_DIR"
+    local desktop_tmp
+    desktop_tmp="$(mktemp)"
+    sed "s|__SETKA_TRAY_EXEC__|${BIN_DIR}/setka-tray|g" "$desktop_src" >"$desktop_tmp"
+    install_file "$desktop_tmp" "$AUTOSTART_DIR/setka-tray.desktop" 0644
+    rm -f "$desktop_tmp"
+    printf 'Zainstalowano autostart traya → %s/setka-tray.desktop\n' "$AUTOSTART_DIR"
+  else
+    printf 'UWAGA: brak %s — autostart setka-tray pominięty\n' "$desktop_src"
+  fi
+
+  # Instalacja skrótów GNOME przez live-keybindings.sh.
+  # Efekt uboczny na żywym gsettings — pomijany gdy SKIP_KEYBINDINGS lub niestandardowy BIN_DIR.
+  if [ -z "$SKIP_KEYBINDINGS" ] && [ "$BIN_DIR" = "$HOME/.local/bin" ]; then
+    if [ -x "$BIN_DIR/live-keybindings.sh" ]; then
+      SETKA_LIVE_CMD="$BIN_DIR/setka-live" bash "$BIN_DIR/live-keybindings.sh" \
+        && printf 'Skróty GNOME zainstalowane (Super+Shift+S show, Super+Shift+D delete-last)\n' \
+        || printf 'UWAGA: instalacja skrótów GNOME nie powiodła się — pomiń i skonfiguruj ręcznie\n'
+    else
+      printf 'UWAGA: brak %s/live-keybindings.sh — skróty GNOME pominięte\n' "$BIN_DIR"
+    fi
+  else
+    printf 'Pomijam instalację skrótów GNOME (SKIP_KEYBINDINGS lub niestandardowy BIN_DIR)\n'
+  fi
+
+  # Defensywny check: rozszerzenie StatusNotifierWatcher (appindicator) dla setka-tray.
+  # Brak → ostrzeżenie (nie błąd); tray może nie wyświetlać ikony bez rozszerzenia.
+  if ! "$GDBUS_BIN" call --session \
+      --dest org.kde.StatusNotifierWatcher \
+      --object-path /StatusNotifierWatcher \
+      --method org.kde.StatusNotifierWatcher.ProtocolVersion \
+      >/dev/null 2>&1; then
+    printf 'UWAGA: StatusNotifierWatcher niedostępny — zainstaluj rozszerzenie GNOME appindicator.\n'
+    printf '       setka-tray może nie wyświetlać ikony do czasu zainstalowania rozszerzenia.\n'
+  fi
+
+  # Defensywne checki zależności GUI (niefatalne; ostrzeżenia operatorskie).
+  for tool in zenity notify-send gio; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      printf 'UWAGA: brak %s — "setka-live delete-last" może działać nieprawidłowo. Zainstaluj: sudo apt install %s\n' "$tool" "$tool"
+    fi
+  done
+  for pkg in gir1.2-gtk-3.0 gir1.2-ayatanaappindicator3-0.1; do
+    if ! dpkg -l "$pkg" >/dev/null 2>&1; then
+      printf 'UWAGA: pakiet %s niezainstalowany — setka-tray wymaga go do wyświetlenia ikony.\n' "$pkg"
+    fi
+  done
 
   # Wycofanie starego kiosk-autostartu: kiosk przechodzi pod systemd (tryb na żądanie, R5).
   # Zmiana nazwy poza rozszerzenie .desktop wyłącza autostart GNOME, zachowując odwracalność.

--- a/deploy/live/install.sh
+++ b/deploy/live/install.sh
@@ -48,6 +48,8 @@ main() {
 
   printf 'Instaluję skrypty → %s\n' "$BIN_DIR"
   for script in "$SCRIPT_DIR"/bin/*; do
+    # Pomijaj nie-pliki (np. __pycache__/ powstały po imporcie setka-tray w testach).
+    [ -f "$script" ] || continue
     install_file "$script" "$BIN_DIR/$(basename "$script")" 0755
   done
   shopt -u nullglob

--- a/deploy/live/install.sh
+++ b/deploy/live/install.sh
@@ -85,11 +85,13 @@ main() {
 
   # Defensywny check: rozszerzenie StatusNotifierWatcher (appindicator) dla setka-tray.
   # Brak → ostrzeżenie (nie błąd); tray może nie wyświetlać ikony bez rozszerzenia.
+  # ProtocolVersion to właściwość D-Bus, nie metoda — sprawdzamy obecność właściciela nazwy
+  # org.kde.StatusNotifierWatcher na busie (zwraca '(true,)' gdy rozszerzenie aktywne).
   if ! "$GDBUS_BIN" call --session \
-      --dest org.kde.StatusNotifierWatcher \
-      --object-path /StatusNotifierWatcher \
-      --method org.kde.StatusNotifierWatcher.ProtocolVersion \
-      >/dev/null 2>&1; then
+      --dest org.freedesktop.DBus \
+      --object-path /org/freedesktop/DBus \
+      --method org.freedesktop.DBus.NameHasOwner org.kde.StatusNotifierWatcher \
+      2>/dev/null | grep -q 'true'; then
     printf 'UWAGA: StatusNotifierWatcher niedostępny — zainstaluj rozszerzenie GNOME appindicator.\n'
     printf '       setka-tray może nie wyświetlać ikony do czasu zainstalowania rozszerzenia.\n'
   fi

--- a/deploy/live/tests/test_install.sh
+++ b/deploy/live/tests/test_install.sh
@@ -211,7 +211,18 @@ KB_LOG="$KB_LOG" SKIP_KEYBINDINGS=1 GDBUS_BIN=true \
 # --- Test U3-5: live-keybindings.sh kopiowany do BIN_DIR ---
 assert_file "$TU1/bin/live-keybindings.sh" "U3 happy: live-keybindings.sh skopiowany do BIN_DIR"
 
-rm -rf "$TU1" "$TU3" "$TU4"
+# --- Test U3-6: nie-plik w bin/ (np. __pycache__/) pomijany — install nie wywala się ---
+TU6="$(mktemp -d)"
+make_src3 "$TU6/src"
+mkdir -p "$TU6/src/bin/__pycache__"
+printf 'dummy bytecode\n' >"$TU6/src/bin/__pycache__/setka-tray.cpython-312.pyc"
+run_install3 "$TU6/src" "$TU6/systemd" "$TU6/bin" "$TU6/autostart"
+rc=$?
+assert_exit "$rc" 0 "U3 pycache: katalog w bin/ pomijany, install kończy się sukcesem"
+assert_no_file "$TU6/bin/__pycache__" "U3 pycache: __pycache__ NIE skopiowany do BIN_DIR"
+assert_file "$TU6/bin/setka-tray" "U3 pycache: setka-tray nadal skopiowany mimo katalogu obok"
+
+rm -rf "$TU1" "$TU3" "$TU4" "$TU6"
 
 printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_install.sh
+++ b/deploy/live/tests/test_install.sh
@@ -121,5 +121,97 @@ grep -qi 'install wmctrl\|brak wmctrl' "$T8/src/out.log" \
 
 rm -rf "$T1" "$T4" "$T5" "$T6" "$T7" "$T8"
 
+# =============================================================================
+# Testy Unitu 3: setka-tray, autostart .desktop, skróty GNOME (install.sh extensions)
+# =============================================================================
+
+# Rozszerzona make_src z atrapami Unit 3: setka-tray, live-keybindings.sh, autostart/.desktop
+make_src3() {
+  local src="$1"
+  make_src "$src"
+  # Atrapa setka-tray (plik wykonywalny Python)
+  printf '#!/usr/bin/env python3\n# atrapa setka-tray\nprint("tray")\n' >"$src/bin/setka-tray"
+  # Atrapa live-keybindings.sh (recorder-mock lub no-op w zależności od testu)
+  printf '#!/usr/bin/env bash\necho "keybindings: $*" >> "${KB_LOG:-/dev/null}"\nexit 0\n' >"$src/bin/live-keybindings.sh"
+  # Plik .desktop z placeholderem
+  mkdir -p "$src/autostart"
+  printf '[Desktop Entry]\nType=Application\nName=Setka Live Tray\nExec=__SETKA_TRAY_EXEC__\nX-GNOME-Autostart-enabled=true\n' \
+    >"$src/autostart/setka-tray.desktop"
+}
+
+# run_install3: uruchamia install.sh z env dla Unit 3.
+# SKIP_KEYBINDINGS=1 → nie woła żywego gsettings.
+# Opcjonalnie GDBUS_BIN → mock gdbus (domyślnie noop/ok).
+run_install3() {
+  local src="$1" sysd="$2" bind="$3" auto="$4"
+  local path="${5:-$PATH}"
+  SYSTEMD_USER_DIR="$sysd" BIN_DIR="$bind" AUTOSTART_DIR="$auto" \
+    SKIP_KEYBINDINGS=1 \
+    GDBUS_BIN="${GDBUS_BIN:-true}" \
+    PATH="$path" bash "$src/install.sh" >"$src/out.log" 2>&1
+}
+
+# --- Test U3-1: Happy path — setka-tray skopiowany, .desktop z podstawioną Exec ---
+TU1="$(mktemp -d)"
+make_src3 "$TU1/src"
+run_install3 "$TU1/src" "$TU1/systemd" "$TU1/bin" "$TU1/autostart"
+rc=$?
+assert_exit "$rc" 0 "U3 happy: install.sh kończy się sukcesem"
+assert_file "$TU1/bin/setka-tray" "U3 happy: setka-tray skopiowany do BIN_DIR"
+[ -x "$TU1/bin/setka-tray" ] && pass "U3 happy: setka-tray jest wykonywalny" \
+  || fail "U3 happy: setka-tray nie jest +x"
+assert_file "$TU1/autostart/setka-tray.desktop" "U3 happy: setka-tray.desktop w AUTOSTART_DIR"
+
+# Placeholder __SETKA_TRAY_EXEC__ musi być zastąpiony absolutną ścieżką
+grep -q '__SETKA_TRAY_EXEC__' "$TU1/autostart/setka-tray.desktop" \
+  && fail "U3 happy: placeholder __SETKA_TRAY_EXEC__ NIE zastąpiony" \
+  || pass "U3 happy: placeholder zastąpiony"
+
+grep -q "$TU1/bin/setka-tray" "$TU1/autostart/setka-tray.desktop" \
+  && pass "U3 happy: Exec wskazuje na $TU1/bin/setka-tray" \
+  || fail "U3 happy: brak absolutnej ścieżki w Exec; .desktop: $(cat "$TU1/autostart/setka-tray.desktop" 2>/dev/null)"
+
+# --- Test U3-2: Idempotencja .desktop — ponowny install identycznych plików → brak backupu ---
+run_install3 "$TU1/src" "$TU1/systemd" "$TU1/bin" "$TU1/autostart"
+rc=$?
+assert_exit "$rc" 0 "U3 idempotent: ponowny run = sukces"
+bak_count=$(find "$TU1/autostart" -name 'setka-tray.desktop.bak-*' 2>/dev/null | wc -l)
+[ "$bak_count" -eq 0 ] && pass "U3 idempotent: brak zbędnych backupów .desktop" \
+  || fail "U3 idempotent: powstały backupy .desktop mimo identycznej treści ($bak_count)"
+
+# --- Test U3-3: Brak StatusNotifierWatcher (gdbus-mock zwraca błąd) → ostrzeżenie, exit 0 ---
+TU3="$(mktemp -d)"
+make_src3 "$TU3/src"
+# Atrapa gdbus zwracająca błąd (StatusNotifierWatcher niedostępny)
+GDBUS_MOCK="$TU3/gdbus-fail"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$GDBUS_MOCK"
+chmod +x "$GDBUS_MOCK"
+
+GDBUS_BIN="$GDBUS_MOCK" \
+  SYSTEMD_USER_DIR="$TU3/systemd" BIN_DIR="$TU3/bin" AUTOSTART_DIR="$TU3/autostart" \
+  SKIP_KEYBINDINGS=1 \
+  bash "$TU3/src/install.sh" >"$TU3/src/out.log" 2>&1
+rc=$?
+assert_exit "$rc" 0 "U3 gdbus-fail: brak StatusNotifierWatcher → exit 0 (nieblokujące)"
+grep -qi 'StatusNotifierWatcher\|appindicator\|tray\|rozszerzenie' "$TU3/src/out.log" \
+  && pass "U3 gdbus-fail: instalator ostrzega o braku StatusNotifierWatcher" \
+  || fail "U3 gdbus-fail: brak ostrzeżenia o StatusNotifierWatcher; log: $(cat "$TU3/src/out.log" 2>/dev/null)"
+
+# --- Test U3-4: live-keybindings.sh NIE wywoływany gdy SKIP_KEYBINDINGS=1 ---
+TU4="$(mktemp -d)"
+make_src3 "$TU4/src"
+KB_LOG="$TU4/kb.log"
+KB_LOG="$KB_LOG" SKIP_KEYBINDINGS=1 GDBUS_BIN=true \
+  SYSTEMD_USER_DIR="$TU4/systemd" BIN_DIR="$TU4/bin" AUTOSTART_DIR="$TU4/autostart" \
+  bash "$TU4/src/install.sh" >"$TU4/src/out.log" 2>&1
+[ -s "$TU4/kb.log" ] \
+  && fail "U3 skip-keybindings: keybindings wywołane mimo SKIP_KEYBINDINGS=1" \
+  || pass "U3 skip-keybindings: keybindings pominięte gdy SKIP_KEYBINDINGS=1"
+
+# --- Test U3-5: live-keybindings.sh kopiowany do BIN_DIR ---
+assert_file "$TU1/bin/live-keybindings.sh" "U3 happy: live-keybindings.sh skopiowany do BIN_DIR"
+
+rm -rf "$TU1" "$TU3" "$TU4"
+
 printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_install.sh
+++ b/deploy/live/tests/test_install.sh
@@ -137,6 +137,9 @@ make_src3() {
   mkdir -p "$src/autostart"
   printf '[Desktop Entry]\nType=Application\nName=Setka Live Tray\nExec=__SETKA_TRAY_EXEC__\nX-GNOME-Autostart-enabled=true\n' \
     >"$src/autostart/setka-tray.desktop"
+  # Mock gdbus udający aktywny StatusNotifierWatcher (NameHasOwner → '(true,)').
+  printf '#!/usr/bin/env bash\nprintf "(true,)\\n"\n' >"$src/gdbus-ok"
+  chmod +x "$src/gdbus-ok"
 }
 
 # run_install3: uruchamia install.sh z env dla Unit 3.
@@ -147,7 +150,7 @@ run_install3() {
   local path="${5:-$PATH}"
   SYSTEMD_USER_DIR="$sysd" BIN_DIR="$bind" AUTOSTART_DIR="$auto" \
     SKIP_KEYBINDINGS=1 \
-    GDBUS_BIN="${GDBUS_BIN:-true}" \
+    GDBUS_BIN="${GDBUS_BIN:-$src/gdbus-ok}" \
     PATH="$path" bash "$src/install.sh" >"$src/out.log" 2>&1
 }
 
@@ -170,6 +173,11 @@ grep -q '__SETKA_TRAY_EXEC__' "$TU1/autostart/setka-tray.desktop" \
 grep -q "$TU1/bin/setka-tray" "$TU1/autostart/setka-tray.desktop" \
   && pass "U3 happy: Exec wskazuje na $TU1/bin/setka-tray" \
   || fail "U3 happy: brak absolutnej ścieżki w Exec; .desktop: $(cat "$TU1/autostart/setka-tray.desktop" 2>/dev/null)"
+
+# Watcher aktywny (mock gdbus-ok → '(true,)') → BRAK fałszywego ostrzeżenia o StatusNotifierWatcher
+grep -qi 'StatusNotifierWatcher niedostępny' "$TU1/out.log" \
+  && fail "U3 happy: fałszywe ostrzeżenie o StatusNotifierWatcher mimo aktywnego watchera" \
+  || pass "U3 happy: brak fałszywego ostrzeżenia gdy watcher aktywny"
 
 # --- Test U3-2: Idempotencja .desktop — ponowny install identycznych plików → brak backupu ---
 run_install3 "$TU1/src" "$TU1/systemd" "$TU1/bin" "$TU1/autostart"

--- a/deploy/live/tests/test_keybindings.sh
+++ b/deploy/live/tests/test_keybindings.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# ABOUTME: Testy live-keybindings.sh — weryfikuje idempotentne dodawanie skrótów GNOME przez gsettings.
+# ABOUTME: Używa recorder-mock gsettings (env GSETTINGS_BIN) zamiast żywego sesji.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KB_SH="$SCRIPT_DIR/../bin/live-keybindings.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); printf 'ok   - %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf 'FAIL - %s\n' "$1"; }
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Recorder-mock gsettings
+#
+# Obsługuje dwa tryby:
+#   get  <schema> <key>   → wypisuje wartość z MOCK_LIST (lub @as [] gdy puste)
+#   set  <schema> <key> <val> → loguje do GSETTINGS_LOG
+#
+# Zmienne sterujące:
+#   MOCK_LIST  — wartość zwracana przez `get ... custom-keybindings` (domyślnie '@as []')
+#   GSETTINGS_LOG — ścieżka do pliku logu (musi być ustawiona przez testy)
+# ---------------------------------------------------------------------------
+GSETTINGS_REC="$WORK/gsettings-rec"
+cat >"$GSETTINGS_REC" <<'EOF'
+#!/usr/bin/env bash
+# Recorder-mock gsettings: get zwraca MOCK_LIST; set loguje do GSETTINGS_LOG.
+cmd="$1"
+shift
+if [ "$cmd" = "get" ]; then
+    # Argumenty: <schema> <key>
+    # Zwracamy MOCK_LIST jeśli pytają o custom-keybindings, inaczej pusty as.
+    key="${2:-}"
+    if [ "$key" = "custom-keybindings" ]; then
+        printf '%s\n' "${MOCK_LIST:-@as []}"
+    else
+        # Dla per-binding get zwracamy puste (nie jest testowane bezpośrednio)
+        printf "''\n"
+    fi
+elif [ "$cmd" = "set" ]; then
+    printf 'set %s\n' "$*" >> "${GSETTINGS_LOG:-/dev/null}"
+else
+    # Passthrough dla innych komend (nieużywane w testach)
+    printf 'cmd=%s args=%s\n' "$cmd" "$*" >> "${GSETTINGS_LOG:-/dev/null}"
+fi
+exit 0
+EOF
+chmod +x "$GSETTINGS_REC"
+
+GSETTINGS_LOG="$WORK/gsettings.log"
+
+# Uruchamia kb_add z recorder-mock gsettings.
+# Argumenty: path name command keys [extra env vars...]
+run_kb_add() {
+    local path="$1" name="$2" command="$3" keys="$4"
+    shift 4
+    : >"$GSETTINGS_LOG"
+    GSETTINGS_BIN="$GSETTINGS_REC" \
+        GSETTINGS_LOG="$GSETTINGS_LOG" \
+        MOCK_LIST="${MOCK_LIST:-@as []}" \
+        "$@" \
+        bash "$KB_SH" kb_add "$path" "$name" "$command" "$keys" >"$WORK/kb.out" 2>&1
+    echo $?
+}
+
+# Uruchamia install_keybindings z recorder-mock gsettings.
+run_install_keybindings() {
+    : >"$GSETTINGS_LOG"
+    GSETTINGS_BIN="$GSETTINGS_REC" \
+        GSETTINGS_LOG="$GSETTINGS_LOG" \
+        MOCK_LIST="${MOCK_LIST:-@as []}" \
+        "$@" \
+        bash "$KB_SH" >"$WORK/kb.out" 2>&1
+    echo $?
+}
+
+# ---------------------------------------------------------------------------
+# TEST 1: Happy path — pusta lista @as [] → kb_add dodaje ścieżkę i ustawia per-binding
+# ---------------------------------------------------------------------------
+MOCK_LIST="@as []" \
+rc="$(run_kb_add \
+    '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/setka-show/' \
+    'Setka: Pokaż okna' \
+    'setka-live show' \
+    '<Super><Shift>s')"
+[ "$rc" = "0" ] \
+    && pass "kb_add pusta-lista: exit 0" \
+    || fail "kb_add pusta-lista: exit $rc"
+
+# Lista custom-keybindings powinna być ustawiona (set na głównej schemie media-keys)
+grep -q "set org.gnome.settings-daemon.plugins.media-keys custom-keybindings" "$GSETTINGS_LOG" \
+    && pass "kb_add pusta-lista: ustawia custom-keybindings" \
+    || fail "kb_add pusta-lista: brak set custom-keybindings; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+# Per-binding name ustawione
+grep -q "set.*setka-show.*name" "$GSETTINGS_LOG" \
+    && pass "kb_add pusta-lista: ustawia name per-binding" \
+    || fail "kb_add pusta-lista: brak set name; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+# Per-binding command ustawione
+grep -q "set.*setka-show.*command" "$GSETTINGS_LOG" \
+    && pass "kb_add pusta-lista: ustawia command per-binding" \
+    || fail "kb_add pusta-lista: brak set command; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+# Per-binding binding ustawione
+grep -q "set.*setka-show.*binding" "$GSETTINGS_LOG" \
+    && pass "kb_add pusta-lista: ustawia binding per-binding" \
+    || fail "kb_add pusta-lista: brak set binding; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+# TEST 2: Idempotencja — ścieżka już w liście → no-op (brak ponownego set listy)
+# ---------------------------------------------------------------------------
+MOCK_LIST="['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/setka-show/']" \
+rc="$(run_kb_add \
+    '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/setka-show/' \
+    'Setka: Pokaż okna' \
+    'setka-live show' \
+    '<Super><Shift>s')"
+[ "$rc" = "0" ] \
+    && pass "kb_add idempotent: exit 0" \
+    || fail "kb_add idempotent: exit $rc"
+
+# Nie powinno set custom-keybindings gdy ścieżka już jest.
+# Szukamy wpisu dla głównej schematy media-keys (klucz 'custom-keybindings'), nie per-binding.
+grep -q "set org.gnome.settings-daemon.plugins.media-keys custom-keybindings" "$GSETTINGS_LOG" \
+    && fail "kb_add idempotent: zbędny set custom-keybindings przy istniejącej ścieżce; log: $(cat "$GSETTINGS_LOG")" \
+    || pass "kb_add idempotent: brak set custom-keybindings (no-op dla listy)"
+
+# ---------------------------------------------------------------------------
+# TEST 3: Lista z istniejącym customem użytkownika → nowa ścieżka dopisana, stara zachowana
+# ---------------------------------------------------------------------------
+USER_CUSTOM="'/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/moj-skrot/'"
+MOCK_LIST="[$USER_CUSTOM]" \
+rc="$(run_kb_add \
+    '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/setka-show/' \
+    'Setka: Pokaż okna' \
+    'setka-live show' \
+    '<Super><Shift>s')"
+[ "$rc" = "0" ] \
+    && pass "kb_add zachowaj-custom: exit 0" \
+    || fail "kb_add zachowaj-custom: exit $rc"
+
+# Nowa ścieżka musi trafić do listy (set na głównej schemie media-keys)
+grep -q "set org.gnome.settings-daemon.plugins.media-keys custom-keybindings" "$GSETTINGS_LOG" \
+    && pass "kb_add zachowaj-custom: ustawia custom-keybindings" \
+    || fail "kb_add zachowaj-custom: brak set custom-keybindings; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+# Stary custom musi być zachowany w nowej liście
+grep "set.*custom-keybindings" "$GSETTINGS_LOG" | grep -q "moj-skrot" \
+    && pass "kb_add zachowaj-custom: stary custom zachowany w liście" \
+    || fail "kb_add zachowaj-custom: stary custom zgubiony; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+# TEST 4: install_keybindings (main) — rejestruje oba skróty (show + delete-last)
+# ---------------------------------------------------------------------------
+MOCK_LIST="@as []" \
+rc="$(SETKA_LIVE_CMD="$WORK/fake-setka-live" \
+    KB_SHOW='<Super><Shift>s' \
+    KB_DELETE='<Super><Shift>d' \
+    run_install_keybindings)"
+[ "$rc" = "0" ] \
+    && pass "install_keybindings: exit 0" \
+    || fail "install_keybindings: exit $rc; out: $(cat "$WORK/kb.out" 2>/dev/null)"
+
+grep -q "setka-show" "$GSETTINGS_LOG" \
+    && pass "install_keybindings: rejestruje setka-show" \
+    || fail "install_keybindings: brak setka-show; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+grep -q "setka-delete-last" "$GSETTINGS_LOG" \
+    && pass "install_keybindings: rejestruje setka-delete-last" \
+    || fail "install_keybindings: brak setka-delete-last; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+# TEST 5: install_keybindings — SETKA_LIVE_CMD używany w command (absolutna ścieżka)
+# ---------------------------------------------------------------------------
+MOCK_LIST="@as []"
+FAKE_CMD="/opt/setka/bin/setka-live"
+rc="$(SETKA_LIVE_CMD="$FAKE_CMD" \
+    KB_SHOW='<Super><Shift>s' \
+    KB_DELETE='<Super><Shift>d' \
+    run_install_keybindings)"
+[ "$rc" = "0" ] \
+    && pass "install_keybindings cmd-abs: exit 0" \
+    || fail "install_keybindings cmd-abs: exit $rc"
+
+grep -q "$FAKE_CMD" "$GSETTINGS_LOG" \
+    && pass "install_keybindings cmd-abs: SETKA_LIVE_CMD w komendach" \
+    || fail "install_keybindings cmd-abs: brak SETKA_LIVE_CMD w logu; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_setka_live.sh
+++ b/deploy/live/tests/test_setka_live.sh
@@ -74,7 +74,7 @@ grep -- '--user stop' "$REC_LOG" | grep -q 'live-preflight.service' \
   && pass "restart: stop obejmuje live-preflight (re-weryfikacja przy starcie)" \
   || fail "restart: stop nie obejmuje live-preflight"
 
-# --- NIGDY nie tyka paternologii (w żadnej komendzie) ---
+# --- NIGDY nie tyka paternologii (w żadnej komendzie, włącznie z delete-last) ---
 touched_pat=0
 for cmd in start stop restart status; do
   run_setka "$cmd" >/dev/null
@@ -114,6 +114,339 @@ rc="$(LAYOUT_RC=1 run_setka start)"
 rc="$(run_setka frobnicate)"
 [ "$rc" != "0" ] && pass "unknown: niezerowy exit dla nieznanej komendy" || fail "unknown: exit 0 (powinno != 0)"
 grep -qi 'show' "$WORK/out.log" && pass "unknown: usage wymienia komendę show" || fail "unknown: usage bez show"
+
+# =============================================================================
+# Testy delete-last (Unit 1)
+# =============================================================================
+# Strategia sourcowania: setka-live ma `set -euo pipefail` i source-guard wokół main "$@".
+# Sourcujemy w subshellach (przez `bash -c "source ..."`), żeby:
+#   (a) uniknąć zarażenia powłoki testowej przez set -e,
+#   (b) każdy test miał izolowany stan.
+# Funkcje testowane czysto przez sourcing ze SETKA_LIVE_SOURCED=1 (guard).
+#
+# Rejestratory GIO_BIN / ZENITY_BIN / NOTIFY_BIN — wzorzec analogiczny do SYSTEMCTL_BIN.
+
+GIO_LOG="$WORK/gio.log"
+ZENITY_LOG="$WORK/zenity.log"
+NOTIFY_LOG="$WORK/notify.log"
+
+# Rejestrator GIO_BIN: loguje argumenty; domyślnie exit 0; GIO_RC override.
+GIO_REC="$WORK/gio-rec"
+cat >"$GIO_REC" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GIO_LOG"
+exit "${GIO_RC:-0}"
+EOF
+chmod +x "$GIO_REC"
+
+# Rejestrator ZENITY_BIN: loguje argumenty; domyślnie exit 0; ZENITY_RC override.
+ZENITY_REC="$WORK/zenity-rec"
+cat >"$ZENITY_REC" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$ZENITY_LOG"
+exit "${ZENITY_RC:-0}"
+EOF
+chmod +x "$ZENITY_REC"
+
+# Rejestrator NOTIFY_BIN: zawsze exit 0; loguje argumenty.
+NOTIFY_REC="$WORK/notify-rec"
+cat >"$NOTIFY_REC" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$NOTIFY_LOG"
+exit 0
+EOF
+chmod +x "$NOTIFY_REC"
+
+# Pomocnicza funkcja wywołująca setka-live delete-last z wstrzykniętymi rejestratorami.
+# Czyści logi przed każdym wywołaniem; dodatkowe zmienne env przez $@.
+run_delete_last() {
+  : >"$GIO_LOG" >"$ZENITY_LOG" >"$NOTIFY_LOG"
+  GIO_LOG="$GIO_LOG" ZENITY_LOG="$ZENITY_LOG" NOTIFY_LOG="$NOTIFY_LOG" \
+    GIO_BIN="$GIO_REC" ZENITY_BIN="$ZENITY_REC" NOTIFY_BIN="$NOTIFY_REC" \
+    GIO_RC="${GIO_RC:-0}" ZENITY_RC="${ZENITY_RC:-0}" \
+    SYSTEMCTL_BIN="$REC" SETKA_REC_LOG="$REC_LOG" \
+    LAYOUT_BIN="$LAYOUT_REC" \
+    HEALTH_URL="http://127.0.0.1:59999/health" \
+    "$@" \
+    bash "$SETKA" delete-last >"$WORK/out.log" 2>&1
+  echo $?
+}
+
+# Funkcja sourcująca setka-live w subshellach dla testów czystych funkcji.
+# Wywołaj: call_fn "SETKA_RECORDINGS_ROOT=/tmp/... resolve_recordings_root"
+# Zwraca: stdout funkcji; exit code z subshella.
+call_fn() {
+  local env_and_fn="$1"
+  bash -c "
+    set +e
+    source '$SETKA'
+    $env_and_fn
+  " 2>&1
+}
+
+call_fn_rc() {
+  local env_and_fn="$1"
+  bash -c "
+    set +e
+    source '$SETKA'
+    $env_and_fn
+  " >/dev/null 2>&1
+  echo $?
+}
+
+# Pomocnicza: utwórz katalog nagrania (z metadata.json + plikiem wideo).
+mk_recording() {
+  local dir="$1"
+  mkdir -p "$dir"
+  touch "$dir/metadata.json"
+  touch "$dir/clip.mp4"
+}
+
+# Pomocnicza: utwórz katalog nagrania tylko z metadata.json (bez wideo).
+mk_no_video() {
+  local dir="$1"
+  mkdir -p "$dir"
+  touch "$dir/metadata.json"
+}
+
+# Pomocnicza: utwórz katalog z wideo bez metadata.json.
+mk_no_meta() {
+  local dir="$1"
+  mkdir -p "$dir"
+  touch "$dir/clip.mp4"
+}
+
+# --- TEST 1: Happy path — 3 prawidłowe katalogi, zenity rc 0, gio trash wywoływany na najnowszym ---
+REC_ROOT="$WORK/recs"
+mkdir -p "$REC_ROOT"
+mk_recording "$REC_ROOT/2026-01-01_10-00-00"
+mk_recording "$REC_ROOT/2026-01-02_10-00-00"
+mk_recording "$REC_ROOT/2026-01-03_10-00-00"
+# Ustaw mtime: najnowszy to 2026-01-03
+touch -d "2026-01-01 10:00:00" "$REC_ROOT/2026-01-01_10-00-00"
+touch -d "2026-01-02 10:00:00" "$REC_ROOT/2026-01-02_10-00-00"
+touch -d "2026-01-03 10:00:00" "$REC_ROOT/2026-01-03_10-00-00"
+
+rc="$(SETKA_RECORDINGS_ROOT="$REC_ROOT" ZENITY_RC=0 run_delete_last)"
+[ "$rc" = "0" ] && pass "delete-last happy: exit 0" || fail "delete-last happy: exit $rc"
+grep -q "trash" "$GIO_LOG" \
+  && pass "delete-last happy: gio trash wywołany" || fail "delete-last happy: brak gio trash"
+grep -q "2026-01-03" "$GIO_LOG" \
+  && pass "delete-last happy: gio trash wskazuje najnowszy katalog" \
+  || fail "delete-last happy: gio trash nie wskazuje 2026-01-03; log: $(cat "$GIO_LOG" 2>/dev/null)"
+grep -q "2026-01-03" "$NOTIFY_LOG" \
+  && pass "delete-last happy: notify-send zawiera nazwę katalogu" \
+  || fail "delete-last happy: notify-send bez nazwy; log: $(cat "$NOTIFY_LOG" 2>/dev/null)"
+
+# --- TEST 2: Zenity anuluje (rc 1) → BRAK gio trash ---
+rc="$(SETKA_RECORDINGS_ROOT="$REC_ROOT" ZENITY_RC=1 run_delete_last)"
+[ "$rc" = "0" ] && pass "delete-last cancel: exit 0 po anulowaniu" || fail "delete-last cancel: exit $rc"
+grep -q "trash" "$GIO_LOG" \
+  && fail "delete-last cancel: gio trash NIE powinien być wywołany" \
+  || pass "delete-last cancel: brak gio trash (fail-safe)"
+
+# --- TEST 3: Katalog bez prawidłowych nagrań → notify 'brak nagrania', brak zenity, brak gio ---
+EMPTY_ROOT="$WORK/empty_recs"
+mkdir -p "$EMPTY_ROOT"
+# Tylko zwykłe pliki lub katalogi bez metadata.json
+touch "$EMPTY_ROOT/jakis_plik.txt"
+mkdir -p "$EMPTY_ROOT/nieprawidlowy_podkatalog"
+
+rc="$(SETKA_RECORDINGS_ROOT="$EMPTY_ROOT" run_delete_last)"
+[ "$rc" = "0" ] && pass "delete-last brak-nagrań: exit 0" || fail "delete-last brak-nagrań: exit $rc"
+[ -s "$GIO_LOG" ] \
+  && fail "delete-last brak-nagrań: gio trash NIE powinien być wywołany; log: $(cat "$GIO_LOG")" \
+  || pass "delete-last brak-nagrań: brak gio trash"
+[ -s "$ZENITY_LOG" ] \
+  && fail "delete-last brak-nagrań: zenity NIE powinien być wywołany" \
+  || pass "delete-last brak-nagrań: brak zenity"
+grep -qi 'brak' "$NOTIFY_LOG" \
+  && pass "delete-last brak-nagrań: notify-send informuje o braku" \
+  || fail "delete-last brak-nagrań: brak notify o braku; log: $(cat "$NOTIFY_LOG" 2>/dev/null)"
+
+# --- TEST 4a: Podkatalog z metadata.json ale bez wideo → pominięty ---
+PARTIAL_ROOT="$WORK/partial_recs"
+mkdir -p "$PARTIAL_ROOT"
+mk_no_video "$PARTIAL_ROOT/tylko_meta"
+mk_no_meta  "$PARTIAL_ROOT/tylko_wideo"
+
+rc="$(SETKA_RECORDINGS_ROOT="$PARTIAL_ROOT" run_delete_last)"
+[ "$rc" = "0" ] && pass "delete-last partial: exit 0 przy braku kompletnych katalogów" \
+  || fail "delete-last partial: exit $rc"
+[ -s "$GIO_LOG" ] \
+  && fail "delete-last partial: gio trash NIE powinien być wywołany; log: $(cat "$GIO_LOG")" \
+  || pass "delete-last partial: brak gio trash dla niekompletnych katalogów"
+
+# --- TEST 5: Walidacja roota — pusty string ---
+rc="$(SETKA_RECORDINGS_ROOT="" run_delete_last)"
+[ "$rc" != "0" ] && pass "delete-last root-pusty: niezerowy exit dla pustego SETKA_RECORDINGS_ROOT" \
+  || fail "delete-last root-pusty: exit 0 dla pustego roota"
+[ -s "$GIO_LOG" ] && fail "delete-last root-pusty: gio trash NIE powinien być wywołany" \
+  || pass "delete-last root-pusty: brak gio trash"
+
+# --- TEST 5b: Walidacja roota — ścieżka względna ---
+rc="$(SETKA_RECORDINGS_ROOT="relative/path" run_delete_last)"
+[ "$rc" != "0" ] && pass "delete-last root-wzgledny: odmowa dla ścieżki względnej" \
+  || fail "delete-last root-wzgledny: exit 0 dla ścieżki względnej"
+[ -s "$GIO_LOG" ] && fail "delete-last root-wzgledny: gio trash NIE powinien być wywołany" \
+  || pass "delete-last root-wzgledny: brak gio trash"
+
+# --- TEST 5c: Walidacja roota — nieistniejąca ścieżka ---
+rc="$(SETKA_RECORDINGS_ROOT="/tmp/setka_test_nonexistent_$$" run_delete_last)"
+[ "$rc" != "0" ] && pass "delete-last root-nieistniejący: odmowa dla nieistniejącej ścieżki" \
+  || fail "delete-last root-nieistniejący: exit 0 dla nieistniejącej ścieżki"
+[ -s "$GIO_LOG" ] && fail "delete-last root-nieistniejący: gio trash NIE powinien być wywołany" \
+  || pass "delete-last root-nieistniejący: brak gio trash"
+
+# --- TEST 5d: Walidacja roota — plik zamiast katalogu ---
+TMPFILE="$WORK/not_a_dir"
+touch "$TMPFILE"
+rc="$(SETKA_RECORDINGS_ROOT="$TMPFILE" run_delete_last)"
+[ "$rc" != "0" ] && pass "delete-last root-plik: odmowa gdy root jest plikiem" \
+  || fail "delete-last root-plik: exit 0 gdy root jest plikiem"
+[ -s "$GIO_LOG" ] && fail "delete-last root-plik: gio trash NIE powinien być wywołany" \
+  || pass "delete-last root-plik: brak gio trash"
+
+# --- TEST 5e: Walidacja roota — $HOME ---
+rc="$(SETKA_RECORDINGS_ROOT="$HOME" run_delete_last)"
+[ "$rc" != "0" ] && pass "delete-last root-HOME: odmowa gdy root == \$HOME" \
+  || fail "delete-last root-HOME: exit 0 gdy root == \$HOME"
+[ -s "$GIO_LOG" ] && fail "delete-last root-HOME: gio trash NIE powinien być wywołany" \
+  || pass "delete-last root-HOME: brak gio trash"
+
+# --- TEST 5f: Walidacja roota — / ---
+rc="$(SETKA_RECORDINGS_ROOT="/" run_delete_last)"
+[ "$rc" != "0" ] && pass "delete-last root-slash: odmowa gdy root == /" \
+  || fail "delete-last root-slash: exit 0 gdy root == /"
+[ -s "$GIO_LOG" ] && fail "delete-last root-slash: gio trash NIE powinien być wywołany" \
+  || pass "delete-last root-slash: brak gio trash"
+
+# --- TEST 6: Fallback roota — brak env, ~/Wideo/obs brak, ~/Videos/obs istnieje (bezpieczny HOME) ---
+FAKE_HOME="$WORK/fake_home"
+mkdir -p "$FAKE_HOME/Videos/obs"
+mk_recording "$FAKE_HOME/Videos/obs/2026-01-01_12-00-00"
+
+rc="$(HOME="$FAKE_HOME" ZENITY_RC=0 run_delete_last)"
+[ "$rc" = "0" ] && pass "delete-last fallback: exit 0 przy fallbacku na ~/Videos/obs" \
+  || fail "delete-last fallback: exit $rc"
+grep -q "trash" "$GIO_LOG" \
+  && pass "delete-last fallback: gio trash wywołany z katalogu ~/Videos/obs" \
+  || fail "delete-last fallback: brak gio trash dla fallbacku"
+
+# --- TEST 7: Symlink-escape — najnowszy 'podkatalog' to symlink poza root → pominięty ---
+SYMLINK_ROOT="$WORK/symlink_recs"
+OUTSIDE_DIR="$WORK/outside_dir"
+mkdir -p "$SYMLINK_ROOT" "$OUTSIDE_DIR"
+touch "$OUTSIDE_DIR/metadata.json" "$OUTSIDE_DIR/clip.mp4"
+# Symlink w roocie wskazuje poza root
+ln -s "$OUTSIDE_DIR" "$SYMLINK_ROOT/symlink_rec"
+# Prawidłowy katalog w roocie (starszy)
+mk_recording "$SYMLINK_ROOT/2026-01-01_10-00-00"
+touch -d "2026-01-01 10:00:00" "$SYMLINK_ROOT/2026-01-01_10-00-00"
+# Symlink ma nowszy mtime
+touch -d "2026-01-04 10:00:00" "$OUTSIDE_DIR"
+
+rc="$(SETKA_RECORDINGS_ROOT="$SYMLINK_ROOT" ZENITY_RC=0 run_delete_last)"
+[ "$rc" = "0" ] && pass "delete-last symlink: exit 0 (nie zawiesza się na symlinkach)" \
+  || fail "delete-last symlink: exit $rc"
+# Symlink poza root powinien być pominięty; trash na prawidłowym
+grep -q "outside_dir" "$GIO_LOG" \
+  && fail "delete-last symlink: gio trash NIE powinien trafić poza root; log: $(cat "$GIO_LOG" 2>/dev/null)" \
+  || pass "delete-last symlink: gio trash nie wyszedł poza root"
+
+# --- TEST 8: describe_recording zawiera nazwę, wiek i rozmiar ---
+DESC_DIR="$WORK/desc_recs/2026-01-05_15-30-00"
+mk_recording "$DESC_DIR"
+desc="$(call_fn "describe_recording '$DESC_DIR'")"
+printf '%s' "$desc" | grep -q "2026-01-05" \
+  && pass "describe_recording: zawiera nazwę katalogu" \
+  || fail "describe_recording: brak nazwy; wynik: $desc"
+# Wiek — jakakolwiek liczba lub jednostka czasu (s, min, godz, h, d, temu, ago)
+printf '%s' "$desc" | grep -qE '[0-9]' \
+  && pass "describe_recording: zawiera wiek (cyfry)" \
+  || fail "describe_recording: brak cyfr w opisie; wynik: $desc"
+# Rozmiar — du -sh zwraca np. '4,0K' lub '4.0K'
+printf '%s' "$desc" | grep -qiE '[0-9]' \
+  && pass "describe_recording: zawiera rozmiar" \
+  || fail "describe_recording: brak rozmiaru; wynik: $desc"
+
+# --- TEST 9: Błąd gio (rc != 0) → notify-send z błędem, nie z 'przeniesiono' ---
+GIO_ROOT="$WORK/gio_err_recs"
+mkdir -p "$GIO_ROOT"
+mk_recording "$GIO_ROOT/2026-01-06_10-00-00"
+
+rc="$(SETKA_RECORDINGS_ROOT="$GIO_ROOT" ZENITY_RC=0 GIO_RC=1 run_delete_last)"
+# Błąd gio → niezerowy exit LUB exit 0 z powiadomieniem o błędzie
+grep -qi "błąd\|error\|nie udało\|fail" "$NOTIFY_LOG" \
+  && pass "delete-last gio-error: notify-send informuje o błędzie gio" \
+  || fail "delete-last gio-error: brak powiadomienia o błędzie; log: $(cat "$NOTIFY_LOG" 2>/dev/null)"
+grep -qi "przeniesion" "$NOTIFY_LOG" \
+  && fail "delete-last gio-error: notify NIE powinien pisać 'przeniesiono' przy błędzie gio" \
+  || pass "delete-last gio-error: brak fałszywego 'przeniesiono'"
+
+# --- TEST 10a: Dispatch delete-last trafia w cmd_delete_last ---
+mk_recording "$REC_ROOT/2026-01-10_10-00-00"
+touch -d "2026-01-10 10:00:00" "$REC_ROOT/2026-01-10_10-00-00"
+rc="$(SETKA_RECORDINGS_ROOT="$REC_ROOT" ZENITY_RC=1 run_delete_last)"
+# Zenity rc=1 = anulowanie → exit 0 (nie exit 2 jak nieznana komenda)
+[ "$rc" = "0" ] && pass "dispatch: delete-last → cmd_delete_last (exit 0 przy anulowaniu)" \
+  || fail "dispatch: delete-last nie trafia w cmd_delete_last; exit $rc"
+
+# --- TEST 10b: Nieznana komenda → exit 2 (regresja) ---
+rc="$(run_setka frobnicate)"
+[ "$rc" = "2" ] && pass "dispatch: nieznana komenda → exit 2 (regresja)" \
+  || fail "dispatch: nieznana komenda exit $rc (oczekiwano 2)"
+
+# --- TEST 10c: delete-last nie dotyka paternologia.service ---
+SETKA_RECORDINGS_ROOT="$REC_ROOT" ZENITY_RC=1 run_delete_last >/dev/null
+grep -q 'paternologia' "$REC_LOG" \
+  && fail "delete-last: NIE powinien tykać paternologia.service" \
+  || pass "delete-last: nie dotyka paternologia.service"
+
+# --- TEST: is_recording_dir rozróżnia struktury ---
+IS_REC_DIR="$WORK/is_rec_test"
+mkdir -p "$IS_REC_DIR/pełny" "$IS_REC_DIR/bez_meta" "$IS_REC_DIR/bez_wideo"
+touch "$IS_REC_DIR/pełny/metadata.json" "$IS_REC_DIR/pełny/clip.mkv"
+touch "$IS_REC_DIR/bez_meta/clip.mp4"
+touch "$IS_REC_DIR/bez_wideo/metadata.json"
+
+rc_pelny="$(call_fn_rc "is_recording_dir '$IS_REC_DIR/pełny'")"
+[ "$rc_pelny" = "0" ] && pass "is_recording_dir: pełny katalog → 0" \
+  || fail "is_recording_dir: pełny katalog → $rc_pelny (oczekiwano 0)"
+
+rc_bez_meta="$(call_fn_rc "is_recording_dir '$IS_REC_DIR/bez_meta'")"
+[ "$rc_bez_meta" != "0" ] && pass "is_recording_dir: bez metadata.json → niezerowy" \
+  || fail "is_recording_dir: bez metadata.json → 0 (błędnie)"
+
+rc_bez_wideo="$(call_fn_rc "is_recording_dir '$IS_REC_DIR/bez_wideo'")"
+[ "$rc_bez_wideo" != "0" ] && pass "is_recording_dir: bez wideo → niezerowy" \
+  || fail "is_recording_dir: bez wideo → 0 (błędnie)"
+
+# --- TEST: find_latest_recording zwraca najnowszy z kilku ---
+FLR_ROOT="$WORK/flr_recs"
+mkdir -p "$FLR_ROOT"
+mk_recording "$FLR_ROOT/2026-02-01_10-00-00"
+mk_recording "$FLR_ROOT/2026-02-02_10-00-00"
+mk_recording "$FLR_ROOT/2026-02-03_10-00-00"
+touch -d "2026-02-01 10:00:00" "$FLR_ROOT/2026-02-01_10-00-00"
+touch -d "2026-02-02 10:00:00" "$FLR_ROOT/2026-02-02_10-00-00"
+touch -d "2026-02-03 10:00:00" "$FLR_ROOT/2026-02-03_10-00-00"
+latest="$(call_fn "find_latest_recording '$FLR_ROOT'")"
+printf '%s' "$latest" | grep -q "2026-02-03" \
+  && pass "find_latest_recording: zwraca najnowszy katalog" \
+  || fail "find_latest_recording: zwrócił '$latest' (oczekiwano 2026-02-03)"
+
+# --- TEST: resolve_recordings_root używa SETKA_RECORDINGS_ROOT gdy ustawiony ---
+rr="$(call_fn "SETKA_RECORDINGS_ROOT='$REC_ROOT' resolve_recordings_root")"
+[ "$rr" = "$REC_ROOT" ] \
+  && pass "resolve_recordings_root: zwraca SETKA_RECORDINGS_ROOT gdy ustawiony i prawidłowy" \
+  || fail "resolve_recordings_root: zwrócił '$rr' (oczekiwano $REC_ROOT)"
+
+# --- TEST: usage wymienia delete-last ---
+rc="$(run_setka frobnicate)"
+grep -qi 'delete-last' "$WORK/out.log" \
+  && pass "usage: wymienia delete-last" \
+  || fail "usage: nie wymienia delete-last"
 
 rm -rf "$WORK"
 printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"

--- a/deploy/live/tests/test_setka_live.sh
+++ b/deploy/live/tests/test_setka_live.sh
@@ -422,6 +422,24 @@ rc_bez_wideo="$(call_fn_rc "is_recording_dir '$IS_REC_DIR/bez_wideo'")"
 [ "$rc_bez_wideo" != "0" ] && pass "is_recording_dir: bez wideo → niezerowy" \
   || fail "is_recording_dir: bez wideo → 0 (błędnie)"
 
+# --- TEST (regresja): plik wideo ze SPACJAMI w nazwie (realny format OBS) ---
+# Realne nagrania OBS to np. "2026-06-04 17-30-58.mp4" lub "Projekt bez nazwy.mp4".
+# Wcześniejsze `ls "$dir"/$glob | grep` rozbijało nazwę na osobne argumenty i zawodziło.
+mkdir -p "$IS_REC_DIR/ze spacją"
+touch "$IS_REC_DIR/ze spacją/metadata.json" "$IS_REC_DIR/ze spacją/Projekt bez nazwy.mp4"
+rc_spacje="$(call_fn_rc "is_recording_dir '$IS_REC_DIR/ze spacją'")"
+[ "$rc_spacje" = "0" ] && pass "is_recording_dir: plik wideo ze spacjami w nazwie → 0" \
+  || fail "is_recording_dir: plik wideo ze spacjami → $rc_spacje (oczekiwano 0)"
+
+# find_latest_recording też musi znaleźć katalog z wideo ze spacjami w nazwie.
+FLR_SP="$WORK/flr_spacje"
+mkdir -p "$FLR_SP/2026-06-04 17-30-58"
+touch "$FLR_SP/2026-06-04 17-30-58/metadata.json" "$FLR_SP/2026-06-04 17-30-58/2026-06-04 17-30-58.mp4"
+latest_sp="$(call_fn "find_latest_recording '$FLR_SP'")"
+printf '%s' "$latest_sp" | grep -q "17-30-58" \
+  && pass "find_latest_recording: znajduje katalog z wideo ze spacjami w nazwie" \
+  || fail "find_latest_recording: zwrócił '$latest_sp' (oczekiwano 17-30-58)"
+
 # --- TEST: find_latest_recording zwraca najnowszy z kilku ---
 FLR_ROOT="$WORK/flr_recs"
 mkdir -p "$FLR_ROOT"

--- a/deploy/live/tests/test_setka_tray.py
+++ b/deploy/live/tests/test_setka_tray.py
@@ -1,0 +1,68 @@
+# ABOUTME: Testy czystej logiki setka-tray (tabela menu → komendy) bez importu GTK.
+# ABOUTME: Importuje moduł przez SourceFileLoader, by uniknąć rozszerzenia .py.
+
+import importlib.util
+import importlib.machinery
+import pathlib
+import pytest
+
+# Ścieżka absolutna do skryptu setka-tray (bez rozszerzenia .py)
+TRAY_SCRIPT = pathlib.Path(__file__).parent.parent / "bin" / "setka-tray"
+
+
+def load_tray_module():
+    """Ładuje moduł setka-tray bez importu GTK (import gi jest w main())."""
+    loader = importlib.machinery.SourceFileLoader("setka_tray", str(TRAY_SCRIPT))
+    spec = importlib.util.spec_from_loader("setka_tray", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def tray():
+    return load_tray_module()
+
+
+class TestMenuStructure:
+    """Testy czystej tabeli menu (bez GTK)."""
+
+    def test_pokaz_okna_mapuje_na_setka_live_show(self, tray):
+        """Pozycja 'Pokaż okna' musi mapować na ['setka-live', 'show']."""
+        items = tray.build_menu_items()
+        labels = {label: argv for label, argv in items if label is not None}
+        assert "Pokaż okna" in labels, "Brak pozycji 'Pokaż okna' w menu"
+        assert labels["Pokaż okna"] == ["setka-live", "show"]
+
+    def test_usun_ostatnie_nagranie_mapuje_na_delete_last(self, tray):
+        """Pozycja 'Usuń ostatnie nagranie' musi mapować na ['setka-live', 'delete-last']."""
+        items = tray.build_menu_items()
+        labels = {label: argv for label, argv in items if label is not None}
+        assert "Usuń ostatnie nagranie" in labels, (
+            "Brak pozycji 'Usuń ostatnie nagranie' w menu"
+        )
+        assert labels["Usuń ostatnie nagranie"] == ["setka-live", "delete-last"]
+
+    def test_zakoncz_mapuje_na_brak_komendy(self, tray):
+        """Pozycja 'Zakończ' musi mieć argv=None (czyste wyjście, brak komendy zewnętrznej)."""
+        items = tray.build_menu_items()
+        labels = {label: argv for label, argv in items if label is not None}
+        assert "Zakończ" in labels, "Brak pozycji 'Zakończ' w menu"
+        assert labels["Zakończ"] is None, (
+            "Zakończ powinno mieć argv=None, nie wywoływać komendy"
+        )
+
+    def test_menu_zawiera_separator(self, tray):
+        """Menu powinno zawierać przynajmniej jeden separator (krotka z label=None)."""
+        items = tray.build_menu_items()
+        separators = [item for item in items if item[0] is None]
+        assert len(separators) >= 1, "Brak separatora w menu"
+
+    def test_menu_zwraca_liste_krotek(self, tray):
+        """build_menu_items() zwraca listę krotek (label, argv)."""
+        items = tray.build_menu_items()
+        assert isinstance(items, list), "build_menu_items() musi zwracać listę"
+        for item in items:
+            assert isinstance(item, tuple) and len(item) == 2, (
+                f"Każda pozycja musi być krotką (label, argv), got: {item!r}"
+            )

--- a/docs/brainstorms/2026-06-04-live-operator-quick-actions-requirements.md
+++ b/docs/brainstorms/2026-06-04-live-operator-quick-actions-requirements.md
@@ -1,0 +1,155 @@
+---
+date: 2026-06-04
+topic: live-operator-quick-actions
+refined: 2026-06-04
+---
+
+> **Aktualizacja 2026-06-04 (podczas /ce:work — ustalanie niewiadomych).** Po zbadaniu
+> realnego środowiska (aktywny profil OBS `live` = `hybrid_mp4` do `/home/wojtas`; nagrania
+> reorganizowane w foldery `~/Wideo/obs/<timestamp>/`; `fermata` kasuje cały folder przez
+> nieodwracalne `remove_dir_all`) operator doprecyzował intencję: kasujemy **cały katalog
+> nagrania**, nie pojedynczy plik, i to **przez przeniesienie do kosza** (odwracalnie), nie
+> `rm`. To zmienia R3–R6 i część Scope Boundaries (patrz znaczniki *[zaktualizowane]*).
+
+# Szybkie akcje operatorskie sesji live (launcher + usuń ostatnie nagranie)
+
+## Problem Frame
+
+Podczas sesji nagraniowej (warstwa `setka-live`: Bitwig + OBS + kiosk paternologii na
+dwóch monitorach) operator co jakiś czas musi wykonać akcję spoza przepływu nagrywania,
+nie schodząc do terminala:
+
+1. **Przywrócić układ okien** (`setka-live show`), gdy okna się rozjechały — to akcja
+   ratunkowa, więc przycisk *wewnątrz* zakopanego okna kiosku jest bezużyteczny;
+   wyzwalacz musi działać globalnie, niezależnie od tego, co jest na wierzchu.
+2. **Usunąć ostatnie nagranie**, gdy ujęcie się nie udało, żeby nie zaśmiecać sesji —
+   akcja destrukcyjna, więc wymaga potwierdzenia i informacji zwrotnej o tym, co znikło.
+
+Obie akcje są wykonywane **między ujęciami** (ręce wolne, wzrok na ekranie), nie w trakcie
+grania.
+
+## Requirements
+
+- **R1.** Globalny wyzwalacz akcji dostępny niezależnie od aktywnego okna — realizowany
+  podwójnie: (a) ikona w tray z menu akcji oraz (b) globalne skróty klawiszowe GNOME na te
+  same akcje. Środowisko docelowe: GNOME na X11.
+- **R2.** Akcja „pokaż okna" wywołuje `setka-live show` (fire-and-forget; rezultat widać na
+  ekranie, brak osobnego powiadomienia wymaganego).
+- **R3.** *[zaktualizowane]* Akcja „usuń ostatnie nagranie" przenosi **cały najnowszy katalog
+  nagrania** (folder `<timestamp>/` w roocie nagrań — całość: plik wideo, `metadata.json`,
+  `extracted/`, `analysis/`, `blender/`) **do kosza GNOME** (`gio trash`), odwracalnie.
+  „Najnowszy" = wg mtime spośród prawidłowych katalogów nagrań pod rootem (katalog zawierający
+  `metadata.json` + plik wideo).
+- **R3a.** *[nowe]* Root nagrań pochodzi z env `SETKA_RECORDINGS_ROOT` (konwencja jak
+  `FERMATA_RECORDINGS_PATH` w fermacie), z defaultem `~/Wideo/obs` i fallbackiem `~/Videos/obs`
+  (zgodnie z listą zaszytą w obsession i realną lokalizacją nagrań). **Nie** pobieramy katalogu
+  z OBS WebSocket — `GetRecordDirectory` zwraca `RecFilePath` (np. `/home/wojtas`), czyli
+  lokalizację surowego pliku przed reorganizacją, a nie root sfolderyzowanych nagrań.
+- **R4.** Przeniesienie następuje wyłącznie po jawnym potwierdzeniu w oknie dialogowym
+  (`zenity`), które **nazywa konkretny katalog** (nazwa + wiek + łączny rozmiar), aby operator
+  upewnił się, że to właściwe nagranie.
+- **R5.** *[zaktualizowane]* Po przeniesieniu pokazywane jest powiadomienie o wyniku
+  (`notify-send`): co trafiło do kosza (+ podpowiedź „przywróć z Kosza/Plików"), lub że
+  anulowano / nic nie znaleziono / wystąpił błąd.
+- **R6.** *[zaktualizowane]* Bezpieczeństwo operacji zapewnia jej **odwracalność**
+  (przeniesienie do kosza, nie skasowanie) oraz **walidacja celu** (istnieje, jest katalogiem,
+  leży ściśle pod rootem, ma prawidłową strukturę nagrania), a nie twarde blokowanie podczas
+  nagrywania. Twardy guard „OBS nagrywa" nie jest wymagany: nagranie w toku to surowy plik w
+  innej lokalizacji (`RecFilePath`), jeszcze nie sfolderyzowane, więc nie jest kandydatem;
+  a nawet błędne przeniesienie jest odwracalne.
+- **R7.** Akcja nie wykonuje żadnego resetu rigu (Bitwig / M:S / Freak / Boss) — to jest
+  świadomie poza zakresem tej iteracji (patrz Scope Boundaries i przyszła faza).
+
+## Success Criteria
+
+- Jedno naciśnięcie skrótu **lub** jedno kliknięcie w tray przywraca układ okien przez
+  `setka-live show` bez dotykania terminala.
+- Akcja przenosi do kosza dokładnie zamierzony, najnowszy **katalog nagrania**, wyłącznie po
+  potwierdzeniu, które jednoznacznie identyfikuje folder (nazwa + wiek + rozmiar); wynik jest
+  widoczny w powiadomieniu, a operacja jest odwracalna (przywrócenie z kosza).
+- Operator nie musi pamiętać żadnej komendy ani ścieżki do katalogu nagrań.
+
+## Scope Boundaries
+
+- **Brak resetu rigu** w tej iteracji: żadnego czyszczenia nagranych ścieżek w Bitwigu ani
+  re-wyboru patternów/presetów na M:S/Freak/Boss. (Świadomie odłożone — „fajnie byłoby",
+  nie krytyczne; wymaga osobnego researchu.)
+- **Brak utrwalania stanu** „ostatniego nagrania" — identyfikacja wyłącznie po mtime katalogu
+  nagrania w roocie (bezstanowo; odporne na restart).
+- *[zaktualizowane]* **Przenosimy cały katalog nagrania do kosza** (`extracted/`, `analysis/`,
+  `blender/` itd. razem z plikiem wideo i `metadata.json`) — poprzednia granica „tylko surowy
+  plik" została świadomie zniesiona przez operatora. Operacja jest **odwracalna** (kosz GNOME),
+  więc nie jest to nieodwracalne kasowanie.
+- *[nowe]* **Brak twardego kasowania (`rm`)** — wyłącznie przeniesienie do kosza. Brak
+  permanentnego opróżniania kosza przez tę funkcję.
+- *[nowe]* **Logika w warstwie `setka-live` (bash), nie w paternologii** — ponieważ po
+  doprecyzowaniu funkcja nie potrzebuje OBS (root z env, brak guardu „nagrywa", brak sidecara),
+  znika powód, dla którego logika miała żyć w serwerze paternologii. Cała funkcja to czysty
+  wrapper bash (find newest dir → zenity → `gio trash` → notify).
+- **Tylko GNOME/X11** — bez wsparcia Wayland / innych DE w tej iteracji.
+
+## Key Decisions
+
+- **Tray + skróty, oba na tych samych akcjach** (wybór operatora) — maksimum wygody kosztem
+  większej infrastruktury; zaakceptowane świadomie.
+- **Kiosk odrzucony jako dom akcji** — `setka-live show` to akcja ratunkowa na rozjechane
+  okna, więc przycisk w (zakopanym) oknie kiosku nie spełniłby celu.
+- **Identyfikacja „ostatniego" po mtime katalogu** (wybór operatora) — prostsze i bezstanowe;
+  ryzyko trafienia w zły folder zneutralizowane przez odwracalność (kosz) + walidację struktury.
+- *[zaktualizowane]* **Przeniesienie do kosza zamiast `rm`** (decyzja operatora: „przesuwaj
+  folder + informuj, bez guard") — bezpieczeństwo przez odwracalność i dobry UX (przywracalne z
+  Nautilusa), zamiast ciężkiej maszynerii guardów. Mechanizm: `gio trash` (natywny kosz GNOME,
+  zweryfikowany na maszynie). Świadomie lepsze niż istniejące `remove_dir_all` w fermacie.
+- *[zaktualizowane]* **Root nagrań z env `SETKA_RECORDINGS_ROOT`** (porównanie plik vs env: env
+  to ustalona konwencja u wszystkich konsumentów — `FERMATA_RECORDINGS_PATH`,
+  `PATERNOLOGIA_DATA_DIR`; nikt nie trzyma roota w pliku-configu). Default `~/Wideo/obs`,
+  fallback `~/Videos/obs`.
+- **Akcje jako podkomendy `setka-live`, tray i skróty jako cienkie wyzwalacze** (DRY/KISS) —
+  pojedyncze źródło prawdy; tray i skrót tylko odpalają komendę. `setka-live show` już istnieje;
+  „usuń ostatnie" jako podkomenda `setka-live delete-last` (implementacja: przeniesienie do
+  kosza). Spójne z wzorcem operatorskim w `deploy/live/`.
+
+## Dependencies / Assumptions
+
+- `zenity`, `notify-send`, `gio` dostępne w środowisku GNOME — **zweryfikowane na maszynie
+  docelowej** (zenity 4.0.1, notify-send 0.8.3, gio 2.80 z działającym backendem kosza gvfs).
+- Root nagrań ustalany z env `SETKA_RECORDINGS_ROOT` (default `~/Wideo/obs`) — **bez** zależności
+  od OBS WebSocket (patrz R3a). Nagrania w roocie to sfolderyzowane katalogi `<timestamp>/` z
+  `metadata.json` (reorganizacja po stopie nagrania — potwierdzone świeżymi folderami z dziś).
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- _(brak — nic nie blokuje planowania)_
+
+### Rozstrzygnięte (podczas planowania / /ce:work 2026-06-04)
+
+- [R3] Cel = cały katalog nagrania, przeniesiony do kosza (`gio trash`), nie pojedynczy plik.
+- [R3a] Root nagrań z env `SETKA_RECORDINGS_ROOT` (default `~/Wideo/obs`, fallback `~/Videos/obs`);
+  nie z OBS WebSocket.
+- [R6] Bezpieczeństwo przez odwracalność + walidację, nie przez guard „OBS nagrywa" → OBS w ogóle
+  niepotrzebny → logika w bashu (`setka-live`), nie w paternologii.
+- [R1] Tray: PyGObject GTK3 + AyatanaAppIndicator3; skróty: `gsettings` media-keys
+  (zweryfikowane na maszynie). Domyślne skróty: `Super+Shift+S` (show), `Super+Shift+D`
+  (delete-last). Instalacja w `deploy/live/install.sh`.
+
+### Deferred to Planning
+
+- [Affects R2] Czy launcher ma eksponować więcej komend niż `show` i usuwanie (np. `restart`,
+  `status`)? Domyślnie startujemy z dwiema akcjami, struktura rozszerzalna.
+
+### Future Phase (poza tą iteracją — „reset rigu")
+
+- [Needs research] Czyszczenie nagranych ścieżek w Bitwigu — skrypt kontrolera Bitwiga
+  (rozszerzenie Java/JS) reagujący na dedykowaną wiadomość MIDI, vs wysyłanie Ctrl+Z do okna.
+- [Needs research] Routing MIDI z paternologii bezpośrednio do sprzętu (M:S/Freak/Boss),
+  żeby re-wysłać zdefiniowane w utworze akcje (re-wybór presetu/patternu). Uwaga: paternologia
+  nie zna stanu gałek — „reset" oznacza tylko re-wybór patternu, nie przywrócenie pełnego
+  stanu sprzętu. Ostrzeżenie o cegłowaniu Pacera nie dotyczy (reset nie zmienia konfiguracji
+  Pacera).
+
+## Next Steps
+
+→ `/ce:plan` dla strukturalnego planu implementacji (iteracja 1: launcher + usuwanie
+ostatniego `.mkv`). Reset rigu zaplanować osobno po researchu.

--- a/docs/plans/2026-06-04-002-feat-live-operator-quick-actions-plan.md
+++ b/docs/plans/2026-06-04-002-feat-live-operator-quick-actions-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Szybkie akcje operatorskie sesji live (launcher + przenieś ostatnie nagranie do kosza)"
 type: feat
-status: active
+status: completed
 date: 2026-06-04
 deepened: 2026-06-04
 reworked: 2026-06-04
@@ -239,7 +239,7 @@ kończy się brakiem akcji i powiadomieniem; nawet udane przeniesienie da się c
 
 ## Implementation Units
 
-- [ ] **Unit 1: `setka-live delete-last` — przeniesienie ostatniego nagrania do kosza (bash, self-contained)**
+- [x] **Unit 1: `setka-live delete-last` — przeniesienie ostatniego nagrania do kosza (bash, self-contained)**
 
 **Goal:** Podkomenda `setka-live delete-last`: ustal root nagrań, znajdź najnowszy prawidłowy
 katalog nagrania, potwierdź (zenity z nazwą/wiekiem/rozmiarem), przenieś do kosza (`gio trash`),
@@ -305,7 +305,7 @@ nieprawidłowy root nigdy nie prowadzi do globowania $HOME/CWD.
 
 ---
 
-- [ ] **Unit 2: `setka-tray` — ikona tray z menu akcji (PyGObject)**
+- [x] **Unit 2: `setka-tray` — ikona tray z menu akcji (PyGObject)**
 
 **Goal:** Lekka apka tray (GTK3 + AyatanaAppIndicator3) z menu wyzwalającym podkomendy `setka-live`.
 
@@ -347,7 +347,7 @@ okna, „Usuń ostatnie nagranie" uruchamia przepływ z Unitu 1.
 
 ---
 
-- [ ] **Unit 3: instalacja skrótów GNOME + traya (install.sh + helper)**
+- [x] **Unit 3: instalacja skrótów GNOME + traya (install.sh + helper)**
 
 **Goal:** Idempotentnie zainstalować `setka-tray`, autostart `.desktop` oraz globalne skróty
 GNOME (`Super+Shift+S` show, `Super+Shift+D` delete-last) wskazujące na podkomendy `setka-live`;

--- a/docs/plans/2026-06-04-002-feat-live-operator-quick-actions-plan.md
+++ b/docs/plans/2026-06-04-002-feat-live-operator-quick-actions-plan.md
@@ -1,0 +1,460 @@
+---
+title: "feat: Szybkie akcje operatorskie sesji live (launcher + przenieś ostatnie nagranie do kosza)"
+type: feat
+status: active
+date: 2026-06-04
+deepened: 2026-06-04
+reworked: 2026-06-04
+origin: docs/brainstorms/2026-06-04-live-operator-quick-actions-requirements.md
+---
+
+# feat: Szybkie akcje operatorskie sesji live (launcher + przenieś ostatnie nagranie do kosza)
+
+> **Przeróbka 2026-06-04 (podczas /ce:work — ustalanie niewiadomych).** Badanie realnego
+> środowiska + doprecyzowanie operatora zmieniły rdzeń planu. Najważniejsze: (1) kasujemy
+> **cały katalog nagrania**, nie pojedynczy plik; (2) **przez przeniesienie do kosza**
+> (`gio trash`), odwracalnie, nie `rm`; (3) root nagrań z **env `SETKA_RECORDINGS_ROOT`**
+> (`~/Wideo/obs`), **nie z OBS WebSocket**; (4) skoro OBS jest zbędny, **logika żyje w bashu
+> `setka-live`, nie w paternologii** — co usuwa dawne Unity 1 i 2 (endpoint + cleanup +
+> `obs_client`). Poprzednia wersja planu (paternologia HTTP + usuwanie pliku `.mkv` + sidecar +
+> kontrakt TOCTOU) jest **nieaktualna** i została zastąpiona poniższą.
+
+## Overview
+
+Dodajemy operatorowi sesji live dwa szybkie, globalne sposoby na akcje spoza przepływu
+nagrywania: (1) przywrócenie układu okien przez istniejące `setka-live show`, (2) przeniesienie
+ostatniego nagrania do kosza (`setka-live delete-last`) z potwierdzeniem i informacją zwrotną.
+Obie akcje są wyzwalane podwójnie — ikoną w system tray (menu) **oraz** globalnymi skrótami
+GNOME — a oba wyzwalacze wołają te same podkomendy `setka-live` (jedno źródło prawdy).
+
+Logika „usuń ostatnie" to **czysty bash** w `setka-live`: ustal root nagrań (env, z defaultem
+`~/Wideo/obs`), znajdź najnowszy prawidłowy katalog nagrania, opisz go (nazwa + wiek + rozmiar),
+potwierdź (`zenity`), przenieś do kosza GNOME (`gio trash`), powiadom (`notify-send`). Operacja
+jest **odwracalna** (przywrócenie z Kosza/Nautilusa), więc nie potrzebuje ciężkiej maszynerii
+guardów ani połączenia z OBS.
+
+Reset rigu (Bitwig clear + re-wybór patternów na M:S/Freak/Boss) jest **poza zakresem** tej
+iteracji (origin: R7) i zaplanowany jako osobna, późniejsza faza.
+
+## Problem Frame
+
+Podczas sesji nagraniowej (warstwa `setka-live`: Bitwig + OBS + kiosk paternologii na dwóch
+monitorach X11) operator musi czasem wykonać akcję między ujęciami bez schodzenia do terminala:
+
+- `setka-live show` to akcja ratunkowa na rozjechane okna — wyzwalacz musi działać globalnie,
+  niezależnie od tego, co jest na wierzchu (przycisk w zakopanym oknie kiosku byłby bezużyteczny).
+- „Usuń ostatnie nagranie" — gdy ujęcie się nie udało, operator chce usunąć **całe** nieudane
+  nagranie (folder), żeby nie zaśmiecać sesji; jako akcja potencjalnie kosztowna ma być
+  **odwracalna** (kosz) i potwierdzona.
+
+Obie akcje wykonywane są z wolnymi rękami i wzrokiem na ekranie (nie w trakcie grania).
+(Pełny kontekst — see origin: docs/brainstorms/2026-06-04-live-operator-quick-actions-requirements.md)
+
+## Requirements Trace
+
+- **R1.** Globalny wyzwalacz dostępny niezależnie od aktywnego okna — realizowany podwójnie:
+  ikona w tray z menu **oraz** globalne skróty GNOME. Środowisko: GNOME na X11.
+- **R2.** Akcja „pokaż okna" wywołuje `setka-live show` (fire-and-forget; rezultat widać na ekranie).
+- **R3.** Akcja „usuń ostatnie nagranie" przenosi **cały najnowszy katalog nagrania** (folder
+  `<timestamp>/` w roocie nagrań — wideo + `metadata.json` + `extracted/`/`analysis/`/`blender/`)
+  **do kosza GNOME** (`gio trash`), odwracalnie. „Najnowszy" = wg mtime spośród prawidłowych
+  katalogów nagrań pod rootem.
+- **R3a.** Root nagrań z env `SETKA_RECORDINGS_ROOT` (default `~/Wideo/obs`, fallback `~/Videos/obs`).
+  **Nie** z OBS WebSocket (`GetRecordDirectory` zwraca `RecFilePath`, np. `/home/wojtas` — surowy
+  plik przed reorganizacją, nie root sfolderyzowanych nagrań).
+- **R4.** Przeniesienie wyłącznie po jawnym potwierdzeniu (`zenity`) nazywającym konkretny
+  **katalog** (nazwa + wiek + łączny rozmiar).
+- **R5.** Po przeniesieniu powiadomienie o wyniku (`notify-send`): co trafiło do kosza
+  (+ podpowiedź o przywracaniu) / anulowano / brak nagrania / błąd.
+- **R6.** Bezpieczeństwo przez **odwracalność** (kosz, nie `rm`) + **walidację celu** (istnieje,
+  katalog, ściśle pod rootem, prawidłowa struktura nagrania); brak twardego guardu „OBS nagrywa"
+  (nagranie w toku to surowy plik w innej lokalizacji, nie kandydat).
+- **R7.** Brak resetu rigu w tej iteracji (poza zakresem — patrz Scope Boundaries).
+
+## Scope Boundaries
+
+- **Brak resetu rigu**: żadnego czyszczenia ścieżek w Bitwigu ani re-wyboru patternów na
+  M:S/Freak/Boss. (Osobna przyszła faza.)
+- **Przenosimy CAŁY katalog nagrania do kosza** (poprzednia granica „tylko surowy plik"
+  świadomie zniesiona). Operacja odwracalna.
+- **Brak twardego `rm`** i brak opróżniania kosza przez tę funkcję.
+- **Brak utrwalania stanu** „ostatniego nagrania" — identyfikacja po mtime katalogu, bezstanowo.
+- **Logika w `setka-live` (bash), nie w paternologii** — OBS/serwer niepotrzebne po
+  doprecyzowaniu. Brak zmian w paternologii, OBS WebSocket, MIDI/bridge/kiosk.
+- **Tylko GNOME/X11** — bez wsparcia Wayland / innych DE.
+- **Tray bez logiki biznesowej** — tray i skróty to wyłącznie wyzwalacze podkomend `setka-live`.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/live/bin/setka-live` — dispatch podkomend przez `case` w `main()` (linie ~79-86),
+  funkcje `cmd_*`, exit 0=ok / 2=unknown. Indirekcja binarek dla testów: `LAYOUT_BIN`,
+  `SYSTEMCTL_BIN`. **Wzorzec dla `cmd_delete_last` + nowej indirekcji** (`GIO_BIN`, `ZENITY_BIN`,
+  `NOTIFY_BIN`, `SETKA_RECORDINGS_ROOT`).
+- `deploy/live/bin/live-layout.sh` — wzorzec: czyste funkcje testowalne tekstem, env z
+  defaultami `"${VAR:-default}"`, `log()`/`err()`, twarda bramka X11, best-effort gdy brak
+  narzędzia. **Wzorzec dla `live-keybindings.sh`** i dla funkcji w `cmd_delete_last`.
+- `deploy/live/install.sh` — idempotentny `install_file()` z `cmp -s` + backup `.bak-<STAMP>`,
+  kopiowanie `bin/*` → `~/.local/bin`, wycofywanie starego `.desktop` w `~/.config/autostart`.
+  `daemon-reload`/efekty uboczne tylko dla domyślnego katalogu (ochrona testów). **Wzorzec dla
+  instalacji `setka-tray`, `.desktop`, skrótów.**
+- `deploy/live/tests/test_*.sh` — plain bash (brak bats), recorder-mock binarek przez env,
+  liczniki `pass/fail`, `mktemp` + cleanup, source-guard. **Wzorzec dla rozszerzenia
+  `test_setka_live.sh`, nowego `test_keybindings.sh`, rozszerzenia `test_install.sh`.**
+- `packages/obsession/.../advanced_scene_switcher_extractor.py` (linie 62-121) — **istniejący
+  wzorzec „znajdź najnowsze nagranie"**: kandydaci `~/Wideo/obs`, `~/Videos/obs`; iteruje
+  podkatalogi; waliduje strukturę (`metadata.json` + plik wideo); wybiera `max` po mtime pliku
+  wideo; odrzuca pliki starsze niż 30 s. **Źródło defaultów roota i pojęcia „prawidłowy katalog
+  nagrania".**
+- `packages/fermata/src-tauri/src/commands/recordings.rs` (linie 30-157) — **prior art kasowania
+  nagrania**: root z env `FERMATA_RECORDINGS_PATH` (default `~/Videos/obs-recordings`),
+  `delete_recording_impl` waliduje `exists` + `is_dir` na `root/name`, po czym **`remove_dir_all`
+  (nieodwracalnie)**. Nasza funkcja jest świadomie bezpieczniejsza (kosz zamiast `rm`); walidacja
+  `exists`+`is_dir`+pod-rootem jest dobrym, sprawdzonym wzorcem do odwzorowania.
+- `packages/paternologia/src/paternologia/dependencies.py` (linie 15-24) — wzorzec env-override
+  (`PATERNOLOGIA_DATA_DIR`): default + `os.environ.get`. Potwierdza konwencję env dla ścieżek.
+
+### Institutional Learnings
+
+- `docs/plans/2026-06-03-001-feat-setka-live-window-layout-plan.md` — EWMH/wmctrl na GNOME/X11,
+  twarda bramka Waylanda, wzorzec testów shell (czyste funkcje + recorder-mock).
+- `docs/plans/2026-06-02-002-feat-live-session-launcher-plan.md` — idempotentny install z backupem,
+  systemd `--user`.
+
+### External References (zweryfikowane na maszynie docelowej: Ubuntu 24.04.4, GNOME 46, X11)
+
+- **Środowisko OBS:** OBS 32.1.2; aktywny profil `live` (z `user.ini`, które w OBS 30+ ma
+  pierwszeństwo nad `global.ini`) → `RecFormat2=hybrid_mp4` (pliki `.mp4`), `RecFilePath=/home/wojtas`,
+  split wyłączony. Nagrania finalnie reorganizowane w foldery `~/Wideo/obs/<timestamp>/` (świeże
+  foldery z dziś potwierdzają, że dzieje się to automatycznie po stopie). Wniosek: root nagrań ≠
+  `RecFilePath` → bierzemy go z env, nie z OBS.
+- **Kosz:** `gio` 2.80 obecny; backend `gvfs` 1.54 aktywny; `gio trash --list` działa i pokazuje
+  istniejące elementy → `gio trash <ścieżka>` przeniesie folder do kosza GNOME (przywracalne z
+  Nautilusa).
+- **Tray:** PyGObject `3.48.2`; `gi.require_version("Gtk","3.0")` + `gi.require_version(
+  "AyatanaAppIndicator3","0.1")` ładują się. `AppIndicator3` (Canonical) **niedostępny** — Ayatana.
+  Indicator pod **GTK3** (menu `Gtk.Menu`), wymaga `set_status(ACTIVE)` + menu. Pakiety apt obecne:
+  `python3-gi`, `gir1.2-gtk-3.0`, `gir1.2-ayatanaappindicator3-0.1`.
+- **Rozszerzenie:** `gnome-shell-extension-appindicator` aktywne (`org.kde.StatusNotifierWatcher`
+  na session busie). Preinstalowane na Ubuntu; install.sh robi defensywny check przez `gdbus`.
+- **Skróty:** `gsettings` schema `org.gnome.settings-daemon.plugins.media-keys` klucz
+  `custom-keybindings` (lista `as`, pusty stan = dosłownie `@as []`) + relocatable
+  `...media-keys.custom-keybinding:/<path>/` z `name`/`command`/`binding`. Ścieżka **musi kończyć
+  się `/`**. Zmiana działa **bez restartu sesji**. Idempotencja: własne nazwane ścieżki +
+  append-if-absent, osobny case na `@as []`.
+- **zenity 4.0.1:** `--question` → exit 0 = potwierdzenie; **wszystko != 0** = „nie ruszaj"
+  (fail-safe). `--default-cancel` + `--icon=dialog-warning`.
+- **notify-send 0.8.3:** sterować widocznością przez `--urgency` (GNOME ignoruje `-t`).
+
+## Key Technical Decisions
+
+- **Logika w czystym bashu `setka-live`, bez paternologii/OBS**: po doprecyzowaniu funkcja
+  potrzebuje tylko: root z env, glob katalogów, `gio trash`, `zenity`, `notify-send` — wszystko
+  dostępne w bashu. Połączenie OBS było uzasadnione tylko, gdy trzeba było pobrać katalog z OBS i
+  sprawdzać `is_recording()`; oba odpadły. (KISS; usuwa cały serwerowy obszar ryzyka.)
+- **Przeniesienie do kosza (`gio trash`) zamiast `rm`**: operacja odwracalna → bezpieczeństwo i
+  UX bez ciężkich guardów (decyzja operatora: „przesuwaj folder + informuj, bez guard"). Świadomie
+  lepsze niż istniejące `remove_dir_all` w fermacie.
+- **Root z env `SETKA_RECORDINGS_ROOT`** (default `~/Wideo/obs`, fallback `~/Videos/obs`):
+  porównanie plik-vs-env wypadło jednoznacznie na env — to ustalona konwencja u wszystkich
+  konsumentów roota (`FERMATA_RECORDINGS_PATH`, `PATERNOLOGIA_DATA_DIR`), nikt nie trzyma roota w
+  pliku-configu; env jest też trywialnie testowalny (tmp dir per test) i ustawialny w deploy.
+- **„Najnowszy" = katalog nagrania, nie plik**: wybór `max` po mtime spośród bezpośrednich
+  podkatalogów roota, które są **prawidłowymi nagraniami** (zawierają `metadata.json` + plik
+  wideo) — odwzorowanie walidacji z obsession/fermaty.
+- **Tray i skróty wołają te same podkomendy `setka-live`**: jedno źródło prawdy; tray/skróty to
+  wyłącznie wyzwalacze. (see origin: Key Decisions.)
+- **Tray: PyGObject + GTK3 + AyatanaAppIndicator3**: jedyny działający namespace na 24.04, zero
+  nowych zależności apt.
+- **Skróty idempotentnie przez `gsettings`**, własne nazwane ścieżki + append-if-absent — nie
+  nadpisujemy customów użytkownika; ponowny install = no-op. Domyślne: `Super+Shift+S` (show),
+  `Super+Shift+D` (delete-last), konfigurowalne env (`KB_SHOW`, `KB_DELETE`).
+- **Lekkie guardy zamiast ciężkich** (bo odwracalne): odmowa, gdy root pusty/nie-katalog/`==$HOME`;
+  kandydat musi mieć prawidłową strukturę i `resolved parent == resolved root` (bez symlink-escape).
+  Brak kontraktu TOCTOU/`expected_mtime`, brak sidecar-by-stem, brak guardu OBS — niepotrzebne.
+
+## Open Questions
+
+### Resolved During Planning / Work
+
+- Co kasujemy? → **Cały najnowszy katalog nagrania**, przeniesiony do kosza (`gio trash`).
+- Skąd root nagrań? → env `SETKA_RECORDINGS_ROOT`, default `~/Wideo/obs`, fallback `~/Videos/obs`.
+- Gdzie żyje logika? → **bash w `setka-live`** (OBS/paternologia niepotrzebne).
+- Jak potwierdzać/informować? → `zenity --question --default-cancel` (!=0 = nie ruszaj) + `notify-send`.
+- Technologia traya/skrótów? → PyGObject GTK3 + AyatanaAppIndicator3; `gsettings` media-keys.
+- Domyślne skróty? → `Super+Shift+S` (show), `Super+Shift+D` (delete-last).
+- Format/rozszerzenie pliku (poprzednia niewiadoma `.mkv` vs `.mp4`)? → **nieistotne** — operujemy
+  na całym folderze; walidacja sprawdza obecność *jakiegokolwiek* pliku wideo, nie konkretne
+  rozszerzenie.
+- Split recording? → wyłączony w profilu; przy operacji na folderze i tak bez znaczenia.
+
+### Deferred to Implementation
+
+- **Dokładny zestaw rozszerzeń wideo** uznawanych za „plik wideo" w walidacji katalogu —
+  pragmatycznie `*.mp4 *.mkv *.mov *.flv` (env-konfigurowalne, np. `REC_VIDEO_GLOBS`); dostroić
+  do realnych nagrań.
+- **Format komunikatu zenity** (czytelny wiek: „2 minuty temu" vs „wczoraj"; rozmiar z `du -sh`).
+- **Zachowanie `setka-tray` przy braku `StatusNotifierWatcher` przy starcie** — domyślnie polegać
+  na późnym dowiązaniu AyatanaAppIndicator3 + drobny `X-GNOME-Autostart-Delay`; dostroić.
+
+### Surfaced (do świadomości operatora — nie blokuje)
+
+- **Niespójność defaultów roota między pakietami**: obsession hardcode `~/Wideo/obs`/`~/Videos/obs`,
+  fermata env-default `~/Videos/obs-recordings`. Ten plan przyjmuje `~/Wideo/obs` (realia). Ujednolicenie
+  defaultów we wszystkich pakietach jest **poza zakresem** (osobny, drobny follow-up).
+- **„Najnowszy" przy odpaleniu między sesjami**: jeśli operator kliknie delete-last zanim nagra
+  dzisiejsze ujęcie, najnowszym folderem jest nagranie z wcześniejszej sesji. Mitygacja: zenity
+  pokazuje nazwę+wiek+rozmiar, a operacja jest odwracalna (kosz). Wystarczające w tej iteracji.
+
+## High-Level Technical Design
+
+> *Ilustruje zamierzony kształt — wskazówka kierunkowa do recenzji, nie specyfikacja do
+> odtworzenia 1:1.*
+
+```
+  ┌─────────────┐         ┌──────────────────┐
+  │  tray menu  │         │  skrót GNOME     │   (oba: tylko wyzwalacze)
+  │ (setka-tray)│         │  (gsettings)     │
+  └──────┬──────┘         └────────┬─────────┘
+         │  subprocess              │  command=
+         └───────────┬──────────────┘
+                     ▼
+            setka-live  show | delete-last        (jedno źródło prawdy)
+                     │
+        show ────────┤──────────► live-layout.sh (istnieje)
+                     │
+   delete-last ──────┘  (czysty bash, bez OBS/serwera)
+        1. root = ${SETKA_RECORDINGS_ROOT:-~/Wideo/obs} (fallback ~/Videos/obs)
+        2. walidacja roota: niepusty / katalog / != $HOME
+        3. najnowszy podkatalog z (metadata.json + plik wideo), wg mtime
+           └─ brak → notify-send „brak nagrania", exit
+        4. zenity --question (nazwa + wiek + rozmiar);  rc != 0 → cicho exit (fail-safe)
+        5. gio trash "<katalog>"   (odwracalne)
+        6. notify-send (sukces + „przywróć z Kosza" / błąd)
+```
+
+Przepływ jest fail-safe i odwracalny: każdy stan inny niż „prawidłowy katalog + zenity rc 0"
+kończy się brakiem akcji i powiadomieniem; nawet udane przeniesienie da się cofnąć z kosza.
+
+## Implementation Units
+
+- [ ] **Unit 1: `setka-live delete-last` — przeniesienie ostatniego nagrania do kosza (bash, self-contained)**
+
+**Goal:** Podkomenda `setka-live delete-last`: ustal root nagrań, znajdź najnowszy prawidłowy
+katalog nagrania, potwierdź (zenity z nazwą/wiekiem/rozmiarem), przenieś do kosza (`gio trash`),
+powiadom (notify-send). Bez OBS, bez serwera.
+
+**Requirements:** R3, R3a, R4, R5, R6
+
+**Dependencies:** Brak.
+
+**Files:**
+- Modify: `deploy/live/bin/setka-live` (czyste funkcje + `cmd_delete_last` + `delete-last)` w
+  `case` w `main()` + wpis w usage)
+- Test: `deploy/live/tests/test_setka_live.sh` (rozszerzyć)
+- Modify: `deploy/live/README.md` (dokumentacja podkomendy + zachowanie + env)
+
+**Approach:**
+- Indirekcja env (jak `LAYOUT_BIN`): `GIO_BIN` (default `gio`), `ZENITY_BIN` (`zenity`),
+  `NOTIFY_BIN` (`notify-send`), `SETKA_RECORDINGS_ROOT`, opcjonalnie `REC_VIDEO_GLOBS`.
+- Czyste, testowalne funkcje:
+  - `resolve_recordings_root()` → echo zwalidowanego roota lub exit z błędem: jeśli
+    `SETKA_RECORDINGS_ROOT` ustawiony, użyj go (`expanduser`); inaczej pierwszy istniejący z
+    `~/Wideo/obs`, `~/Videos/obs`. Walidacja: niepusty, absolutny, istnieje, jest katalogiem,
+    `!= $HOME` (i `!= /`) — inaczej err i odmowa (**nigdy** fallback do CWD/$HOME).
+  - `is_recording_dir <dir>` → 0, jeśli `dir` zawiera `metadata.json` **oraz** co najmniej jeden
+    plik wideo (`*.mp4`/`*.mkv`/`*.mov`/`*.flv`); inaczej !=0.
+  - `find_latest_recording <root>` → echo ścieżki najnowszego (wg mtime) bezpośredniego
+    podkatalogu, dla którego `is_recording_dir` == 0; pusto, gdy brak. Pomija nie-katalogi i
+    symlinki (resolve + sprawdź `parent == root`).
+  - `describe_recording <dir>` → „nazwa | wiek czytelnie | rozmiar (`du -sh`)".
+  - `cmd_delete_last`: root → latest → brak? `notify-send` „Brak nagrania do usunięcia", exit 0.
+    Inaczej `zenity --question --default-cancel --icon=dialog-warning` z opisem (R4); rc != 0 →
+    cicho exit (fail-safe); rc == 0 → `gio trash "<dir>"`; sukces → `notify-send` „Przeniesiono
+    do kosza: <nazwa> (przywrócisz z Kosza w Plikach)"; błąd `gio` → `notify-send --urgency=critical`.
+- Best-effort dla narzędzi GUI (brak `zenity`/`notify-send` → `log`/`err` + sensowny fallback),
+  ale potwierdzenie jest twardym warunkiem przeniesienia.
+- Zachowaj istniejący kontrakt dispatchu: nieznana komenda → exit 2.
+
+**Patterns to follow:** `cmd_show`/`cmd_start` + indirekcja w `setka-live`; `live-layout.sh`
+(`"${VAR:-default}"`, `log`/`err`, bramki); walidacja `exists`+`is_dir`+pod-rootem jak w
+`recordings.rs`; pojęcie „prawidłowe nagranie" jak w `advanced_scene_switcher_extractor.py`.
+
+**Test scenarios:** (recorder-mock dla `GIO_BIN`/`ZENITY_BIN`/`NOTIFY_BIN`; tmp root z atrapami
+nagrań: `mkdir <ts>/`, `touch <ts>/metadata.json`, `touch <ts>/clip.mp4`, kontrola mtime)
+- Happy path: root z 3 prawidłowymi katalogami o różnych mtime → `find_latest_recording` zwraca
+  najnowszy; zenity-mock rc 0 → `gio trash <najnowszy>` w logu + `notify-send` z nazwą folderu.
+- Error path (R4): zenity-mock rc 1 → **brak** `gio trash` w logu; brak destrukcyjnej notyfikacji.
+- Edge case: katalog bez prawidłowych nagrań (same pliki / podkatalog bez `metadata.json`) →
+  brak zenity, brak `gio trash`, `notify-send` „brak nagrania".
+- Edge case (walidacja struktury): podkatalog z `metadata.json` ale bez pliku wideo →
+  `is_recording_dir` != 0 → pominięty; podkatalog z wideo bez `metadata.json` → pominięty.
+- Edge case (root): `SETKA_RECORDINGS_ROOT` = `""`, względny, nieistniejący, plik, `$HOME`, `/` →
+  odmowa (err), **zero** globowania CWD/$HOME, brak `gio trash`.
+- Edge case (fallback): brak env, `~/Wideo/obs` nie istnieje, `~/Videos/obs` istnieje → użyty fallback.
+- Edge case (symlink-escape): najnowszy „podkatalog" to symlink wskazujący poza root → pominięty.
+- Edge case (opis): `describe_recording` zawiera nazwę, wiek i rozmiar (asercja na obecności pól).
+- Error path (`gio`): `GIO_BIN` zwraca !=0 → `notify-send` pokazuje **błąd**, nie „przeniesiono".
+- Dispatch: `setka-live delete-last` trafia w `cmd_delete_last`; nieznana komenda → exit 2
+  (regresja istniejącego dispatchu); żadna komenda nie dotyka `paternologia.service` (jak istniejący test).
+
+**Verification:** rozszerzony `test_setka_live.sh` przechodzi; `gio trash` jest wywoływany
+wyłącznie po potwierdzeniu, tylko na prawidłowym katalogu nagrania ściśle pod zwalidowanym rootem;
+nieprawidłowy root nigdy nie prowadzi do globowania $HOME/CWD.
+
+---
+
+- [ ] **Unit 2: `setka-tray` — ikona tray z menu akcji (PyGObject)**
+
+**Goal:** Lekka apka tray (GTK3 + AyatanaAppIndicator3) z menu wyzwalającym podkomendy `setka-live`.
+
+**Requirements:** R1 (część: tray), R2
+
+**Dependencies:** Unit 1 (menu wywołuje `delete-last`; `show` już istnieje).
+
+**Files:**
+- Create: `deploy/live/bin/setka-tray` (python3, shebang `#!/usr/bin/env python3`)
+- Create: `deploy/live/autostart/setka-tray.desktop` (szablon do instalacji)
+- Test: `deploy/live/tests/test_setka_tray.py` (test czystej części: tabela menu → komendy)
+
+**Approach:**
+- `gi.require_version("Gtk","3.0")` + `gi.require_version("AyatanaAppIndicator3","0.1")`;
+  `Indicator.new(...)`, `set_status(ACTIVE)`, `set_menu(menu)`.
+- Menu: „Pokaż okna" → `["setka-live","show"]`; „Usuń ostatnie nagranie" → `["setka-live","delete-last"]`;
+  separator; „Zakończ". Komendy odpalane `subprocess.Popen([...])` (lista argów, bez `shell=True`).
+- Wydzielić **czystą strukturę menu** (lista krotek etykieta→argv) jako dane testowalne bez GUI;
+  warstwa GTK tylko ją renderuje.
+- `.desktop`: `Type=Application`, `Exec=` absolutna ścieżka (uzupełniana przez install.sh),
+  `StartupNotify=false`, `OnlyShowIn=GNOME;Unity;`, `X-GNOME-Autostart-enabled=true`,
+  drobny `X-GNOME-Autostart-Delay` na wypadek późnego `StatusNotifierWatcher`.
+- Plik zaczyna się od dwóch linii `# ABOUTME:`.
+
+**Execution note:** Warstwa GTK/AppIndicator trudna do testów jednostkowych — utrzymać cienką;
+logika (mapowanie menu→komenda) testowana osobno.
+
+**Patterns to follow:** brak lokalnego precedensu GUI; trzymać się decyzji z research (GTK3,
+Ayatana, menu + `set_status(ACTIVE)`).
+
+**Test scenarios:**
+- Happy path: tabela menu zawiera „Pokaż okna"→`["setka-live","show"]` i „Usuń ostatnie
+  nagranie"→`["setka-live","delete-last"]` (asercja na czystej strukturze).
+- Edge case: „Zakończ" mapuje na czyste wyjście (brak komendy zewnętrznej).
+- (GUI/AppIndicator — weryfikacja manualna: ikona pojawia się, menu działa.)
+
+**Verification:** `test_setka_tray.py` przechodzi; manualnie: ikona w tray, „Pokaż okna" układa
+okna, „Usuń ostatnie nagranie" uruchamia przepływ z Unitu 1.
+
+---
+
+- [ ] **Unit 3: instalacja skrótów GNOME + traya (install.sh + helper)**
+
+**Goal:** Idempotentnie zainstalować `setka-tray`, autostart `.desktop` oraz globalne skróty
+GNOME (`Super+Shift+S` show, `Super+Shift+D` delete-last) wskazujące na podkomendy `setka-live`;
+defensywne sprawdzenia środowiska.
+
+**Requirements:** R1 (część: skróty + autostart traya)
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Create: `deploy/live/bin/live-keybindings.sh` (czyste funkcje gsettings, env `GSETTINGS_BIN`)
+- Modify: `deploy/live/install.sh` (instalacja `setka-tray`, `.desktop` z abs. `Exec`, wywołanie
+  helpera skrótów, defensywny check `StatusNotifierWatcher` + zależności)
+- Test: `deploy/live/tests/test_keybindings.sh` (recorder-mock `gsettings`)
+- Modify: `deploy/live/tests/test_install.sh` (rozszerzyć o tray/.desktop/skróty)
+- Modify: `deploy/live/README.md` (sekcja skrótów + traya + tabela domyślnych klawiszy + env
+  `SETKA_RECORDINGS_ROOT`)
+
+**Approach:**
+- `live-keybindings.sh`: `kb_add path name command keys` — append-if-absent do `custom-keybindings`
+  z osobnym case na `@as []`; ścieżki **własne, nazwane** (`.../setka-show/`, `.../setka-delete-last/`)
+  zakończone `/`; per-binding `name`/`command`/`binding`. Domyślne klawisze env (`KB_SHOW`=`<Super><Shift>s`,
+  `KB_DELETE`=`<Super><Shift>d`).
+- `install.sh`: kopiuje `setka-tray` → `~/.local/bin` (0755, `install_file`); instaluje
+  `setka-tray.desktop` → `~/.config/autostart` z podstawioną absolutną `Exec`; woła
+  `live-keybindings.sh` (pomijalne env-em w testach, jak istniejące efekty uboczne); defensywny
+  `gdbus` check `org.kde.StatusNotifierWatcher` + warn o brakujących `gir1.2-*`/`zenity`/
+  `notify-send`/`gio`. Może udokumentować/ustawić `SETKA_RECORDINGS_ROOT`, jeśli != default.
+- Idempotencja: ponowny install = no-op (backup tylko przy różnicy, skróty bez duplikatów).
+
+**Patterns to follow:** `install.sh` (`install_file`, backup, efekty uboczne tylko dla domyślnego
+katalogu), `live-layout.sh` (env indirekcja + czyste funkcje), `test_install.sh`.
+
+**Test scenarios:** (recorder-mock `gsettings`)
+- Happy path: pusta lista (`@as []`) → po `kb_add` lista zawiera nową ścieżkę; per-binding
+  `name`/`command`/`binding` ustawione (asercja na logu gsettings).
+- Edge case (idempotencja): `kb_add` z istniejącą ścieżką → lista bez duplikatu (no-op).
+- Edge case: lista z istniejącym customem użytkownika → nowa ścieżka **dopisana**, stara zachowana.
+- Happy path install: `setka-tray` skopiowany do BIN_DIR (0755), `.desktop` w autostart z abs. `Exec`.
+- Edge case install: ponowny install identycznych plików → brak backupu (no-op).
+- Error path: brak `StatusNotifierWatcher` (gdbus-mock) → ostrzeżenie, install nie zawala (exit 0).
+
+**Verification:** `test_keybindings.sh` i rozszerzony `test_install.sh` przechodzą; po realnej
+instalacji skróty działają bez restartu sesji, tray startuje przy logowaniu (weryfikacja manualna).
+
+## System-Wide Impact
+
+- **Interaction graph:** Nowa podkomenda `setka-live delete-last` (czysty bash) + tray + skróty
+  jako nowe zewnętrzne punkty wejścia. **Brak zmian** w paternologii, OBS WebSocket, MIDI/bridge/kiosk.
+- **Error propagation:** Każdy stan != „prawidłowy katalog + zenity rc 0" → brak akcji +
+  `notify-send`. Błąd `gio` → notyfikacja krytyczna, nie cisza.
+- **State lifecycle / destrukcyjność:** Operacja jest **odwracalna** (kosz). Brak TOCTOU-ryzyka
+  wymagającego kontraktu mtime — najgorszy przypadek (zły folder) jest cofalny z kosza. Ochrona:
+  walidacja roota (`!= $HOME`, bez fallbacku do CWD), walidacja struktury kandydata, `parent ==
+  root` (anty-symlink-escape), zenity `--default-cancel`, fail-safe.
+- **API surface parity:** Wszystkie wyzwalacze (tray, skrót) idą przez tę samą `setka-live
+  delete-last` → spójne zachowanie i potwierdzenie niezależnie od źródła.
+- **Integration coverage:** recorder-mock `gio`/`zenity`/`notify-send` + realny tmp filesystem
+  (atrapy nagrań) dowodzą, że `gio trash` leci tylko po potwierdzeniu na prawidłowym katalogu.
+
+## Risks & Dependencies
+
+- **Operacja na całym folderze, ale odwracalna:** mitygacja — `gio trash` (nie `rm`), walidacja
+  roota/struktury/pod-rootem, zenity z nazwą+wiekiem+rozmiarem, fail-safe na każdy stan != „ok".
+  Świadomie bezpieczniejsze niż istniejące `remove_dir_all` w fermacie.
+- **Zależność od kosza GNOME (`gio`/gvfs):** obecne i zweryfikowane; gdyby `gio trash` zawiódł —
+  notyfikacja błędu, brak twardego kasowania w zastępstwie (fail-safe, nic nie ginie).
+- **Niespójność defaultów roota między pakietami** (obsession/fermata/ten plan) — patrz „Surfaced";
+  ujednolicenie poza zakresem.
+- **Zależności GNOME (tray):** rozszerzenie appindicator i `gir1.2-*` muszą być obecne — na Ubuntu
+  są; install.sh ostrzega defensywnie, nie zawala.
+- **Kolizje skrótów GNOME:** install.sh ostrzega, gdy ustawiony `binding` został przejęty.
+- **GUI traya nietestowalny jednostkowo:** mitygacja — cienka warstwa GTK, testowalna tabela menu,
+  weryfikacja manualna.
+
+## Documentation / Operational Notes
+
+- `deploy/live/README.md`: nowa podkomenda `delete-last` (przenosi ostatnie nagranie do **kosza**,
+  odwracalnie; nazwa+wiek+rozmiar w potwierdzeniu; env `SETKA_RECORDINGS_ROOT`), sekcja traya i
+  skrótów (domyślne klawisze `Super+Shift+S`/`Super+Shift+D`, jak zmienić, defensywne checki),
+  wzmianka o zależnościach GNOME (`gio`/gvfs, appindicator, `gir1.2-*`).
+- Reset rigu udokumentowany jako świadomie odłożony (link do origin R7 / przyszła faza).
+
+## Alternative Approaches Considered
+
+- **Logika w paternologii (endpoint HTTP) — poprzednia wersja planu**: odrzucone po doprecyzowaniu.
+  Uzasadnienie endpointu (reuse połączenia OBS + `is_recording()` guard) odpadło: root bierzemy z
+  env, guard zastąpiła odwracalność. Czysty bash jest prostszy (KISS) i nie wprowadza zależności od
+  działającego serwera dla operacji czysto plikowej.
+- **Twarde `rm`/`remove_dir_all` (jak fermata)**: odrzucone — nieodwracalne; `gio trash` daje to
+  samo UX, ale bezpiecznie.
+- **Root z OBS WebSocket `GetRecordDirectory`**: odrzucone — zwraca `RecFilePath` (np. `/home/wojtas`),
+  lokalizację surowego pliku przed reorganizacją, nie root sfolderyzowanych nagrań.
+- **Root w pliku-configu (YAML)**: odrzucone — żaden konsument roota nie używa pliku; env to ustalona
+  konwencja (`FERMATA_RECORDINGS_PATH`, `PATERNOLOGIA_DATA_DIR`) i jest trywialnie testowalny.
+- **Tray przez `yad --notification` / `AppIndicator3` (Canonical) / `alltray` / `kdocker`**:
+  odrzucone — wymaga apt lub oparte na martwym XEmbed; jedyny działający namespace to AyatanaAppIndicator3.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-04-live-operator-quick-actions-requirements.md](docs/brainstorms/2026-06-04-live-operator-quick-actions-requirements.md)
+- Related plans: `docs/plans/2026-06-03-001-feat-setka-live-window-layout-plan.md`,
+  `docs/plans/2026-06-02-002-feat-live-session-launcher-plan.md`
+- Related code: `deploy/live/bin/setka-live`, `deploy/live/bin/live-layout.sh`,
+  `deploy/live/install.sh`,
+  `packages/obsession/src/obsession/obs_integration/advanced_scene_switcher_extractor.py`,
+  `packages/fermata/src-tauri/src/commands/recordings.rs`
+- External (zweryfikowane na maszynie): OBS 32.1.2 profil `live` (hybrid_mp4, RecFilePath=$HOME);
+  `gio trash`/gvfs; PyGObject + AyatanaAppIndicator3 (GTK3); `org.gnome.settings-daemon.plugins.media-keys`
+  custom-keybindings; zenity 4.0.1; notify-send 0.8.3.


### PR DESCRIPTION
## Summary

Dwa globalne sposoby na akcje operatorskie sesji live — **ikona w tray** (GTK3 + AyatanaAppIndicator3) **oraz globalne skróty GNOME** — oba wołające te same podkomendy `setka-live` (jedno źródło prawdy):

- **`Super+Shift+S`** → `setka-live show` (układa okna; istniejąca komenda).
- **`Super+Shift+D`** → `setka-live delete-last` (NOWE): znajduje najnowszy katalog nagrania w `~/Wideo/obs`, potwierdza w `zenity` (nazwa + wiek + rozmiar), przenosi **cały folder do kosza GNOME** (`gio trash`, odwracalnie), powiadamia `notify-send`.

Czysty bash, bez OBS/serwera. Root z env `SETKA_RECORDINGS_ROOT` (default `~/Wideo/obs`, fallback `~/Videos/obs`). Bezpieczeństwo przez odwracalność (kosz, nie `rm`) + walidację (root ≠ `$HOME`, struktura nagrania, anty-symlink-escape, zenity `--default-cancel`, fail-safe).

Plan: `docs/plans/2026-06-04-002-feat-live-operator-quick-actions-plan.md`. Reset rigu (Bitwig/M:S/Freak/Boss) świadomie poza zakresem (R7, przyszła faza).

## Implementation Units
- **Unit 1** — `setka-live delete-last` (bash, self-contained): `resolve_recordings_root`, `is_recording_dir`, `find_latest_recording`, `describe_recording`, `cmd_delete_last`.
- **Unit 2** — `setka-tray` (PyGObject): czysta tabela menu testowalna bez GTK; warstwa GTK tylko w `main()`; autostart `.desktop`.
- **Unit 3** — `install.sh` + `live-keybindings.sh`: idempotentna rejestracja skrótów (gsettings, append-if-absent, obsługa `@as []`), instalacja traya, defensywne checki.

## Testing
- `test_setka_live.sh` **66**, `test_keybindings.sh` **15**, `test_install.sh` **36**, `test_setka_tray.py` **5** — wszystkie zielone; istniejące testy warstwy live bez regresji.
- Weryfikacja end-to-end na żywej sesji: oba skróty działają bez restartu sesji; folder ląduje w koszu i jest przywracalny (`gio trash --list` potwierdza).

### Błędy złapane i naprawione w trakcie (z testami regresyjnymi)
1. **Spacje w nazwie pliku wideo** — realne nagrania OBS (`2026-06-04 17-30-58.mp4`, `Projekt bez nazwy.mp4`) były odrzucane przez `ls "$dir"/$glob | grep`; przez gnome-shell (czyste env) `delete-last` zawsze mówił „brak nagrania", choć z terminala działał. Fix: dopasowanie przez tablicę z `nullglob`.
2. **`install.sh` wywracał się na katalogu `__pycache__`** w `bin/` (po imporcie `setka-tray` w pytest). Fix: guard `[ -f ]`.
3. **Fałszywe ostrzeżenie o `StatusNotifierWatcher`** — sprawdzał właściwość D-Bus jako metodę. Fix: `NameHasOwner`.

## Post-Deploy Monitoring & Validation
- **Co monitorować:** zachowanie `setka-live delete-last` na realnych nagraniach (czy zawsze trafia w najnowszy ważny katalog; czy notyfikacje są czytelne).
- **Walidacja (komendy):**
  - `gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings` → zawiera `setka-show/` i `setka-delete-last/`.
  - `env -i HOME=$HOME PATH=/usr/bin:/bin ZENITY_BIN=false NOTIFY_BIN=echo GIO_BIN=echo setka-live delete-last` → znajduje najnowsze nagranie (regresja czystego env).
  - `gio trash --list` → przeniesione foldery widoczne i przywracalne.
- **Zdrowy sygnał:** skrót → zenity z nazwą+wiekiem+rozmiarem → po potwierdzeniu folder w koszu; po anulowaniu brak akcji.
- **Sygnał awarii / rollback:** `delete-last` mówi „brak nagrania" mimo istniejących nagrań (regresja środowiskowa) → cofnij przez `git revert`; nic nie ginie nieodwracalnie (kosz, nie `rm`).
- **Okno walidacji / właściciel:** najbliższa sesja nagraniowa; Wojtas.

🤖 Generated with Claude Opus 4.8 (1M context) via [Claude Code](https://claude.com/claude-code)