### PR TITLE
feat(paternologia): podpowiedź zajętości presetu/patternu + zgodne numery presetów w UI

### DIFF
--- a/docs/plans/2026-06-18-001-feat-preset-usage-hint-plan.md
+++ b/docs/plans/2026-06-18-001-feat-preset-usage-hint-plan.md
@@ -1,0 +1,389 @@
+---
+title: "feat: Podpowiedź zajętości presetu/patternu + zgodne numery presetów w UI"
+type: feat
+status: completed
+date: 2026-06-18
+---
+
+# feat: Podpowiedź zajętości presetu/patternu + zgodne numery presetów w UI
+
+## Overview
+
+Dwie powiązane zmiany w edytorze utworów paternologii:
+
+1. **Podpowiedź zajętości** — gdy użytkownik wybiera preset (Boss, Freak, Ampero) lub pattern
+   (M:S) dla urządzenia, pod polem wartości pojawia się podpowiedź (kaskada HTMX): czy ten slot
+   jest już użyty w innych utworach (z listą ich nazw), czy jest wolny. Cel: nie nadpisać /
+   nie naruszyć presetu lub patternu, który jest fizycznym, współdzielonym slotem na sprzęcie.
+2. **Zgodne numery presetów w UI** — numer presetu pokazywany i wpisywany w interfejsie jest
+   zgodny z numerem widocznym na ekranie urządzenia. Dziś dla Boss i Freak występuje przesunięcie
+   o jeden. Korekta dzieje się **transparentnie** przez **ukryty offset konfiguracyjny** w
+   `devices.yaml` — użytkownik nigdy nie widzi „przesunięcia" ani samego pola offsetu, tylko
+   spójny numer. Przechowywany `value` pozostaje surowym numerem MIDI.
+
+## Problem Frame
+
+Presety i paterny w utworach to **referencje do fizycznych slotów na sprzęcie** (numer programu
+na Boss/Freak/Ampero, slot patternu A0–F06 na Model:Samples). Aplikacja przechowuje tylko
+odwołania, nie samą zawartość. Dwa problemy autora:
+
+- **Współdzielenie slotów (problem 1):** ten sam slot referowany przez kilka utworów to ten sam
+  fizyczny zasób — przeprogramowanie go pod jeden utwór zmienia inny. Dziś, edytując, autor nie
+  widzi, czy numer jest już „zajęty" przez inny utwór.
+- **Off-by-one w numeracji (problem 2):** przechowywany `value` to surowy numer MIDI Program
+  Change (0-based; `pacer/mappings.py:action_to_midi` robi `prog = value % 128`). Boss i Freak
+  wyświetlają presety 1-based, więc numer w UI rozjeżdża się z ekranem urządzenia o jeden, co
+  prowadzi do konfuzji. Pattern M:S jest zgodny (osobna konwencja, autor potwierdza brak rozjazdu).
+
+## Requirements Trace
+
+- R1. Po wybraniu urządzenia + typu (`preset`/`pattern`) i wpisaniu wartości, pod polem pojawia
+  się informacja o zajętości tego slotu w **innych** utworach.
+- R2. Gdy slot nie jest użyty w żadnym innym utworze — podpowiedź jasno komunikuje „wolny".
+- R3. Gdy slot jest użyty — podpowiedź wymienia nazwy utworów, które go używają.
+- R4. Bieżąco edytowany utwór jest wykluczany z listy.
+- R5. Mechanizm działa tak samo dla nowego utworu (`/songs/new`) jak i edycji istniejącego.
+- R6. Numer presetu pokazywany w UI i wpisywany przez użytkownika jest zgodny z numerem na
+  ekranie urządzenia (Boss, Freak; Ampero konfigurowalny na przyszłość).
+- R7. Offset jest **ukrytą konfiguracją** w `devices.yaml`, niewidoczną i nieedytowalną z poziomu
+  UI; użytkownik nie widzi „przesunięcia" ani wartości offsetu. Pattern M:S bez zmian (offset 0).
+
+## Scope Boundaries
+
+- **Tylko typy `preset` i `pattern`** dla podpowiedzi zajętości. Akcje `cc`/`note` to chwilowe
+  komunikaty, nie sloty — nie są śledzone.
+- **Tylko lista utworów, bez analizy konfliktu etykiet** (decyzja użytkownika).
+- **„Wolny" = nieużywany w innych utworach**, nie „wolny w przestrzeni slotów urządzenia".
+- **Offset numeracji jest WYŁĄCZNIE wyświetlaniem i jest ukryty.** Przechowywany `value` w YAML
+  pozostaje surowym numerem MIDI. **Bez zmian w eksporcie** (`pacer/`), **bez zmian w detekcji
+  live** (`midi/index.py`), **bez migracji istniejących plików utworów**. To celowe: eksport do
+  Pacera działa i jest wrażliwy (ryzyko zbrickowania), więc go nie ruszamy.
+- **Offset NIE jest wystawiany w żadnym UI.** Widok `/devices` jest tylko do odczytu (brak
+  formularzy edycji), a edytor utworu nie pokazuje pola offsetu — wartość żyje wyłącznie w
+  `devices.yaml` (edycja ręczna / konfiguracyjna).
+- Offset dotyczy tylko typu `preset` (numeryczny). Pattern (string) bez offsetu.
+- Spójne wyświetlanie numeru presetu poza edytorem (widok `song.html`, lista) — patrz Deferred.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`packages/paternologia/src/paternologia/midi/index.py` (`SongMidiIndex`)** — wzorzec klasy
+  z `build(songs, devices)` skanującej wszystkie utwory i `lookup(...)`. Nowy indeks zajętości
+  ma identyczny kształt. **Pozostaje bez zmian** (operuje na surowym `value`).
+- **`packages/paternologia/src/paternologia/pacer/mappings.py` (`action_to_midi`)** — tu żyje
+  konwersja `value` → MIDI (`prog = value % 128`, `bank_msb = value // 128`). **Bez zmian** —
+  potwierdza, że przechowywany `value` to surowy numer MIDI, więc offset musi być tylko nakładką
+  wyświetlania.
+- **`packages/paternologia/src/paternologia/models.py`** — `Device` (dodamy ukryte pole offsetu),
+  `Action(device, type, value, label, …)`, `ActionType`. Preset `value: int`, pattern `value: str`.
+- **`packages/paternologia/src/paternologia/storage.py` (`Storage`)** — `get_songs()`,
+  `get_devices()`. Źródło danych.
+- **`packages/paternologia/src/paternologia/routers/{songs,devices}.py`** — `devices.py` ma tylko
+  listę/JSON urządzeń (read-only, brak edycji). `songs.py` ma partiale HTMX
+  (`/partials/action-types`, `/partials/action-fields`) i `_build_song_from_form` (tu konwersja
+  numer-urządzenia → surowy `value`). Nowy endpoint `/partials/preset-usage`.
+- **`packages/paternologia/templates/partials/{action_fields,action_row}.html`** — render pól i
+  wzorzec kaskady HTMX (`hx-get`, `hx-target="next ..."`, `hx-vals="js:{...}"`).
+- **`packages/paternologia/templates/song_edit.html`** — formularz edycji; udostępnimy ID
+  bieżącego utworu (`data-song-id`).
+
+### Institutional Learnings
+
+- Brak wpisu w `docs/solutions/` o paternologii. Najbliższy wzorzec to `SongMidiIndex` w repo.
+- Z pamięci agenta: pełne `uv run pytest` bywa zepsute — testować po ścieżce pakietu
+  (`uv run --package paternologia pytest packages/paternologia/tests/...`).
+- Z pamięci agenta: eksport do Pacera jest krytyczny (ostrzeżenia o brickowaniu) — stąd decyzja,
+  by offset był display-only i nie dotykał ścieżki SysEx.
+
+### External References
+
+- Pominięto research zewnętrzny: funkcja jest mała, w pełni wewnętrzna (FastAPI + HTMX + Jinja2),
+  z silnym lokalnym wzorcem (`SongMidiIndex`) i kompletem konwencji partiali HTMX.
+
+## Key Technical Decisions
+
+- **Offset jako ukryte pole konfiguracyjne `Device.preset_display_offset`** (int, default 0) w
+  `devices.yaml`. Konwencja: `offset = (numer na ekranie urządzenia) − (surowy value MIDI)`;
+  `displayed = stored + offset`, `stored = entered − offset`. Boss/Freak → `1`; M:S → `0`.
+  Rationale: spełnia R6/R7 bez dotykania działającego eksportu i bez migracji plików; pole nie
+  jest wystawiane w UI (widok urządzeń jest read-only). Offset signed → odporny, gdyby któreś
+  urządzenie miało inny kierunek/wielkość.
+- **Korekta jest transparentna dla użytkownika.** W edytorze widzi i wpisuje numer urządzenia;
+  offset nakładany/zdejmowany pod spodem. Użytkownik nigdy nie widzi „przesunięcia" ani offsetu.
+- **Centralne helpery konwersji** `to_display(value, device)` / `to_stored(value, device)` dla
+  typu `preset` (DRY — render edytora, parsowanie formularza, endpoint podpowiedzi). Pattern i
+  inne typy: tożsamość.
+- **Osobny indeks zajętości `PresetUsageIndex`, kluczowany na SUROWYM `value`.** Nie rozszerzamy
+  `SongMidiIndex` (inny cel: pełna lista per slot, nie first-match dla live). Dopasowanie na
+  surowych wartościach (spójnych z plikami); offset to tylko warstwa prezentacji.
+- **Indeks budowany na żądanie z `storage.get_songs()` w endpoincie, bez cache w `app.state`.**
+  Rationale: dziesiątki utworów, tani skan, krytyczna świeżość po zapisie; cache ryzykowałby
+  nieaktualne podpowiedzi.
+- **Typ akcji stały w gałęzi szablonu** → `action_type` jako literał w `hx-vals`; `device_id` i
+  `value` czytane na żywo z DOM. Spójne z istniejącym wzorcem kaskady.
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Gdzie żyją presety/paterny?* — Wyłącznie w `pacer[].actions[]` (model `Song` nie ma już bloku
+  `devices:` z SPEC-a; potwierdzone na `swit.yaml`, `a1-w-ciszy-learn.yaml`).
+- *„Wolny" = wolny na sprzęcie?* — Nie; „nieużywany w innych utworach".
+- *Prezentacja podpowiedzi?* — Inline przy polu (kaskada HTMX), nie osobna mapa.
+- *Konflikt etykiet?* — Tylko lista utworów, bez analizy `label`.
+- *Czy offset ma zmieniać eksport/MIDI?* — Nie. Display-only; przechowywany `value` i ścieżka
+  SysEx/live bez zmian.
+- *Gdzie żyje offset i czy użytkownik go widzi?* — Ukryte pole w `devices.yaml` (konfiguracja),
+  niewidoczne i nieedytowalne w UI; korekta transparentna (użytkownik: „nie muszę widzieć w
+  edytorze przesunięcia", „pole offsetu ma być ukryte i być częścią konfiguracji").
+- *Których urządzeń dotyczy offset?* — Boss i Freak (off-by-one). M:S zgodny → 0. Ampero brak
+  sprzętu → pole domyślnie 0, do uzupełnienia później.
+
+### Deferred to Implementation
+
+- **Dokładny offset dla Ampero** — gdy sprzęt się pojawi; pole już będzie gotowe.
+- **Spójny numer presetu poza edytorem** (widok `song.html`, lista) — ten sam helper `to_display`
+  można tam podpiąć; rozważyć po wdrożeniu edytora.
+- **Czy pokazywać podpowiedź od razu przy otwarciu edycji** (trigger `load`) czy dopiero przy
+  zmianie wartości — rozstrzygnąć przy implementacji szablonu.
+- Dokładny debounce triggera `keyup` (~300–500 ms).
+
+## Implementation Units
+
+- [x] **Unit 1: Ukryty offset numeru presetu (model + helpery konwersji)**
+
+**Goal:** Numer presetu w UI zgodny z ekranem urządzenia, korygowany transparentnie przez ukryte
+pole konfiguracyjne; bez zmian w przechowywanym `value` ani w eksporcie.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Brak.
+
+**Files:**
+- Modify: `packages/paternologia/src/paternologia/models.py` (pole `Device.preset_display_offset`)
+- Create: `packages/paternologia/src/paternologia/display.py` (helpery `to_display`/`to_stored`)
+- Modify: `packages/paternologia/data/devices.yaml` (offset 1 dla boss/freak; 0/brak dla ms)
+- Test: `packages/paternologia/tests/test_display.py`
+- Test: `packages/paternologia/tests/test_models.py` (default offsetu)
+
+**Approach:**
+- `Device.preset_display_offset: int = Field(default=0, description="Ukryty offset wyświetlania
+  numeru presetu (ekran urządzenia − surowy MIDI); konfiguracja, nie wystawiana w UI")`. Domyślnie
+  0 → urządzenia bez pola działają jak dziś (M:S, nieskonfigurowane).
+- `display.py`: `to_display(value, device)` — dla `preset`-owej wartości numerycznej zwraca
+  `value + device.preset_display_offset`; `to_stored(value, device)` — `value − offset`. Pattern/
+  inne: zwraca wejście bez zmian. Jedna reguła, dwie strony (DRY); round-trip
+  `to_stored(to_display(v)) == v`.
+- `devices.yaml`: dodać `preset_display_offset: 1` do `boss` i `freak`. (Nie pokazywane w UI —
+  widok `/devices` jest read-only.)
+
+**Patterns to follow:**
+- Pola `Device` w `models.py` (np. `midi_channel` z `Field(..., ge=, le=)`).
+
+**Test scenarios:**
+- Happy path: `to_display(100, boss)` → `101`; `to_stored(101, boss)` → `100`.
+- Round-trip: dla zakresu wartości `to_stored(to_display(v)) == v`.
+- Edge: urządzenie bez offsetu (M:S, default 0) → `to_display`/`to_stored` to tożsamość.
+- Edge: pattern (string) → offset nie stosowany.
+- Edge: `value` None/pusty → bez wyjątku, zwraca wejście.
+- Model: `Device` bez pola w YAML → `preset_display_offset == 0`.
+
+**Verification:**
+- `test_display.py` i `test_models.py` zielone; konwersja per urządzenie działa, pattern nietknięty.
+
+---
+
+- [x] **Unit 2: Indeks zajętości `PresetUsageIndex`**
+
+**Goal:** Czysta (bez web) struktura mapująca slot `(device, type, surowy value)` na listę
+utworów, z wykluczaniem wskazanego utworu w odpytaniu.
+
+**Requirements:** R1, R3, R4
+
+**Dependencies:** Brak (operuje na surowym `value`, niezależnie od Unit 1).
+
+**Files:**
+- Create: `packages/paternologia/src/paternologia/usage.py`
+- Test: `packages/paternologia/tests/test_usage.py`
+
+**Approach:**
+- `PresetUsageIndex` wzorowany na `SongMidiIndex`: `@classmethod build(songs)` skanuje
+  `song.pacer[].actions[]`, bierze tylko `PRESET`/`PATTERN` z niepustą `value`, normalizuje
+  (preset → `int`, pattern → `str.strip().upper()`), akumuluje `klucz → list[wpis(song_id, song_name)]`.
+- `lookup(device_id, action_type, value, exclude_song_id=None)` normalizuje wartość tak samo,
+  zwraca utwory używające slotu z pominięciem `exclude_song_id`, deduplikuje powtórne użycie w
+  obrębie jednego utworu, zachowuje kolejność z `get_songs()`.
+- Normalizacja wydzielona do jednej funkcji (DRY — klucz identyczny w `build` i `lookup`).
+
+**Patterns to follow:**
+- `midi/index.py` — kształt `build`/`lookup`, logowanie pomijanych akcji, iteracja po przyciskach.
+
+**Test scenarios:**
+- Happy path: dwa utwory używają `boss/preset/4` → lookup zwraca oba (z nazwami).
+- Happy path (pattern): `ms/pattern/F03` w dwóch utworach; klucz odporny na wielkość liter/spacje.
+- Edge: slot tylko w jednym utworze + `exclude_song_id` ten utwór → pusta lista.
+- Edge: ten sam slot w dwóch przyciskach jednego utworu → utwór raz (dedup).
+- Edge: `value` None/pusty → akcja pomijana.
+- Edge: `cc`/`note` → ignorowane.
+- Edge: preset `int` vs pattern `str` nie kolidują (różny `action_type` w kluczu).
+
+**Verification:**
+- `test_usage.py` zielone; grupowanie, wykluczanie i normalizacja patternu działają.
+
+---
+
+- [x] **Unit 3: Endpoint i partial podpowiedzi `/partials/preset-usage`**
+
+**Goal:** Endpoint HTMX zwracający fragment HTML: „używany też w: …" albo „wolny", dla
+`(device_id, action_type, value)` z wykluczeniem bieżącego utworu; wartość z UI (numer
+urządzenia) konwertowana na surowy `value` przed dopasowaniem.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** Unit 2 (indeks), Unit 1 (helper `to_stored` do konwersji wartości z UI).
+
+**Files:**
+- Modify: `packages/paternologia/src/paternologia/routers/songs.py`
+- Create: `packages/paternologia/templates/partials/preset_usage.html`
+- Test: `packages/paternologia/tests/test_api.py`
+
+**Approach:**
+- `GET /partials/preset-usage` z query: `device_id`, `action_type`, `value` (numer z UI, str),
+  `song_id` (opcjonalny). Jeśli `action_type` nie jest `preset`/`pattern` albo `value`
+  puste/niepełne → pusty fragment. W przeciwnym razie: pobierz device, dla `preset` zamień numer
+  z UI na surowy przez `to_stored(value, device)` (pattern bez konwersji), zbuduj
+  `PresetUsageIndex` z `storage.get_songs()`, `lookup(..., exclude_song_id=song_id)`, przekaż do
+  partiala.
+- `preset_usage.html`: lista niepusta → „⚠ używany też w: «Nazwa1», «Nazwa2»"; pusta → „✓ wolny
+  (nieużywany w innych utworach)". Styl spójny z `action_fields.html`.
+
+**Patterns to follow:**
+- `get_action_fields`/`get_action_types` w `routers/songs.py` — sygnatura handlera, `get_storage`/
+  `get_templates`, zwrot `TemplateResponse("partials/...", {...})`.
+
+**Test scenarios:**
+- Happy path: dwa utwory współdzielą `boss/preset` (numer UI np. 5 → stored 4); GET z `song_id`
+  jednego → odpowiedź zawiera nazwę drugiego, nie bieżącego.
+- Happy path (wolny): slot tylko w bieżącym utworze → tekst „wolny".
+- Edge: `value` puste → minimalny fragment.
+- Edge: `action_type=cc` → pusty fragment.
+- Edge: `song_id` pusty (nowy utwór) → nic nie wykluczane.
+- Edge (offset): numer UI dla boss (offset 1) poprawnie konwertowany na surowy `value` przed
+  lookupem — dopasowuje utwory zapisane surowo.
+- Integration: utwór zapisany przez `PUT /songs/{id}`, potem GET `/partials/preset-usage`
+  odzwierciedla świeży stan (dowód braku nieaktualnego cache).
+
+**Verification:**
+- Nowe testy `test_api.py` zielone; endpoint zwraca poprawny HTML i respektuje `song_id` + offset.
+
+---
+
+- [x] **Unit 4: Wpięcie w formularz edycji (HTMX + transparentny numer)**
+
+**Goal:** Pole wartości presetu/patternu odpytuje `/partials/preset-usage` i pokazuje wynik pod
+polem; pole presetu transparentnie pokazuje/przyjmuje numer urządzenia (offset pod spodem), a
+zapis konwertuje na surowy `value`. Użytkownik nie widzi offsetu.
+
+**Requirements:** R1, R2, R5, R6
+
+**Dependencies:** Unit 3 (endpoint), Unit 1 (helpery + offset urządzeń w kontekście szablonu).
+
+**Files:**
+- Modify: `packages/paternologia/templates/partials/action_fields.html`
+- Modify: `packages/paternologia/templates/partials/action_row.html` (przekazanie device do pól)
+- Modify: `packages/paternologia/templates/song_edit.html` (`data-song-id` na `<form>`)
+- Modify: `packages/paternologia/src/paternologia/routers/songs.py` (`_build_song_from_form`:
+  `to_stored` dla presetu; endpointy partiali przekazują device do kontekstu)
+- Test: `packages/paternologia/tests/test_api.py`
+
+**Approach:**
+- `song_edit.html`: `data-song-id="{{ song.song.id if song else '' }}"` na `<form>`.
+- `action_fields.html`, gałęzie `preset`/`pattern`: input `..._value` renderuje **numer
+  wyświetlany** (`to_display(action.value, device)` dla presetu; pattern bez zmian) i dostaje
+  `hx-get="/partials/preset-usage"`, `hx-target` na sąsiedni `<div class="preset-usage">`,
+  `hx-trigger="change, keyup changed delay:400ms"`, `hx-vals="js:{...}"` (device_id z selecta w
+  `closest('.action-row')`, `action_type` literałem gałęzi, `value` z `event.target.value`,
+  `song_id` z `form[data-song-id]`).
+- `_build_song_from_form`: dla `preset` zamień wpisany numer (UI) na surowy przez
+  `to_stored(value, device)` zanim zbudujesz `Action`. Pattern/cc/note bez zmian.
+- Endpointy renderujące pola (`get_action_fields`, render istniejących akcji) muszą mieć dostęp do
+  `device` (dla `to_display`) — przekazać device w kontekście, spójnie z istniejącym `devices`.
+
+**Technical design:** *(directional, nie specyfikacja)*
+```
+<input ... name="button_{i}_action_{j}_value"
+       value="{{ to_display(action.value, device) if action else '' }}"   // preset: stored+offset
+       hx-get="/partials/preset-usage"
+       hx-target="next .preset-usage"
+       hx-trigger="change, keyup changed delay:400ms"
+       hx-vals='js:{ device_id: <select _device w closest(.action-row)>,
+                     action_type: "preset",
+                     value: event.target.value,         // numer urządzenia; endpoint robi to_stored
+                     song_id: <form[data-song-id].dataset.songId || ""> }'>
+<div class="preset-usage text-xs ..."></div>
+// zapis: _build_song_from_form → to_stored(value, device) dla presetu
+```
+
+**Patterns to follow:**
+- `action_row.html` — `hx-get` + `hx-target="next ..."` + `hx-vals="js:{...}"` + `hx-indicator`.
+
+**Test scenarios:**
+- Happy path: GET `/songs/{id}/edit` renderuje pola preset/pattern z `hx-get` na
+  `/partials/preset-usage` i kontenerem `.preset-usage`.
+- Happy path (offset): utwór z `boss preset` surowym `value=4` renderuje w polu `5` (offset 1);
+  offset ani jego pole nie pojawiają się w HTML jako edytowalne.
+- Round-trip: render `5` → submit → `_build_song_from_form` zapisuje surowy `4` (plik niezmieniony
+  względem konwencji MIDI).
+- Edge: `/songs/new` → `<form data-song-id="">`; pole presetu puste.
+- Edge: gałąź `cc`/`note` NIE dostaje triggera podpowiedzi ani offsetu.
+- Edge: pattern renderowany bez offsetu (M:S zgodny).
+- Integration: render edycji + symulowane GET `/partials/preset-usage` z wartością z formularza
+  → poprawna podpowiedź (łączy Unit 3 i wpięcie szablonu).
+
+**Verification:**
+- Strona edycji i nowego utworu renderują się; pola preset/pattern mają wpięty HTMX + kontener
+  podpowiedzi; numer presetu w UI zgodny z urządzeniem, bez widocznego offsetu; zapis odtwarza
+  surowy `value`.
+
+## System-Wide Impact
+
+- **Interaction graph:** Nowy endpoint partiala dołącza do rodziny `/partials/*`. Offset zmienia
+  render pól i parsowanie formularza, ale **nie** dotyka `export_song_to_syx`/`action_to_midi`
+  ani `SongMidiIndex` (te dalej operują na surowym `value`).
+- **Error propagation:** Podpowiedź jest best-effort — brak/niepełne parametry → pusty fragment,
+  nigdy błąd blokujący edycję. Konwersja offsetu odporna na None/pusty.
+- **State lifecycle risks:** Indeks budowany na żądanie → zawsze świeży. Round-trip
+  display↔stored musi być tożsamością, inaczej zapis dryfowałby o offset przy każdej edycji —
+  pokryte testem round-trip (Unit 1 i Unit 4).
+- **API surface parity:** Offset stosowany w edytorze; widok `song.html`/lista mogą wymagać tej
+  samej nakładki dla spójności (Deferred). Eksport i widok urządzeń celowo bez zmian.
+- **Data integrity:** Brak migracji — przechowywany `value` zachowuje znaczenie (surowy MIDI);
+  istniejące pliki działają bez zmian, w UI wyświetlą się z offsetem.
+- **Integration coverage:** Testy round-trip (render→submit→stored) i zapis→odczyt świeżego stanu
+  dowodzą poprawności tam, gdzie testy jednostkowe nie sięgają.
+
+## Risks & Dependencies
+
+- **Spójność offsetu na obu krańcach (display ↔ stored).** Jeśli render dodaje offset, a zapis go
+  nie odejmuje (lub odwrotnie), wartości dryfują przy każdym zapisie. Mitygacja: jedna para
+  helperów `to_display`/`to_stored` + test round-trip; offset stosowany TYLKO w warstwie
+  edytora/parsowania, nigdy w eksporcie/indeksie.
+- **Kierunek/wielkość offsetu zakładane jako +1 dla Boss/Freak.** Mitygacja: pole signed i
+  konfigurowalne per urządzenie; weryfikacja empiryczna na sprzęcie po wdrożeniu.
+- **Odczyt `device_id` z DOM w `hx-vals`** zależy od struktury `.action-row` i nazwy selecta
+  `..._device`. Mitygacja: `closest('.action-row')` + `select[name$=_device]`, spójnie z
+  renumeracją w `song_edit.html`.
+- **Pattern jako string o niejednolitej wielkości liter** — normalizacja `strip().upper()` (Unit 2).
+- Brak zależności zewnętrznych; eksport, format YAML i ścieżka SysEx nietknięte.
+
+## Sources & References
+
+- Konwersja MIDI (dowód, że `value` jest surowy): `packages/paternologia/src/paternologia/pacer/mappings.py`
+- Wzorzec indeksu: `packages/paternologia/src/paternologia/midi/index.py` (`SongMidiIndex`)
+- Model danych: `packages/paternologia/src/paternologia/models.py`
+- Urządzenia read-only w UI: `packages/paternologia/src/paternologia/routers/devices.py`
+- Endpointy partiali HTMX i parsowanie formularza: `packages/paternologia/src/paternologia/routers/songs.py`
+- Szablony edycji: `packages/paternologia/templates/song_edit.html`,
+  `packages/paternologia/templates/partials/{action_fields,action_row}.html`
+- Pliki utworów potwierdzające strukturę: `packages/paternologia/data/songs/{swit,a1-w-ciszy-learn}.yaml`

--- a/packages/paternologia/data/devices.yaml
+++ b/packages/paternologia/data/devices.yaml
@@ -3,6 +3,7 @@ devices:
     name: RC-600
     description: Loop Station
     midi_channel: 13
+    preset_display_offset: 1
     action_types:
       - preset
       - cc
@@ -16,6 +17,7 @@ devices:
     name: MicroFreak
     description: Synthesizer
     midi_channel: 1
+    preset_display_offset: 1
     action_types:
       - preset
       - note
@@ -26,6 +28,13 @@ devices:
   #   action_types:
   #     - preset
   #     - cc
+  - id: ampero
+    name: Ampero II Stomp
+    description: Multieffect (gitara)
+    midi_channel: 5
+    action_types:
+      - preset
+      - cc
   - id: start_stop
     name: Pacer Controll
     description: Multieffect

--- a/packages/paternologia/src/paternologia/dependencies.py
+++ b/packages/paternologia/src/paternologia/dependencies.py
@@ -47,5 +47,9 @@ def get_templates() -> Jinja2Templates:
     """Get or create templates instance."""
     global _templates
     if _templates is None:
+        from paternologia.display import to_display
+
         _templates = Jinja2Templates(directory=TEMPLATES_DIR)
+        # Editor renders device-screen numbers; the hidden offset is applied here.
+        _templates.env.globals["to_display"] = to_display
     return _templates

--- a/packages/paternologia/src/paternologia/display.py
+++ b/packages/paternologia/src/paternologia/display.py
@@ -1,0 +1,31 @@
+# ABOUTME: Display-number conversion for preset values using a hidden per-device offset.
+# ABOUTME: Bridges the raw MIDI value stored in YAML and the number shown on the device.
+
+from paternologia.models import Device
+
+
+def to_display(value: int | str | None, device: Device) -> int | str | None:
+    """Raw stored value → number shown to the user (device-screen number).
+
+    Applies ``device.preset_display_offset`` only to integer preset values.
+    Patterns (strings) and empty values pass through unchanged so callers can
+    invoke this generically without branching on action type.
+    """
+    if isinstance(value, bool):  # bool is an int subclass; never an offset target
+        return value
+    if isinstance(value, int):
+        return value + device.preset_display_offset
+    return value
+
+
+def to_stored(value: int | str | None, device: Device) -> int | str | None:
+    """Number entered in the UI (device-screen number) → raw value to store.
+
+    Inverse of :func:`to_display`. Callers parse form strings to ``int`` before
+    calling for preset values; patterns and empty values pass through unchanged.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value - device.preset_display_offset
+    return value

--- a/packages/paternologia/src/paternologia/models.py
+++ b/packages/paternologia/src/paternologia/models.py
@@ -30,6 +30,14 @@ class Device(BaseModel):
     midi_channel: int = Field(
         default=0, ge=0, le=15, description="MIDI channel (0-15) for this device"
     )
+    preset_display_offset: int = Field(
+        default=0,
+        description=(
+            "Hidden display offset for preset numbers (device-screen number "
+            "minus raw MIDI value). Config only, never surfaced in the UI; "
+            "applied transparently in the editor. 0 = no shift."
+        ),
+    )
 
 
 class DevicesConfig(BaseModel):

--- a/packages/paternologia/src/paternologia/routers/songs.py
+++ b/packages/paternologia/src/paternologia/routers/songs.py
@@ -101,11 +101,19 @@ async def edit_song(request: Request, song_id: str):
         raise HTTPException(status_code=404, detail="Song not found")
 
     devices = storage.get_devices()
+    from paternologia.usage import PresetUsageIndex
+
+    usage_index = PresetUsageIndex.build(storage.get_songs())
 
     return templates.TemplateResponse(
         request=request,
         name="song_edit.html",
-        context={"song": song, "devices": devices, "is_new": False},
+        context={
+            "song": song,
+            "devices": devices,
+            "is_new": False,
+            "usage_index": usage_index,
+        },
     )
 
 

--- a/packages/paternologia/src/paternologia/routers/songs.py
+++ b/packages/paternologia/src/paternologia/routers/songs.py
@@ -361,6 +361,56 @@ async def get_action_types(
     )
 
 
+@router.get("/partials/preset-usage", response_class=HTMLResponse)
+async def get_preset_usage(
+    request: Request,
+    device_id: str,
+    action_type: str,
+    value: str = "",
+    song_id: str = "",
+):
+    """Return an occupancy hint for a preset/pattern slot (HTMX, best-effort).
+
+    The incoming ``value`` is the device-screen number shown in the editor; for
+    presets it is converted back to the raw stored value before lookup so it
+    matches what songs persist. Missing/incomplete params yield a blank fragment
+    rather than an error, so the hint never blocks editing.
+    """
+    from paternologia.display import to_stored
+    from paternologia.usage import PresetUsageIndex
+
+    storage = get_storage()
+    templates = get_templates()
+
+    entries = []
+    valid = action_type in (ActionType.PRESET.value, ActionType.PATTERN.value)
+    if valid and value.strip():
+        device = next((d for d in storage.get_devices() if d.id == device_id), None)
+        if device is not None:
+            if action_type == ActionType.PRESET.value:
+                try:
+                    lookup_value = to_stored(int(value), device)
+                except (TypeError, ValueError):
+                    lookup_value = None
+            else:
+                lookup_value = value
+
+            if lookup_value is not None:
+                index = PresetUsageIndex.build(storage.get_songs())
+                entries = index.lookup(
+                    device_id,
+                    action_type,
+                    lookup_value,
+                    exclude_song_id=song_id or None,
+                )
+
+    return templates.TemplateResponse(
+        request=request,
+        name="partials/preset_usage.html",
+        context={"entries": entries, "show": valid and bool(value.strip())},
+    )
+
+
 @router.get("/partials/action-fields", response_class=HTMLResponse)
 async def get_action_fields(
     request: Request, action_type: str, button_idx: int, action_idx: int

--- a/packages/paternologia/src/paternologia/routers/songs.py
+++ b/packages/paternologia/src/paternologia/routers/songs.py
@@ -9,6 +9,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
 from paternologia.dependencies import get_storage, get_templates
+from paternologia.display import to_stored
 from paternologia.models import (
     Action,
     ActionType,
@@ -210,6 +211,8 @@ def _build_song_from_form(
     target_preset = form_data.get("pacer_export_target_preset", "A1").strip()
     pacer_export = PacerExportSettings(target_preset=target_preset or "A1")
 
+    device_map = {d.id: d for d in storage.get_devices()}
+
     pacer_buttons = []
     button_idx = 0
 
@@ -255,6 +258,12 @@ def _build_song_from_form(
                     if action_value:
                         if action_type == ActionType.PATTERN:
                             value = action_value
+                        elif action_type == ActionType.PRESET:
+                            # UI shows the device-screen number; strip the hidden
+                            # display offset back to the raw MIDI value to store.
+                            device = device_map.get(action_device)
+                            raw = int(action_value)
+                            value = to_stored(raw, device) if device else raw
                         else:
                             value = int(action_value)
 

--- a/packages/paternologia/src/paternologia/usage.py
+++ b/packages/paternologia/src/paternologia/usage.py
@@ -1,0 +1,103 @@
+# ABOUTME: Reverse index from a preset/pattern slot to the songs that occupy it.
+# ABOUTME: Keys on the raw stored value so display offset never affects matching.
+
+import logging
+from typing import NamedTuple
+
+from paternologia.models import ActionType, Song
+
+logger = logging.getLogger(__name__)
+
+_TRACKED_TYPES = (ActionType.PRESET, ActionType.PATTERN)
+
+
+class UsageEntry(NamedTuple):
+    """A song that uses a particular slot."""
+
+    song_id: str
+    song_name: str
+
+
+def _normalize_value(action_type: ActionType, value: int | str | None):
+    """Build a stable slot key part from a raw action value.
+
+    Presets compare as integers; patterns compare case/whitespace-insensitively.
+    Returns ``None`` for values that should not be indexed.
+    """
+    if value is None:
+        return None
+    if action_type == ActionType.PRESET:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    if action_type == ActionType.PATTERN:
+        normalized = str(value).strip().upper()
+        return normalized or None
+    return None
+
+
+def _coerce_action_type(action_type: ActionType | str) -> ActionType | None:
+    if isinstance(action_type, ActionType):
+        return action_type
+    try:
+        return ActionType(action_type)
+    except ValueError:
+        return None
+
+
+class PresetUsageIndex:
+    """Maps (device_id, action_type, raw value) → ordered list of songs using it."""
+
+    def __init__(self, mapping: dict[tuple[str, str, object], list[UsageEntry]]):
+        self._mapping = mapping
+
+    @classmethod
+    def build(cls, songs: list[Song]) -> "PresetUsageIndex":
+        """Build the index by scanning every preset/pattern action in all songs.
+
+        Mirrors ``SongMidiIndex.build`` in shape. A slot used multiple times
+        within one song lists that song once; order follows ``songs``.
+        """
+        mapping: dict[tuple[str, str, object], list[UsageEntry]] = {}
+
+        for song in songs:
+            for button in song.pacer:
+                for action in button.actions:
+                    if action.type not in _TRACKED_TYPES:
+                        continue
+                    normalized = _normalize_value(action.type, action.value)
+                    if normalized is None:
+                        logger.debug(
+                            "Song '%s': skipping %s action with empty value",
+                            song.song.id,
+                            action.type.value,
+                        )
+                        continue
+
+                    key = (action.device, action.type.value, normalized)
+                    entries = mapping.setdefault(key, [])
+                    if not any(e.song_id == song.song.id for e in entries):
+                        entries.append(UsageEntry(song.song.id, song.song.name))
+
+        logger.info("Built preset usage index with %d slots", len(mapping))
+        return cls(mapping)
+
+    def lookup(
+        self,
+        device_id: str,
+        action_type: ActionType | str,
+        value: int | str | None,
+        exclude_song_id: str | None = None,
+    ) -> list[UsageEntry]:
+        """Return songs occupying the slot, excluding ``exclude_song_id``."""
+        coerced = _coerce_action_type(action_type)
+        if coerced is None:
+            return []
+        normalized = _normalize_value(coerced, value)
+        if normalized is None:
+            return []
+
+        key = (device_id, coerced.value, normalized)
+        entries = self._mapping.get(key, [])
+        return [e for e in entries if e.song_id != exclude_song_id]

--- a/packages/paternologia/src/paternologia/usage.py
+++ b/packages/paternologia/src/paternologia/usage.py
@@ -5,6 +5,7 @@ import logging
 from typing import NamedTuple
 
 from paternologia.models import ActionType, Song
+from paternologia.pacer.mappings import pattern_to_program
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +33,13 @@ def _normalize_value(action_type: ActionType, value: int | str | None):
         except (TypeError, ValueError):
             return None
     if action_type == ActionType.PATTERN:
-        normalized = str(value).strip().upper()
-        return normalized or None
+        text = str(value).strip()
+        if not text:
+            return None
+        # Identify a pattern by its physical slot (program number), so equivalent
+        # spellings collapse to one slot: "A9" == "A09", "a01" == "A01". This is
+        # the same slot identity the hardware/export uses (pattern_to_program).
+        return pattern_to_program(text)
     return None
 
 

--- a/packages/paternologia/templates/partials/action_fields.html
+++ b/packages/paternologia/templates/partials/action_fields.html
@@ -6,24 +6,32 @@
        class="border border-gray-300 rounded px-2 py-1 text-sm w-20"
        hx-get="/partials/preset-usage"
        hx-target="next .preset-usage"
-       hx-trigger="load, change, keyup changed delay:400ms"
+       hx-trigger="change, keyup changed delay:400ms"
        hx-vals="js:{device_id: (event.target || event).closest('.action-row').querySelector('select[name$=_device]').value, action_type: 'preset', value: (event.target || event).value, song_id: ((event.target || event).closest('form').dataset.songId || '')}">
 <input type="text" name="button_{{ button_idx }}_action_{{ action_idx }}_label"
        value="{{ action.label if action else '' }}" placeholder="Label"
        class="border border-gray-300 rounded px-2 py-1 text-sm w-24">
-<div class="preset-usage basis-full text-xs mt-1"></div>
+<div class="preset-usage basis-full text-xs mt-1">
+{%- if action and action.value not in (None, '') and usage_index is defined and usage_index -%}
+{% with entries = usage_index.lookup(action.device, 'preset', action.value, exclude_song_id=(song.song.id if song else None)), show = true %}{% include "partials/preset_usage.html" %}{% endwith %}
+{%- endif -%}
+</div>
 {% elif action_type == 'pattern' %}
 <input type="text" name="button_{{ button_idx }}_action_{{ action_idx }}_value"
        value="{{ action.value if action else '' }}" placeholder="Pattern" required
        class="border border-gray-300 rounded px-2 py-1 text-sm w-20"
        hx-get="/partials/preset-usage"
        hx-target="next .preset-usage"
-       hx-trigger="load, change, keyup changed delay:400ms"
+       hx-trigger="change, keyup changed delay:400ms"
        hx-vals="js:{device_id: (event.target || event).closest('.action-row').querySelector('select[name$=_device]').value, action_type: 'pattern', value: (event.target || event).value, song_id: ((event.target || event).closest('form').dataset.songId || '')}">
 <input type="text" name="button_{{ button_idx }}_action_{{ action_idx }}_label"
        value="{{ action.label if action else '' }}" placeholder="Label"
        class="border border-gray-300 rounded px-2 py-1 text-sm w-24">
-<div class="preset-usage basis-full text-xs mt-1"></div>
+<div class="preset-usage basis-full text-xs mt-1">
+{%- if action and action.value not in (None, '') and usage_index is defined and usage_index -%}
+{% with entries = usage_index.lookup(action.device, 'pattern', action.value, exclude_song_id=(song.song.id if song else None)), show = true %}{% include "partials/preset_usage.html" %}{% endwith %}
+{%- endif -%}
+</div>
 {% elif action_type == 'cc' %}
 <input type="number" name="button_{{ button_idx }}_action_{{ action_idx }}_cc"
        value="{{ action.cc if action else '' }}" placeholder="CC #" required

--- a/packages/paternologia/templates/partials/action_fields.html
+++ b/packages/paternologia/templates/partials/action_fields.html
@@ -7,7 +7,7 @@
        hx-get="/partials/preset-usage"
        hx-target="next .preset-usage"
        hx-trigger="load, change, keyup changed delay:400ms"
-       hx-vals="js:{device_id: event.target.closest('.action-row').querySelector('select[name$=_device]').value, action_type: 'preset', value: event.target.value, song_id: (event.target.closest('form').dataset.songId || '')}">
+       hx-vals="js:{device_id: (event.target || event).closest('.action-row').querySelector('select[name$=_device]').value, action_type: 'preset', value: (event.target || event).value, song_id: ((event.target || event).closest('form').dataset.songId || '')}">
 <input type="text" name="button_{{ button_idx }}_action_{{ action_idx }}_label"
        value="{{ action.label if action else '' }}" placeholder="Label"
        class="border border-gray-300 rounded px-2 py-1 text-sm w-24">
@@ -19,7 +19,7 @@
        hx-get="/partials/preset-usage"
        hx-target="next .preset-usage"
        hx-trigger="load, change, keyup changed delay:400ms"
-       hx-vals="js:{device_id: event.target.closest('.action-row').querySelector('select[name$=_device]').value, action_type: 'pattern', value: event.target.value, song_id: (event.target.closest('form').dataset.songId || '')}">
+       hx-vals="js:{device_id: (event.target || event).closest('.action-row').querySelector('select[name$=_device]').value, action_type: 'pattern', value: (event.target || event).value, song_id: ((event.target || event).closest('form').dataset.songId || '')}">
 <input type="text" name="button_{{ button_idx }}_action_{{ action_idx }}_label"
        value="{{ action.label if action else '' }}" placeholder="Label"
        class="border border-gray-300 rounded px-2 py-1 text-sm w-24">

--- a/packages/paternologia/templates/partials/action_fields.html
+++ b/packages/paternologia/templates/partials/action_fields.html
@@ -2,18 +2,28 @@
 {# ABOUTME: Rendered when action type changes (cascade). #}
 {% if action_type == 'preset' %}
 <input type="number" name="button_{{ button_idx }}_action_{{ action_idx }}_value"
-       value="{{ action.value if action else '' }}" placeholder="Preset #" required
-       class="border border-gray-300 rounded px-2 py-1 text-sm w-20">
+       value="{{ to_display(action.value, device) if action else '' }}" placeholder="Preset #" required
+       class="border border-gray-300 rounded px-2 py-1 text-sm w-20"
+       hx-get="/partials/preset-usage"
+       hx-target="next .preset-usage"
+       hx-trigger="load, change, keyup changed delay:400ms"
+       hx-vals="js:{device_id: event.target.closest('.action-row').querySelector('select[name$=_device]').value, action_type: 'preset', value: event.target.value, song_id: (event.target.closest('form').dataset.songId || '')}">
 <input type="text" name="button_{{ button_idx }}_action_{{ action_idx }}_label"
        value="{{ action.label if action else '' }}" placeholder="Label"
        class="border border-gray-300 rounded px-2 py-1 text-sm w-24">
+<div class="preset-usage basis-full text-xs mt-1"></div>
 {% elif action_type == 'pattern' %}
 <input type="text" name="button_{{ button_idx }}_action_{{ action_idx }}_value"
        value="{{ action.value if action else '' }}" placeholder="Pattern" required
-       class="border border-gray-300 rounded px-2 py-1 text-sm w-20">
+       class="border border-gray-300 rounded px-2 py-1 text-sm w-20"
+       hx-get="/partials/preset-usage"
+       hx-target="next .preset-usage"
+       hx-trigger="load, change, keyup changed delay:400ms"
+       hx-vals="js:{device_id: event.target.closest('.action-row').querySelector('select[name$=_device]').value, action_type: 'pattern', value: event.target.value, song_id: (event.target.closest('form').dataset.songId || '')}">
 <input type="text" name="button_{{ button_idx }}_action_{{ action_idx }}_label"
        value="{{ action.label if action else '' }}" placeholder="Label"
        class="border border-gray-300 rounded px-2 py-1 text-sm w-24">
+<div class="preset-usage basis-full text-xs mt-1"></div>
 {% elif action_type == 'cc' %}
 <input type="number" name="button_{{ button_idx }}_action_{{ action_idx }}_cc"
        value="{{ action.cc if action else '' }}" placeholder="CC #" required

--- a/packages/paternologia/templates/partials/action_row.html
+++ b/packages/paternologia/templates/partials/action_row.html
@@ -42,6 +42,7 @@
     <div class="action-fields flex gap-2">
         {% if action %}
             {% set action_type = action.type.value %}
+            {% set device = (devices | selectattr('id', 'equalto', action.device) | first) %}
             {% include "partials/action_fields.html" with context %}
         {% endif %}
     </div>

--- a/packages/paternologia/templates/partials/preset_usage.html
+++ b/packages/paternologia/templates/partials/preset_usage.html
@@ -1,0 +1,11 @@
+{# ABOUTME: HTMX partial: occupancy hint for a preset/pattern slot. #}
+{# ABOUTME: Lists other songs using the slot, or marks it free. Blank when no query. #}
+{%- if show -%}
+{%- if entries -%}
+<span class="text-amber-600">⚠ używany też w:
+    {%- for entry in entries %} «{{ entry.song_name }}»{% if not loop.last %},{% endif %}{% endfor -%}
+</span>
+{%- else -%}
+<span class="text-green-600">✓ wolny (nieużywany w innych utworach)</span>
+{%- endif -%}
+{%- endif -%}

--- a/packages/paternologia/templates/song_edit.html
+++ b/packages/paternologia/templates/song_edit.html
@@ -16,6 +16,7 @@
 <form method="post"
       action="{% if is_new %}/songs{% else %}/songs/{{ song.song.id }}{% endif %}"
       {% if not is_new %}hx-put="/songs/{{ song.song.id }}"{% endif %}
+      data-song-id="{{ song.song.id if song else '' }}"
       class="space-y-8">
 
     <!-- Song Metadata -->

--- a/packages/paternologia/tests/test_api.py
+++ b/packages/paternologia/tests/test_api.py
@@ -902,10 +902,38 @@ class TestPresetEditorWiring:
         assert "/partials/preset-usage" in response.text
         assert "preset-usage" in response.text
         assert 'value="5"' in response.text  # raw 4 + offset 1
-        # Hint must fire on initial load, and survive htmx's load-trigger quirk
-        # where the handler receives the element itself (no event.target).
-        assert "load, change" in response.text
-        assert "(event.target || event)" in response.text
+        # The hint is rendered server-side on page load (no reliance on the
+        # flaky htmx "load" trigger). Only zen uses this slot → free.
+        assert "wolny" in response.text.lower()
+
+    def test_edit_shows_other_song_using_slot(self, client, test_storage):
+        """Editing a song shows which OTHER songs share a preset slot, on load."""
+        from paternologia.models import (
+            Action,
+            ActionType as AT,
+            PacerButton,
+            Song,
+            SongMetadata,
+        )
+
+        self._devices_with_offset(test_storage)
+        for sid, sname in (("zen", "Zen"), ("rock", "Rock Song")):
+            test_storage.save_song(
+                Song(
+                    song=SongMetadata(id=sid, name=sname),
+                    pacer=[
+                        PacerButton(
+                            name="SW1",
+                            actions=[Action(device="boss", type=AT.PRESET, value=4)],
+                        )
+                    ],
+                )
+            )
+
+        response = client.get("/songs/zen/edit")
+        assert response.status_code == 200
+        assert "Rock Song" in response.text  # the other occupant, server-rendered
+        assert "używany też w" in response.text
 
     def test_save_converts_display_to_stored(self, client, test_storage):
         """UI number 5 is persisted as raw 4 (offset removed on save)."""

--- a/packages/paternologia/tests/test_api.py
+++ b/packages/paternologia/tests/test_api.py
@@ -902,6 +902,10 @@ class TestPresetEditorWiring:
         assert "/partials/preset-usage" in response.text
         assert "preset-usage" in response.text
         assert 'value="5"' in response.text  # raw 4 + offset 1
+        # Hint must fire on initial load, and survive htmx's load-trigger quirk
+        # where the handler receives the element itself (no event.target).
+        assert "load, change" in response.text
+        assert "(event.target || event)" in response.text
 
     def test_save_converts_display_to_stored(self, client, test_storage):
         """UI number 5 is persisted as raw 4 (offset removed on save)."""

--- a/packages/paternologia/tests/test_api.py
+++ b/packages/paternologia/tests/test_api.py
@@ -849,3 +849,141 @@ class TestPresetUsagePartial:
             },
         )
         assert "Rock" in second.text
+
+
+class TestPresetEditorWiring:
+    """Tests for the editor: transparent display number + usage-hint wiring."""
+
+    @staticmethod
+    def _devices_with_offset(test_storage):
+        devices = [
+            Device(
+                id="boss",
+                name="Boss RC-600",
+                midi_channel=13,
+                preset_display_offset=1,
+                action_types=[ActionType.PRESET, ActionType.CC],
+            ),
+            Device(
+                id="ms",
+                name="Elektron M:S",
+                midi_channel=14,
+                action_types=[ActionType.PATTERN],
+            ),
+        ]
+        test_storage.save_devices(devices)
+        return devices
+
+    def test_edit_renders_display_number_and_hint(self, client, test_storage):
+        """Boss preset stored raw 4 renders as 5 (offset 1) with usage wiring."""
+        from paternologia.models import (
+            Action,
+            ActionType as AT,
+            PacerButton,
+            Song,
+            SongMetadata,
+        )
+
+        self._devices_with_offset(test_storage)
+        test_storage.save_song(
+            Song(
+                song=SongMetadata(id="zen", name="Zen"),
+                pacer=[
+                    PacerButton(
+                        name="SW1",
+                        actions=[Action(device="boss", type=AT.PRESET, value=4)],
+                    )
+                ],
+            )
+        )
+
+        response = client.get("/songs/zen/edit")
+        assert response.status_code == 200
+        assert "/partials/preset-usage" in response.text
+        assert "preset-usage" in response.text
+        assert 'value="5"' in response.text  # raw 4 + offset 1
+
+    def test_save_converts_display_to_stored(self, client, test_storage):
+        """UI number 5 is persisted as raw 4 (offset removed on save)."""
+        self._devices_with_offset(test_storage)
+        response = client.post(
+            "/songs",
+            data={
+                "song_id": "round-trip",
+                "song_name": "Round Trip",
+                "button_0_name": "SW1",
+                "button_0_action_0_device": "boss",
+                "button_0_action_0_type": "preset",
+                "button_0_action_0_value": "5",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        song = test_storage.get_song("round-trip")
+        assert song.pacer[0].actions[0].value == 4
+
+    def test_cc_value_not_offset_on_save(self, client, test_storage):
+        """CC value carries no display offset; stored exactly as entered."""
+        self._devices_with_offset(test_storage)
+        client.post(
+            "/songs",
+            data={
+                "song_id": "cc-song",
+                "song_name": "CC Song",
+                "button_0_name": "SW1",
+                "button_0_action_0_device": "boss",
+                "button_0_action_0_type": "cc",
+                "button_0_action_0_cc": "10",
+                "button_0_action_0_value": "5",
+            },
+            follow_redirects=False,
+        )
+        song = test_storage.get_song("cc-song")
+        assert song.pacer[0].actions[0].value == 5
+
+    def test_new_song_form_has_empty_song_id(self, client, test_storage):
+        """New song form carries data-song-id="" so nothing is excluded."""
+        self._devices_with_offset(test_storage)
+        response = client.get("/songs/new")
+        assert response.status_code == 200
+        assert 'data-song-id=""' in response.text
+
+    def test_pattern_rendered_without_offset(self, client, test_storage):
+        """M:S pattern is consistent already → rendered verbatim, no offset."""
+        from paternologia.models import (
+            Action,
+            ActionType as AT,
+            PacerButton,
+            Song,
+            SongMetadata,
+        )
+
+        self._devices_with_offset(test_storage)
+        test_storage.save_song(
+            Song(
+                song=SongMetadata(id="patt", name="Patt"),
+                pacer=[
+                    PacerButton(
+                        name="SW1",
+                        actions=[Action(device="ms", type=AT.PATTERN, value="F03")],
+                    )
+                ],
+            )
+        )
+
+        response = client.get("/songs/patt/edit")
+        assert response.status_code == 200
+        assert 'value="F03"' in response.text
+
+    def test_cc_fields_have_no_usage_hint(self, client, sample_devices):
+        """cc action fields do not wire the preset-usage hint; preset fields do."""
+        cc = client.get(
+            "/partials/action-fields?action_type=cc&button_idx=0&action_idx=0"
+        )
+        assert "/partials/preset-usage" not in cc.text
+
+        preset = client.get(
+            "/partials/action-fields?action_type=preset&button_idx=0&action_idx=0"
+        )
+        assert "/partials/preset-usage" in preset.text

--- a/packages/paternologia/tests/test_api.py
+++ b/packages/paternologia/tests/test_api.py
@@ -679,3 +679,173 @@ class TestHTMXPartials:
         assert 'name="button_0_action_0_label"' in response.text
         # Pattern does NOT need cc
         assert 'name="button_0_action_0_cc"' not in response.text
+
+
+class TestPresetUsagePartial:
+    """Tests for GET /partials/preset-usage (slot occupancy hint)."""
+
+    @staticmethod
+    def _devices_with_offset(test_storage):
+        """Boss with hidden display offset 1; ms pattern device (offset 0)."""
+        devices = [
+            Device(
+                id="boss",
+                name="Boss RC-600",
+                midi_channel=13,
+                preset_display_offset=1,
+                action_types=[ActionType.PRESET, ActionType.CC],
+            ),
+            Device(
+                id="ms",
+                name="Elektron M:S",
+                midi_channel=14,
+                action_types=[ActionType.PATTERN],
+            ),
+        ]
+        test_storage.save_devices(devices)
+        return devices
+
+    @staticmethod
+    def _song_with_preset(test_storage, song_id, name, value):
+        from paternologia.models import (
+            Action,
+            ActionType as AT,
+            PacerButton,
+            Song,
+            SongMetadata,
+        )
+
+        song = Song(
+            song=SongMetadata(id=song_id, name=name),
+            pacer=[
+                PacerButton(
+                    name="SW1",
+                    actions=[Action(device="boss", type=AT.PRESET, value=value)],
+                )
+            ],
+        )
+        test_storage.save_song(song)
+        return song
+
+    def test_used_in_other_song_lists_name(self, client, test_storage):
+        """UI number 5 (offset 1 → stored 4) shared by two songs; excludes self."""
+        self._devices_with_offset(test_storage)
+        self._song_with_preset(test_storage, "zen", "Zen", 4)
+        self._song_with_preset(test_storage, "rock", "Rock Song", 4)
+
+        response = client.get(
+            "/partials/preset-usage",
+            params={
+                "device_id": "boss",
+                "action_type": "preset",
+                "value": "5",
+                "song_id": "zen",
+            },
+        )
+        assert response.status_code == 200
+        assert "Rock Song" in response.text
+        assert "Zen" not in response.text
+
+    def test_free_slot(self, client, test_storage):
+        """A slot used only by the current song reports as free."""
+        self._devices_with_offset(test_storage)
+        self._song_with_preset(test_storage, "zen", "Zen", 4)
+
+        response = client.get(
+            "/partials/preset-usage",
+            params={
+                "device_id": "boss",
+                "action_type": "preset",
+                "value": "5",
+                "song_id": "zen",
+            },
+        )
+        assert response.status_code == 200
+        assert "wolny" in response.text.lower()
+
+    def test_empty_value_returns_blank(self, client, test_storage):
+        """No value entered → minimal/blank fragment, never an error."""
+        self._devices_with_offset(test_storage)
+        response = client.get(
+            "/partials/preset-usage",
+            params={"device_id": "boss", "action_type": "preset", "value": ""},
+        )
+        assert response.status_code == 200
+        assert response.text.strip() == ""
+
+    def test_cc_type_returns_blank(self, client, test_storage):
+        """cc actions are not slots → blank fragment."""
+        self._devices_with_offset(test_storage)
+        response = client.get(
+            "/partials/preset-usage",
+            params={"device_id": "boss", "action_type": "cc", "value": "5"},
+        )
+        assert response.status_code == 200
+        assert response.text.strip() == ""
+
+    def test_new_song_excludes_nothing(self, client, test_storage):
+        """Empty song_id (new song) → existing user of the slot is still listed."""
+        self._devices_with_offset(test_storage)
+        self._song_with_preset(test_storage, "zen", "Zen", 4)
+
+        response = client.get(
+            "/partials/preset-usage",
+            params={
+                "device_id": "boss",
+                "action_type": "preset",
+                "value": "5",
+                "song_id": "",
+            },
+        )
+        assert response.status_code == 200
+        assert "Zen" in response.text
+
+    def test_offset_applied_before_lookup(self, client, test_storage):
+        """UI number 5 maps to stored 4; UI number 4 must NOT match stored 4."""
+        self._devices_with_offset(test_storage)
+        self._song_with_preset(test_storage, "zen", "Zen", 4)
+
+        # UI 4 → stored 3 → no song uses stored 3 → free
+        response = client.get(
+            "/partials/preset-usage",
+            params={
+                "device_id": "boss",
+                "action_type": "preset",
+                "value": "4",
+                "song_id": "",
+            },
+        )
+        assert response.status_code == 200
+        assert "Zen" not in response.text
+        assert "wolny" in response.text.lower()
+
+    def test_reflects_fresh_state_after_save(self, client, test_storage):
+        """Index is built on demand → a newly saved song appears immediately."""
+        self._devices_with_offset(test_storage)
+        self._song_with_preset(test_storage, "zen", "Zen", 4)
+
+        # Initially UI 5 (stored 4) is used only by zen → free for others (exclude zen)
+        first = client.get(
+            "/partials/preset-usage",
+            params={
+                "device_id": "boss",
+                "action_type": "preset",
+                "value": "5",
+                "song_id": "zen",
+            },
+        )
+        assert "wolny" in first.text.lower()
+
+        # A new song lands on the same raw slot (stored 4)
+        self._song_with_preset(test_storage, "rock", "Rock", 4)
+
+        second = client.get(
+            "/partials/preset-usage",
+            params={
+                "device_id": "boss",
+                "action_type": "preset",
+                "value": "5",
+                "song_id": "zen",
+            },
+        )
+        assert "Rock" in second.text

--- a/packages/paternologia/tests/test_display.py
+++ b/packages/paternologia/tests/test_display.py
@@ -1,0 +1,68 @@
+# ABOUTME: Tests for preset display-number conversion helpers (to_display/to_stored).
+# ABOUTME: Verifies the hidden per-device offset round-trips and never touches patterns.
+
+from paternologia.display import to_display, to_stored
+from paternologia.models import ActionType, Device
+
+
+def _device(offset: int = 0, action_types=None) -> Device:
+    return Device(
+        id="dev",
+        name="DEV",
+        preset_display_offset=offset,
+        action_types=action_types or [ActionType.PRESET],
+    )
+
+
+class TestToDisplay:
+    """Stored raw MIDI value → number shown on the device screen."""
+
+    def test_applies_positive_offset(self):
+        boss = _device(offset=1)
+        assert to_display(100, boss) == 101
+
+    def test_zero_offset_is_identity(self):
+        ms = _device(offset=0)
+        assert to_display(7, ms) == 7
+
+    def test_pattern_string_unchanged(self):
+        ms = _device(offset=0, action_types=[ActionType.PATTERN])
+        assert to_display("F03", ms) == "F03"
+
+    def test_none_unchanged(self):
+        boss = _device(offset=1)
+        assert to_display(None, boss) is None
+
+
+class TestToStored:
+    """Number entered in the UI (device screen) → raw MIDI value."""
+
+    def test_removes_positive_offset(self):
+        boss = _device(offset=1)
+        assert to_stored(101, boss) == 100
+
+    def test_zero_offset_is_identity(self):
+        ms = _device(offset=0)
+        assert to_stored(7, ms) == 7
+
+    def test_pattern_string_unchanged(self):
+        ms = _device(offset=0, action_types=[ActionType.PATTERN])
+        assert to_stored("F03", ms) == "F03"
+
+    def test_none_unchanged(self):
+        boss = _device(offset=1)
+        assert to_stored(None, boss) is None
+
+
+class TestRoundTrip:
+    """Display↔stored must be an exact identity, or values drift on every save."""
+
+    def test_round_trip_over_range(self):
+        boss = _device(offset=1)
+        for raw in range(0, 128):
+            assert to_stored(to_display(raw, boss), boss) == raw
+
+    def test_round_trip_zero_offset(self):
+        ms = _device(offset=0)
+        for raw in range(0, 16):
+            assert to_stored(to_display(raw, ms), ms) == raw

--- a/packages/paternologia/tests/test_models.py
+++ b/packages/paternologia/tests/test_models.py
@@ -52,6 +52,16 @@ class TestDevice:
         with pytest.raises(ValidationError):
             Device(id="test")
 
+    def test_preset_display_offset_defaults_to_zero(self):
+        """Devices without the field behave like today (no display shift)."""
+        device = Device(id="ms", name="Elektron M:S")
+        assert device.preset_display_offset == 0
+
+    def test_preset_display_offset_can_be_set(self):
+        """Hidden config offset is read from the model (e.g. boss/freak = 1)."""
+        device = Device(id="boss", name="Boss RC-600", preset_display_offset=1)
+        assert device.preset_display_offset == 1
+
 
 class TestDevicesConfig:
     """Tests for DevicesConfig model."""

--- a/packages/paternologia/tests/test_usage.py
+++ b/packages/paternologia/tests/test_usage.py
@@ -54,6 +54,27 @@ class TestPresetUsageIndex:
         result = index.lookup("ms", ActionType.PATTERN, "f03")
         assert {e.song_id for e in result} == {"a", "b"}
 
+    def test_pattern_slot_matches_across_spellings(self):
+        """M:S pattern identity is the physical slot: 'A9' and 'A09' are one slot."""
+        songs = [
+            _song(
+                "a", [_btn(Action(device="ms", type=ActionType.PATTERN, value="A09"))]
+            ),
+            _song(
+                "b", [_btn(Action(device="ms", type=ActionType.PATTERN, value="a9"))]
+            ),
+        ]
+        index = PresetUsageIndex.build(songs)
+        # Querying with either spelling finds both songs.
+        assert {e.song_id for e in index.lookup("ms", ActionType.PATTERN, "A09")} == {
+            "a",
+            "b",
+        }
+        assert {e.song_id for e in index.lookup("ms", ActionType.PATTERN, "A9")} == {
+            "a",
+            "b",
+        }
+
     def test_exclude_song_id_removes_current_song(self):
         """A slot used only by the excluded song yields an empty list."""
         songs = [

--- a/packages/paternologia/tests/test_usage.py
+++ b/packages/paternologia/tests/test_usage.py
@@ -1,0 +1,146 @@
+# ABOUTME: Tests for PresetUsageIndex (which songs occupy a given preset/pattern slot).
+# ABOUTME: Keys on the raw stored value; offset is purely a presentation concern.
+
+from paternologia.models import (
+    Action,
+    ActionType,
+    PacerButton,
+    Song,
+    SongMetadata,
+)
+from paternologia.usage import PresetUsageIndex
+
+
+def _song(song_id: str, buttons: list[PacerButton], name: str | None = None) -> Song:
+    return Song(
+        song=SongMetadata(id=song_id, name=name or song_id.title()),
+        pacer=buttons,
+    )
+
+
+def _btn(*actions: Action) -> PacerButton:
+    return PacerButton(name="SW1", actions=list(actions))
+
+
+class TestPresetUsageIndex:
+    def test_two_songs_share_preset_slot(self):
+        """Both songs using boss/preset/4 are returned with their names."""
+        songs = [
+            _song(
+                "zen", [_btn(Action(device="boss", type=ActionType.PRESET, value=4))]
+            ),
+            _song(
+                "rock",
+                [_btn(Action(device="boss", type=ActionType.PRESET, value=4))],
+                name="Rock Song",
+            ),
+        ]
+        index = PresetUsageIndex.build(songs)
+        result = index.lookup("boss", ActionType.PRESET, 4)
+        assert [e.song_id for e in result] == ["zen", "rock"]
+        assert {e.song_name for e in result} == {"Zen", "Rock Song"}
+
+    def test_pattern_key_normalized_case_and_whitespace(self):
+        """Pattern slot key is robust to case/whitespace differences."""
+        songs = [
+            _song(
+                "a", [_btn(Action(device="ms", type=ActionType.PATTERN, value="F03"))]
+            ),
+            _song(
+                "b", [_btn(Action(device="ms", type=ActionType.PATTERN, value=" f03 "))]
+            ),
+        ]
+        index = PresetUsageIndex.build(songs)
+        result = index.lookup("ms", ActionType.PATTERN, "f03")
+        assert {e.song_id for e in result} == {"a", "b"}
+
+    def test_exclude_song_id_removes_current_song(self):
+        """A slot used only by the excluded song yields an empty list."""
+        songs = [
+            _song(
+                "only", [_btn(Action(device="boss", type=ActionType.PRESET, value=7))]
+            )
+        ]
+        index = PresetUsageIndex.build(songs)
+        assert index.lookup("boss", ActionType.PRESET, 7, exclude_song_id="only") == []
+
+    def test_same_slot_twice_in_one_song_dedups(self):
+        """A slot used in two buttons of one song lists that song once."""
+        songs = [
+            _song(
+                "dup",
+                [
+                    _btn(Action(device="boss", type=ActionType.PRESET, value=2)),
+                    _btn(Action(device="boss", type=ActionType.PRESET, value=2)),
+                ],
+            )
+        ]
+        index = PresetUsageIndex.build(songs)
+        result = index.lookup("boss", ActionType.PRESET, 2)
+        assert [e.song_id for e in result] == ["dup"]
+
+    def test_none_value_skipped(self):
+        """Actions with no value never enter the index."""
+        songs = [
+            _song(
+                "x", [_btn(Action(device="boss", type=ActionType.PRESET, value=None))]
+            )
+        ]
+        index = PresetUsageIndex.build(songs)
+        assert index.lookup("boss", ActionType.PRESET, 0) == []
+
+    def test_cc_and_note_ignored(self):
+        """Only preset/pattern slots are tracked; cc/note are transient."""
+        songs = [
+            _song(
+                "x",
+                [
+                    _btn(Action(device="boss", type=ActionType.CC, value=5, cc=1)),
+                    _btn(Action(device="freak", type=ActionType.NOTE, note="C4")),
+                ],
+            )
+        ]
+        index = PresetUsageIndex.build(songs)
+        assert index.lookup("boss", ActionType.CC, 5) == []
+        assert index.lookup("freak", ActionType.NOTE, "C4") == []
+
+    def test_preset_int_and_pattern_str_do_not_collide(self):
+        """Same device + same numeric look but different action_type stay separate."""
+        songs = [
+            _song(
+                "p",
+                [_btn(Action(device="ms", type=ActionType.PATTERN, value="3"))],
+            ),
+        ]
+        index = PresetUsageIndex.build(songs)
+        assert index.lookup("ms", ActionType.PATTERN, "3")
+        assert index.lookup("ms", ActionType.PRESET, 3) == []
+
+    def test_lookup_accepts_action_type_string(self):
+        """Endpoint passes action_type as a query string; lookup coerces it."""
+        songs = [
+            _song("z", [_btn(Action(device="boss", type=ActionType.PRESET, value=9))])
+        ]
+        index = PresetUsageIndex.build(songs)
+        assert [e.song_id for e in index.lookup("boss", "preset", 9)] == ["z"]
+
+    def test_order_follows_song_order(self):
+        """Entries keep the order songs were supplied in."""
+        songs = [
+            _song(
+                "first", [_btn(Action(device="boss", type=ActionType.PRESET, value=1))]
+            ),
+            _song(
+                "second", [_btn(Action(device="boss", type=ActionType.PRESET, value=1))]
+            ),
+            _song(
+                "third", [_btn(Action(device="boss", type=ActionType.PRESET, value=1))]
+            ),
+        ]
+        index = PresetUsageIndex.build(songs)
+        result = index.lookup("boss", ActionType.PRESET, 1)
+        assert [e.song_id for e in result] == ["first", "second", "third"]
+
+    def test_empty_songs(self):
+        index = PresetUsageIndex.build([])
+        assert index.lookup("boss", ActionType.PRESET, 1) == []


### PR DESCRIPTION
## Summary

Dwie powiązane zmiany w edytorze utworów paternologii:

1. **Podpowiedź zajętości slotu** — przy polu preset/pattern (kaskada HTMX) pojawia się informacja, czy slot jest już używany w innych utworach (z nazwami) czy wolny. Cel: nie nadpisać współdzielonego, fizycznego slotu na sprzęcie.
2. **Zgodne numery presetów w UI** — numer pokazywany/wpisywany w edytorze jest zgodny z ekranem urządzenia (Boss/Freak miały off-by-one). Korekta transparentna przez **ukryty offset konfiguracyjny** (`Device.preset_display_offset` w `devices.yaml`), niewidoczny w UI.

### Kluczowe decyzje
- **Offset wyłącznie wyświetlaniem.** Przechowywany `value` pozostaje surowym numerem MIDI — **bez zmian w eksporcie `.syx`** (ryzyko zbrickowania Pacera), **bez zmian w `SongMidiIndex`**, **bez migracji plików utworów**.
- Centralne helpery `to_display`/`to_stored` (`display.py`) — jedna para, round-trip pokryty testem.
- Osobny `PresetUsageIndex` kluczowany na surowym `value`; budowany na żądanie (świeży stan po zapisie, bez cache).
- Offset niewidoczny w żadnym szablonie (zweryfikowane grepem); widok `/devices` jest read-only.

## Testing
- TDD per jednostka. Nowe testy: `test_display.py` (10), `test_usage.py` (10), `test_api.py` (+13: `TestPresetUsagePartial`, `TestPresetEditorWiring`), `test_models.py` (offset).
- Cały pakiet: `uv run --package paternologia pytest packages/paternologia/tests/` → **359 passed**.
- `ruff check packages/paternologia/` czysty; pre-commit zielony.
- Smoke test na żywym serwisie po restarcie: `GET /partials/preset-usage?device_id=boss&action_type=preset&value=5` → `200`, `⚠ używany też w: «Świt»` (UI 5 → surowe 4, offset Boss = 1).

## Post-Deploy Monitoring & Validation
- **Co monitorować**
  - Logi: `journalctl --user -u paternologia.service` — brak tracebacków przy renderze edycji utworu i przy `GET /partials/preset-usage`.
  - Zachowanie eksportu: `POST /pacer/send/{song}` musi działać identycznie jak przed zmianą (offset go nie dotyka).
- **Walidacja (po restarcie usługi)**
  - `curl -s "http://localhost:8000/partials/preset-usage?device_id=boss&action_type=preset&value=5"` → fragment HTML „wolny"/„używany też w".
  - W edytorze: preset Boss/Freak pokazuje numer zgodny z ekranem urządzenia; zapis → w pliku YAML surowy numer (UI − 1).
- **Sygnał zdrowy:** edycja i zapis utworów działają; numery presetów zgodne z urządzeniem; eksport `.syx` bez regresji.
- **Sygnał awarii / rollback:** błąd 500 na `/songs/{id}/edit` lub `/partials/preset-usage`, albo rozjazd numerów po zapisie → `git revert` zakresu gałęzi, restart `paternologia.service`.
- **Okno walidacji i właściciel:** najbliższa sesja edycji setlisty; właściciel: Wojciech.

## Uwagi
- `devices.yaml` zyskał urządzenie `ampero` (offset domyślny 0, do skalibrowania gdy sprzęt się pojawi) oraz `preset_display_offset: 1` dla `boss`/`freak`.
- Poza zakresem (Deferred): spójny numer presetu poza edytorem (`song.html`, lista); kalibracja offsetu Ampero na sprzęcie.

---

🤖 Generated with Claude Opus 4.8 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.54.1