### PR TITLE
feat(live): setka-live new-take — czysty projekt Bitwig z szablonu

### DIFF
--- a/deploy/live/README.md
+++ b/deploy/live/README.md
@@ -35,6 +35,7 @@ setka-live restart      # całościowy restart GUI (stop+start; re-weryfikuje pr
 setka-live status       # stan członków + paternologia /health + środowisko graficzne
 setka-live show         # wyciągnij na wierzch i ułóż okna na dwóch monitorach (patrz niżej)
 setka-live delete-last  # przenieś ostatnie nagranie do kosza z potwierdzeniem (patrz niżej)
+setka-live new-take     # otwórz czysty projekt Bitwig z szablonu (świeży stan do nagrywania)
 ```
 
 ### `setka-live delete-last` — przeniesienie ostatniego nagrania do kosza
@@ -62,6 +63,29 @@ Walidacja roota: musi być niepustą, **absolutną** ścieżką do istniejącego
 
 Wymagane narzędzia: `zenity` (potwierdzenie — bez niego operacja jest blokowana), `gio` (kosz),
 `notify-send` (powiadomienia, best-effort).
+
+### `setka-live new-take` — czysty projekt Bitwig z szablonu
+
+Otwiera w Bitwigu **nienazwany projekt z szablonu** — świeży stan po skasowaniu nieudanego ujęcia.
+
+Mechanizm: `flatpak run <app-id> <szablon>`. Działający Bitwig przejmuje plik
+(*„Bitwig Studio is already running — opening files"*) i tworzy nowy projekt z szablonu **bez
+ubijania instancji**. Gdy Bitwig nie działa, flatpak wystartuje go z tym szablonem.
+
+Zmienne środowiskowe:
+
+| Zmienna | Domyślna wartość | Opis |
+|---------|-----------------|------|
+| `BITWIG_TEMPLATE` | `~/Bitwig Studio/Library/Templates/template.bwtemplate` | Szablon projektu (ten sam, którym startuje `bitwig.service`) |
+| `BITWIG_APP_ID` | `com.bitwig.BitwigStudio` | Id aplikacji flatpak |
+
+Uwagi:
+- Brak szablonu → odmowa z komunikatem błędu (FAIL FAST), bez wołania flatpaka.
+- **Niezapisane zmiany** w bieżącym projekcie wywołują własny prompt zapisu Bitwiga (ochrona przed
+  utratą danych — nie da się go bezpiecznie wyciszyć).
+- To wyłącznie **połowa-Bitwig** „resetu rigu" — **nie** czyści Model:Samples / MicroFreak / RC-600.
+  Pełny reset sprzętu pozostaje osobną, większą fazą (API rozszerzeń Bitwiga nie zarządza projektami,
+  dlatego sięgamy po CLI-open pliku).
 
 ### `setka-live show` — układanie okien
 
@@ -151,6 +175,7 @@ szybkich akcji operatorskich. Startuje automatycznie przy logowaniu do sesji GNO
 
 Menu traya:
 - **Pokaż okna** → wywołuje `setka-live show`
+- **Nowy projekt Bitwig** → wywołuje `setka-live new-take`
 - **Usuń ostatnie nagranie** → wywołuje `setka-live delete-last`
 - **Zakończ** → zamyka samą apkę tray
 
@@ -170,6 +195,7 @@ Instalowane przez `install.sh` (idempotentnie; działają bez restartu sesji):
 |-------|-------|
 | `Super+Shift+S` | `setka-live show` (pokaż/ułóż okna) |
 | `Super+Shift+D` | `setka-live delete-last` (usuń ostatnie nagranie) |
+| `Super+Shift+N` | `setka-live new-take` (czysty projekt Bitwig z szablonu) |
 
 Skróty wpisywane są do `org.gnome.settings-daemon.plugins.media-keys.custom-keybindings`
 i nie nadpisują skrótów użytkownika — nowe ścieżki są tylko dołączane (append-if-absent).
@@ -177,7 +203,7 @@ i nie nadpisują skrótów użytkownika — nowe ścieżki są tylko dołączane
 Aby zmienić domyślne klawisze — ustaw env przed `install.sh`:
 
 ```bash
-KB_SHOW='<Super><Shift>F1' KB_DELETE='<Super><Shift>F2' deploy/live/install.sh
+KB_SHOW='<Super><Shift>F1' KB_DELETE='<Super><Shift>F2' KB_NEW_TAKE='<Super><Shift>F3' deploy/live/install.sh
 ```
 
 Zmiana działa bez restartu sesji GNOME — skróty są aktywne od razu po instalacji.

--- a/deploy/live/bin/live-keybindings.sh
+++ b/deploy/live/bin/live-keybindings.sh
@@ -9,6 +9,7 @@ GSETTINGS_BIN="${GSETTINGS_BIN:-gsettings}"
 # Domyślne klawisze — nadpisywalne przez env.
 KB_SHOW="${KB_SHOW:-<Super><Shift>s}"
 KB_DELETE="${KB_DELETE:-<Super><Shift>d}"
+KB_NEW_TAKE="${KB_NEW_TAKE:-<Super><Shift>n}"
 
 # Komenda setka-live — absolutna ścieżka z env (przekazywana przez install.sh).
 # Bez absolutnej ścieżki GNOME może jej nie znaleźć (skróty uruchamiane bez PATH użytkownika).
@@ -93,6 +94,7 @@ kb_add() {
 main() {
     local show_path="${BINDING_PREFIX}/setka-show/"
     local delete_path="${BINDING_PREFIX}/setka-delete-last/"
+    local new_take_path="${BINDING_PREFIX}/setka-new-take/"
 
     kb_add "$show_path" \
         "Setka: Pokaż okna" \
@@ -104,7 +106,12 @@ main() {
         "${SETKA_LIVE_CMD} delete-last" \
         "$KB_DELETE"
 
-    log "skróty zainstalowane: show=$KB_SHOW delete-last=$KB_DELETE"
+    kb_add "$new_take_path" \
+        "Setka: Nowy projekt Bitwig" \
+        "${SETKA_LIVE_CMD} new-take" \
+        "$KB_NEW_TAKE"
+
+    log "skróty zainstalowane: show=$KB_SHOW delete-last=$KB_DELETE new-take=$KB_NEW_TAKE"
 }
 
 # Odpal main lub zadaną funkcję zależnie od argumentów.

--- a/deploy/live/bin/setka-live
+++ b/deploy/live/bin/setka-live
@@ -12,6 +12,13 @@ LAYOUT_BIN="${LAYOUT_BIN:-$(dirname "$0")/live-layout.sh}"
 GIO_BIN="${GIO_BIN:-gio}"
 ZENITY_BIN="${ZENITY_BIN:-zenity}"
 NOTIFY_BIN="${NOTIFY_BIN:-notify-send}"
+# Narzędzia/parametry podkomendy new-take; env override dla testów.
+FLATPAK_BIN="${FLATPAK_BIN:-flatpak}"
+BITWIG_APP_ID="${BITWIG_APP_ID:-com.bitwig.BitwigStudio}"
+# Szablon projektu Bitwig — ten sam, którym startuje bitwig.service. Env override.
+# .bwtemplate to katalog-pakiet (nie pojedynczy plik).
+BITWIG_TEMPLATE="${BITWIG_TEMPLATE:-$HOME/Bitwig Studio/Library/Templates/template.bwtemplate}"
+
 # Root katalogu nagrań; env override. Default: ~/Wideo/obs, fallback: ~/Videos/obs.
 # Nie ustawiamy tutaj wartości — resolve_recordings_root obsługuje logikę fallbacku.
 
@@ -27,7 +34,7 @@ err() { printf 'setka-live: %s\n' "$*" >&2; }
 
 usage() {
   cat >&2 <<EOF
-Użycie: setka-live <start|stop|restart|status|show|delete-last>
+Użycie: setka-live <start|stop|restart|status|show|delete-last|new-take>
 
   start        postaw komplet live (OBS + Bitwig + kiosk) po preflighcie; na końcu układa okna
   stop         zatrzymaj całą warstwę GUI
@@ -35,6 +42,7 @@ Użycie: setka-live <start|stop|restart|status|show|delete-last>
   status       stan członków + paternologia /health + środowisko graficzne
   show         wyciągnij na wierzch i ułóż okna: Bitwig (lewy) | OBS+Paternologia (prawy)
   delete-last  przenieś ostatnie nagranie do kosza (z potwierdzeniem)
+  new-take     otwórz czysty projekt Bitwig z szablonu (świeży stan do nagrywania)
 
 Most MIDI (paternologia.service) jest poza zakresem — rzadki restart ręcznie:
   systemctl --user restart paternologia.service
@@ -42,6 +50,10 @@ Most MIDI (paternologia.service) jest poza zakresem — rzadki restart ręcznie:
 Zmienne środowiskowe (delete-last):
   SETKA_RECORDINGS_ROOT  root katalogu nagrań (default: ~/Wideo/obs, fallback: ~/Videos/obs)
   REC_VIDEO_GLOBS        glob rozszerzeń wideo (default: *.mp4 *.mkv *.mov *.flv)
+
+Zmienne środowiskowe (new-take):
+  BITWIG_TEMPLATE        szablon projektu Bitwig (default: ~/Bitwig Studio/Library/Templates/template.bwtemplate)
+  BITWIG_APP_ID          id aplikacji flatpak Bitwiga (default: com.bitwig.BitwigStudio)
 EOF
 }
 
@@ -338,6 +350,44 @@ Operacja jest odwracalna — przywrócisz z Kosza w Menedżerze Plików."
   fi
 }
 
+# Podkomenda: otwórz świeży projekt Bitwig z szablonu (czysty stan do nagrywania).
+# Mechanizm: `flatpak run <app-id> <template>` — działający Bitwig otwiera plik
+# ("Bitwig Studio is already running - opening files"), więc dostajemy nienazwany
+# projekt z szablonu BEZ ubijania instancji. Gdy Bitwig nie działa, flatpak go
+# wystartuje z tym szablonem (w warstwie live Bitwig zwykle już działa, więc
+# flatpak run szybko oddaje sterowanie po przekazaniu pliku).
+# UWAGA: to wyłącznie połowa-Bitwig „resetu rigu" — NIE czyści M:S/Freak/Boss.
+# Niezapisane zmiany w bieżącym projekcie wywołują własny prompt zapisu Bitwiga.
+cmd_new_take() {
+  local template="$BITWIG_TEMPLATE"
+
+  # Szablon musi istnieć — bez niego nie ma „czystego" projektu (FAIL FAST).
+  # .bwtemplate to katalog-pakiet, więc -e (nie -f).
+  if [ ! -e "$template" ]; then
+    err "Brak szablonu Bitwig: '$template'. Ustaw BITWIG_TEMPLATE."
+    if command -v "$NOTIFY_BIN" >/dev/null 2>&1; then
+      "$NOTIFY_BIN" --urgency=critical "setka-live" \
+        "Brak szablonu Bitwig — nie otworzę czystego projektu." || true
+    fi
+    return 1
+  fi
+
+  log "Otwieram czysty projekt Bitwig z szablonu: $template"
+  if "$FLATPAK_BIN" run "$BITWIG_APP_ID" "$template"; then
+    if command -v "$NOTIFY_BIN" >/dev/null 2>&1; then
+      "$NOTIFY_BIN" --urgency=normal "setka-live" \
+        "Otwarto czysty projekt Bitwig z szablonu." || true
+    fi
+  else
+    err "Błąd: flatpak run $BITWIG_APP_ID nie powiódł się."
+    if command -v "$NOTIFY_BIN" >/dev/null 2>&1; then
+      "$NOTIFY_BIN" --urgency=critical "setka-live" \
+        "Błąd: nie udało się otworzyć projektu Bitwig." || true
+    fi
+    return 1
+  fi
+}
+
 main() {
   case "${1:-}" in
     start)       cmd_start ;;
@@ -346,6 +396,7 @@ main() {
     status)      cmd_status ;;
     show)        cmd_show ;;
     delete-last) cmd_delete_last ;;
+    new-take)    cmd_new_take ;;
     *)           usage; exit 2 ;;
   esac
 }

--- a/deploy/live/bin/setka-tray
+++ b/deploy/live/bin/setka-tray
@@ -20,6 +20,7 @@ def build_menu_items():
     """
     return [
         ("Pokaż okna", ["setka-live", "show"]),
+        ("Nowy projekt Bitwig", ["setka-live", "new-take"]),
         ("Usuń ostatnie nagranie", ["setka-live", "delete-last"]),
         (None, None),  # separator
         ("Zakończ", None),

--- a/deploy/live/install.sh
+++ b/deploy/live/install.sh
@@ -74,7 +74,7 @@ main() {
   if [ -z "$SKIP_KEYBINDINGS" ] && [ "$BIN_DIR" = "$HOME/.local/bin" ]; then
     if [ -x "$BIN_DIR/live-keybindings.sh" ]; then
       SETKA_LIVE_CMD="$BIN_DIR/setka-live" bash "$BIN_DIR/live-keybindings.sh" \
-        && printf 'Skróty GNOME zainstalowane (Super+Shift+S show, Super+Shift+D delete-last)\n' \
+        && printf 'Skróty GNOME zainstalowane (Super+Shift+S show, Super+Shift+D delete-last, Super+Shift+N new-take)\n' \
         || printf 'UWAGA: instalacja skrótów GNOME nie powiodła się — pomiń i skonfiguruj ręcznie\n'
     else
       printf 'UWAGA: brak %s/live-keybindings.sh — skróty GNOME pominięte\n' "$BIN_DIR"

--- a/deploy/live/tests/test_keybindings.sh
+++ b/deploy/live/tests/test_keybindings.sh
@@ -162,6 +162,7 @@ MOCK_LIST="@as []" \
 rc="$(SETKA_LIVE_CMD="$WORK/fake-setka-live" \
     KB_SHOW='<Super><Shift>s' \
     KB_DELETE='<Super><Shift>d' \
+    KB_NEW_TAKE='<Super><Shift>n' \
     run_install_keybindings)"
 [ "$rc" = "0" ] \
     && pass "install_keybindings: exit 0" \
@@ -174,6 +175,10 @@ grep -q "setka-show" "$GSETTINGS_LOG" \
 grep -q "setka-delete-last" "$GSETTINGS_LOG" \
     && pass "install_keybindings: rejestruje setka-delete-last" \
     || fail "install_keybindings: brak setka-delete-last; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
+
+grep -q "setka-new-take" "$GSETTINGS_LOG" \
+    && pass "install_keybindings: rejestruje setka-new-take" \
+    || fail "install_keybindings: brak setka-new-take; log: $(cat "$GSETTINGS_LOG" 2>/dev/null)"
 
 # ---------------------------------------------------------------------------
 # TEST 5: install_keybindings — SETKA_LIVE_CMD używany w command (absolutna ścieżka)

--- a/deploy/live/tests/test_setka_live.sh
+++ b/deploy/live/tests/test_setka_live.sh
@@ -466,6 +466,93 @@ grep -qi 'delete-last' "$WORK/out.log" \
   && pass "usage: wymienia delete-last" \
   || fail "usage: nie wymienia delete-last"
 
+# =============================================================================
+# Testy new-take (otwarcie czystego projektu Bitwig z szablonu)
+# =============================================================================
+# Mechanizm: `flatpak run <app-id> <template>` — działający Bitwig otwiera plik
+# i daje nienazwany projekt z szablonu. Rejestrator FLATPAK_BIN — wzorzec jak GIO_BIN.
+
+FLATPAK_LOG="$WORK/flatpak.log"
+FLATPAK_REC="$WORK/flatpak-rec"
+cat >"$FLATPAK_REC" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FLATPAK_LOG"
+exit "${FLATPAK_RC:-0}"
+EOF
+chmod +x "$FLATPAK_REC"
+
+# Szablon-atrapa: .bwtemplate to katalog-pakiet, więc tworzymy katalog (test -e, nie -f).
+NT_TEMPLATE="$WORK/template.bwtemplate"
+mkdir -p "$NT_TEMPLATE"
+
+# Wywołuje setka-live new-take z wstrzykniętym flatpakiem; czyści logi przed każdym wywołaniem.
+run_new_take() {
+  : >"$FLATPAK_LOG" >"$NOTIFY_LOG" >"$REC_LOG"
+  FLATPAK_LOG="$FLATPAK_LOG" NOTIFY_LOG="$NOTIFY_LOG" \
+    FLATPAK_BIN="$FLATPAK_REC" NOTIFY_BIN="$NOTIFY_REC" \
+    FLATPAK_RC="${FLATPAK_RC:-0}" \
+    SYSTEMCTL_BIN="$REC" SETKA_REC_LOG="$REC_LOG" \
+    LAYOUT_BIN="$LAYOUT_REC" \
+    HEALTH_URL="http://127.0.0.1:59999/health" \
+    "$@" \
+    bash "$SETKA" new-take >"$WORK/out.log" 2>&1
+  echo $?
+}
+
+# --- TEST NT1: Happy path — szablon istnieje → flatpak run z app-id + szablonem ---
+rc="$(BITWIG_TEMPLATE="$NT_TEMPLATE" run_new_take)"
+[ "$rc" = "0" ] && pass "new-take happy: exit 0" || fail "new-take happy: exit $rc"
+grep -q -- 'run' "$FLATPAK_LOG" \
+  && pass "new-take happy: flatpak run wywołany" || fail "new-take happy: brak flatpak run"
+grep -q 'com.bitwig.BitwigStudio' "$FLATPAK_LOG" \
+  && pass "new-take happy: woła app-id Bitwiga" \
+  || fail "new-take happy: brak app-id; log: $(cat "$FLATPAK_LOG" 2>/dev/null)"
+grep -q 'template.bwtemplate' "$FLATPAK_LOG" \
+  && pass "new-take happy: przekazuje szablon" \
+  || fail "new-take happy: brak szablonu w argumentach; log: $(cat "$FLATPAK_LOG" 2>/dev/null)"
+grep -qi 'bitwig\|projekt\|szablon' "$NOTIFY_LOG" \
+  && pass "new-take happy: notify-send potwierdza otwarcie" \
+  || fail "new-take happy: brak notify; log: $(cat "$NOTIFY_LOG" 2>/dev/null)"
+
+# --- TEST NT2: Brak szablonu → niezerowy exit, flatpak NIE wołany ---
+rc="$(BITWIG_TEMPLATE="$WORK/nieistnieje.bwtemplate" run_new_take)"
+[ "$rc" != "0" ] && pass "new-take brak-szablonu: niezerowy exit" \
+  || fail "new-take brak-szablonu: exit 0 (powinno != 0)"
+[ -s "$FLATPAK_LOG" ] \
+  && fail "new-take brak-szablonu: flatpak NIE powinien być wołany; log: $(cat "$FLATPAK_LOG")" \
+  || pass "new-take brak-szablonu: brak flatpak run (FAIL FAST)"
+
+# --- TEST NT3: Dispatch — new-take trafia w cmd_new_take (exit 0, nie 2) ---
+rc="$(BITWIG_TEMPLATE="$NT_TEMPLATE" run_new_take)"
+[ "$rc" = "0" ] && pass "dispatch: new-take → cmd_new_take" \
+  || fail "dispatch: new-take nie trafia w cmd_new_take; exit $rc"
+
+# --- TEST NT4: new-take nie dotyka paternologia.service (most MIDI nietknięty) ---
+BITWIG_TEMPLATE="$NT_TEMPLATE" run_new_take >/dev/null
+grep -q 'paternologia' "$REC_LOG" \
+  && fail "new-take: NIE powinien tykać paternologia.service" \
+  || pass "new-take: nie dotyka paternologia.service"
+
+# --- TEST NT5: Błąd flatpak (rc != 0) → notify o błędzie, niezerowy exit ---
+rc="$(BITWIG_TEMPLATE="$NT_TEMPLATE" FLATPAK_RC=1 run_new_take)"
+[ "$rc" != "0" ] && pass "new-take flatpak-error: niezerowy exit" \
+  || fail "new-take flatpak-error: exit 0 (powinno != 0)"
+grep -qi 'błąd\|error\|nie udało\|fail' "$NOTIFY_LOG" \
+  && pass "new-take flatpak-error: notify-send informuje o błędzie" \
+  || fail "new-take flatpak-error: brak notify o błędzie; log: $(cat "$NOTIFY_LOG" 2>/dev/null)"
+
+# --- TEST NT6: new-take czysto Bitwig — nie rusza systemd (start/stop) ---
+BITWIG_TEMPLATE="$NT_TEMPLATE" run_new_take >/dev/null
+grep -qE -- '--user (start|stop)' "$REC_LOG" \
+  && fail "new-take: niepotrzebnie ruszył systemd" \
+  || pass "new-take: nie dotyka systemd (czysto Bitwig)"
+
+# --- TEST NT7: usage wymienia new-take ---
+rc="$(run_setka frobnicate)"
+grep -qi 'new-take' "$WORK/out.log" \
+  && pass "usage: wymienia new-take" \
+  || fail "usage: nie wymienia new-take"
+
 rm -rf "$WORK"
 printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/deploy/live/tests/test_setka_tray.py
+++ b/deploy/live/tests/test_setka_tray.py
@@ -43,6 +43,15 @@ class TestMenuStructure:
         )
         assert labels["Usuń ostatnie nagranie"] == ["setka-live", "delete-last"]
 
+    def test_nowy_projekt_bitwig_mapuje_na_new_take(self, tray):
+        """Pozycja 'Nowy projekt Bitwig' musi mapować na ['setka-live', 'new-take']."""
+        items = tray.build_menu_items()
+        labels = {label: argv for label, argv in items if label is not None}
+        assert "Nowy projekt Bitwig" in labels, (
+            "Brak pozycji 'Nowy projekt Bitwig' w menu"
+        )
+        assert labels["Nowy projekt Bitwig"] == ["setka-live", "new-take"]
+
     def test_zakoncz_mapuje_na_brak_komendy(self, tray):
         """Pozycja 'Zakończ' musi mieć argv=None (czyste wyjście, brak komendy zewnętrznej)."""
         items = tray.build_menu_items()


### PR DESCRIPTION
## Summary
Nowa podkomenda operatorska **`setka-live new-take`** — otwiera świeży, nienazwany projekt Bitwig z szablonu, dając stan „na czysto" do nagrywania (komplementarne do `delete-last`: skasuj nieudane ujęcie → otwórz czysty projekt).

- **Mechanizm**: `flatpak run com.bitwig.BitwigStudio "<szablon>"` — działający Bitwig przejmuje plik (*„Bitwig Studio is already running — opening files"*) i tworzy nowy projekt **bez ubijania instancji**. Gdy Bitwig nie działa, flatpak wystartuje go z szablonem. Szablon to ten sam, którym startuje `bitwig.service`.
- **Walidacja** istnienia szablonu (FAIL FAST) zanim cokolwiek odpalimy; env override `BITWIG_TEMPLATE` / `BITWIG_APP_ID` / `FLATPAK_BIN`.
- **Wpięcie** spójne z `show`/`delete-last`: pozycja menu traya **„Nowy projekt Bitwig"** + globalny skrót GNOME **`Super+Shift+N`** (`KB_NEW_TAKE`).

### Zakres / granice
- To **połowa-Bitwig** „resetu rigu" — **NIE** czyści Model:Samples / MicroFreak / RC-600 (pełny reset sprzętu to osobna, większa faza; API rozszerzeń Bitwiga nie zarządza projektami, stąd CLI-open pliku).
- Niezapisane zmiany w bieżącym projekcie → własny prompt zapisu Bitwiga (ochrona danych, nie da się bezpiecznie wyciszyć).

> **Stacked PR:** gałąź bazuje na `feat/live-operator-quick-actions` (PR #38, jeszcze otwarty). Base ustawiony na tamtą gałąź — diff pokazuje wyłącznie `new-take`. Mergeować **po** #38 (albo przebazować na `master` po jego merge'u).

## Testing
- **TDD** (red→green) we wszystkich warstwach:
  - `test_setka_live.sh`: **79** (7 nowych dla `cmd_new_take`: happy path, brak szablonu, dispatch, brak paternologii, błąd flatpak, czysto-Bitwig, usage)
  - `test_keybindings.sh`: **16** (rejestracja `setka-new-take`)
  - `test_setka_tray.py`: **6** (pozycja menu → `['setka-live','new-take']`)
  - `test_install.sh`: **36** (bez regresji)
- Recorder-mock `FLATPAK_BIN` (wzorzec jak `GIO_BIN`/`SYSTEMCTL_BIN`) — bez mutowania żywego flatpaka.
- **Smoke-test pod `env -i`** (czyste środowisko jak ze skrótu GNOME) ze **spacjami w ścieżce szablonu** — potwierdza, że klasa błędu z poprzedniej sesji (word-splitting w czystym env) nie powraca.
- `ruff check` czysty.

## Post-Deploy Monitoring & Validation
- **Walidacja ręczna (operator)**: przy działającym Bitwigu naciśnij `Super+Shift+N` (lub menu traya) → Bitwig otwiera nienazwany projekt z szablonu; `notify-send` potwierdza. Z `BITWIG_TEMPLATE` wskazującym nieistniejącą ścieżkę → krytyczne powiadomienie + brak wywołania flatpaka.
- **Sygnał zdrowy**: nowy, czysty projekt w Bitwigu; brak osieroconych procesów flatpak.
- **Sygnał awarii / mitygacja**: jeśli `flatpak run` blokuje (Bitwig był ubity) — to znany edge (komenda foreground); zatrzymaj komendę, wystartuj `setka-live start`. Rollback: rewert commita / odinstalowanie skrótu (gsettings).
- **Okno walidacji / właściciel**: najbliższa sesja nagraniowa; Wojtas.
- Brak wpływu produkcyjnego poza lokalną stacją operatora.

---
🤖 Generated with Claude Opus 4.8 (1M context) via [Claude Code](https://claude.com/claude-code)